### PR TITLE
Python module: define constant MODULE_RESTART_NEXT 

### DIFF
--- a/pythonmod/interface.i
+++ b/pythonmod/interface.i
@@ -1128,6 +1128,7 @@ struct delegpt {
 %rename ("MODULE_STATE_INITIAL") "module_state_initial";
 %rename ("MODULE_WAIT_REPLY") "module_wait_reply";
 %rename ("MODULE_WAIT_MODULE") "module_wait_module";
+%rename ("MODULE_RESTART_NEXT") "module_restart_next";
 %rename ("MODULE_WAIT_SUBQUERY") "module_wait_subquery";
 %rename ("MODULE_ERROR") "module_error";
 %rename ("MODULE_FINISHED") "module_finished";
@@ -1136,6 +1137,7 @@ enum module_ext_state {
    module_state_initial = 0,
    module_wait_reply,
    module_wait_module,
+   module_restart_next,
    module_wait_subquery,
    module_error,
    module_finished


### PR DESCRIPTION
The python module does not define a constant `MODULE_RESTART_NEXT` for the `module_ext_state`'s enumeration value [`module_restart_next`](http://unbound.net/documentation/doxygen/module_8h.html#a42696d302cc419299b98207675a2ba18).

This pull requests adds the constant to swig's interface file.

I've been successfully using this patch with unbound-[1.6.0](https://github.com/episource/unbound/tree/dev/module_ext_state/v1.6.0), [1.6.1](https://github.com/episource/unbound/tree/dev/module_ext_state/v1.6.1), [1.6.4](https://github.com/episource/unbound/tree/dev/module_ext_state/v1.6.4) and [1.7.0](https://github.com/episource/unbound/tree/dev/module_ext_state/v1.7.0).

See also: https://www.nlnetlabs.nl/bugs-script/show_bug.cgi?id=1214
(Pull-Requests were disabled when I created this ticket)