### PR TITLE
allow query of "." without recursive flag

### DIFF
--- a/daemon/worker.c
+++ b/daemon/worker.c
@@ -1397,7 +1397,8 @@ worker_handle_request(struct comm_point* c, void* arg, int error,
 
 	/* If this request does not have the recursion bit set, verify
 	 * ACLs allow the snooping. */
-	if(!(LDNS_RD_WIRE(sldns_buffer_begin(c->buffer))) &&
+	if(qinfo.qname_len > 1 && /* non-recursive query "." is allowed */
+		!(LDNS_RD_WIRE(sldns_buffer_begin(c->buffer))) &&
 		acl != acl_allow_snoop ) {
 		error_encode(c->buffer, LDNS_RCODE_REFUSED, &qinfo,
 			*(uint16_t*)(void *)sldns_buffer_begin(c->buffer),


### PR DESCRIPTION
Resolving the root name is not usual, although some programs do this.
And they do it without setting recursive flag
So "dig +tra @127.0.0.1 example.com" (where unbound is on 127.0.0.1) fails because unbound rejects query of root name without  recursive flag.
It works with any other nameserver ("dig +tra @8.8.8.8 example.com", etc)