### PR TITLE
Allow suppression of pidfiles.

### DIFF
--- a/doc/unbound.8.in
+++ b/doc/unbound.8.in
@@ -14,6 +14,7 @@
 .B unbound
 .RB [ \-h ]
 .RB [ \-d ]
+.RB [ \-p ]
 .RB [ \-v ]
 .RB [ \-c
 .IR cfgfile ]
@@ -66,6 +67,11 @@ the console.  This flag will also delay writing to the log file until
 the thread\-spawn time, so that most config and setup errors appear on
 stderr. If given twice or more, logging does not switch to the log file
 or to syslog, but the log messages are printed to stderr all the time.
+.TP
+.B \-p
+Don't use a pidfile.  This argument should only be used by supervision
+systems which can ensure that only one instance of unbound will run
+concurrently.
 .TP
 .B \-v
 Increase verbosity. If given multiple times, more information is logged.


### PR DESCRIPTION
When unbound is maintained by a system manager that can actually keep
track of what daemons are running correctly, a pidfile is an
opportunity for extra failures, rather than a way to avoid failures.

In particular, if unbound terminates roughly, it might leave the
pidfile lying around. Then a subsequent unbound instance will think
that another unbound process is running when it isn't (particularly if
some other stable process happens to have landed on the same process
ID).

So for a system manager that is already capable of keeping track of
whether the daemon is running or not, it would be nice to have the
ability to avoid these extra failure modes by just ignoring pidfiles
entirely.

Since the same unbound config file might need to be used on a
distribution that might use different system managers, being able to
control the use of a pidfile by a command-line argument is probably
the cleanest way to go (see https://bugs.debian.org/867192).