### PR TITLE
fix cachedb portability problem

### DIFF
--- a/cachedb/cachedb.c
+++ b/cachedb/cachedb.c
@@ -57,6 +57,21 @@
 #include "sldns/wire2str.h"
 #include "sldns/sbuffer.h"
 
+/* header file for htobe64 */
+#ifdef HAVE_ENDIAN_H
+#  include <endian.h>
+#endif
+#ifdef HAVE_SYS_ENDIAN_H
+#  include <sys/endian.h>
+#endif
+#ifdef HAVE_LIBKERN_OSBYTEORDER_H
+/* In practice this is specific to MacOS X.  We assume it doesn't have
+* htobe64/be64toh but has alternatives with a different name. */
+#  include <libkern/OSByteOrder.h>
+#  define htobe64(x) OSSwapHostToBigInt64(x)
+#  define be64toh(x) OSSwapBigToHostInt64(x)
+#endif
+
 /** the unit test testframe for cachedb, its module state contains
  * a cache for a couple queries (in memory). */
 struct testframe_moddata {

--- a/cachedb/redis.c
+++ b/cachedb/redis.c
@@ -48,21 +48,6 @@
 #include "util/config_file.h"
 #include "sldns/sbuffer.h"
 
-/* header file for htobe64 */
-#ifdef HAVE_ENDIAN_H
-#  include <endian.h>
-#endif
-#ifdef HAVE_SYS_ENDIAN_H
-#  include <sys/endian.h>
-#endif
-#ifdef HAVE_LIBKERN_OSBYTEORDER_H
-/* In practice this is specific to MacOS X.  We assume it doesn't have
-* htobe64/be64toh but has alternatives with a different name. */
-#  include <libkern/OSByteOrder.h>
-#  define htobe64(x) OSSwapHostToBigInt64(x)
-#  define be64toh(x) OSSwapBigToHostInt64(x)
-#endif
-
 #ifdef USE_REDIS
 #include "hiredis/hiredis.h"
 

--- a/doc/Changelog
+++ b/doc/Changelog
@@ -1,5 +1,5 @@
 15 March 2018: Wouter
-	- Add --with-libhiredis, unbound support for a new cached backend
+	- Add --with-libhiredis, unbound support for a new cachedb backend
 	  that uses a Redis server as the storage.  This implementation
 	  depends on the hiredis client library (https://redislabs.com/lp/hiredis/).
 	  And unbound should be built with both --enable-cachedb and


### PR DESCRIPTION
by moving htobe64/be64toh portability code from redis.c to cachedb.c.
the former actually doesn't use these functions and doesn't need them.
without the change cachedb doesn't compile on BSDs and MacOS X (and maybe some others).
(note that this is not related to the redis support.  the issue has been in cachedb.c from the beginning).