### PR TITLE
Python module: assign something useful to the per-query data store 'qdata' 

### DIFF
--- a/pythonmod/pythonmod.c
+++ b/pythonmod/pythonmod.c
@@ -317,8 +317,7 @@ int pythonmod_init(struct module_env* env, int id)
    /* Load file */
    pe->module = PyImport_AddModule("__main__");
    pe->dict = PyModule_GetDict(pe->module);
-   pe->data = Py_None;
-   Py_INCREF(pe->data);
+   pe->data = PyDict_New();
    PyModule_AddObject(pe->module, "mod_env", pe->data);
 
    /* TODO: deallocation of pe->... if an error occurs */
@@ -485,8 +484,7 @@ void pythonmod_operate(struct module_qstate* qstate, enum module_ev event,
       pq = qstate->minfo[id] = malloc(sizeof(struct pythonmod_qstate));
 
       /* Initialize per query data */
-      pq->data = Py_None;
-      Py_INCREF(pq->data);
+      pq->data = PyDict_New();
    }
 
    /* Call operate */


### PR DESCRIPTION
The methods [`operate`](https://www.unbound.net/documentation/pythonmod/examples/example0.html#operate) and [`inform_super`](https://www.unbound.net/documentation/pythonmod/examples/example0.html#inform_super) both have a parameter named `qdata` which is described as "per query data, here you can store your own data".

However, the python module implementation passes `qdata=None` as argument value. There's no way for the python code to assign something else to the per-query data store or modify `None`.

Please consider initializing the per-query data store as `dict` (this pull request). This would allow the python module script to add custom items.

The proposed patch also changes the initialization of the `mod_env` global variable from `None` to a `dict` instance. Certainly, `mod_env` could be omitted completely: If needed, a global variable could be created from the python module's code as well. I see no need for storing the data in the python module's internal C data structures.

I've been successfully using this patch with unbound-[1.6.0](https://github.com/episource/unbound/tree/dev/pythonmod-data/v1.6.0), [1.6.1](https://github.com/episource/unbound/tree/dev/pythonmod-data/v1.6.1), [1.6.4](https://github.com/episource/unbound/tree/dev/pythonmod-data/v1.6.4) and [1.7.0](https://github.com/episource/unbound/tree/dev/pythonmod-data/v1.7.0).

See also: https://www.nlnetlabs.nl/bugs-script/show_bug.cgi?id=1212
(Pull-Requests were disabled when I created this ticket)