### PR TITLE
Remove left-over requirements on OpenSSL >= 1.1.0 for cert name matching

### DIFF
--- a/daemon/remote.c
+++ b/daemon/remote.c
@@ -1987,7 +1987,7 @@ parse_delegpt(RES* ssl, char* args, uint8_t* nm, int allow_names)
 				return NULL;
 			}
 		} else {
-#ifndef HAVE_SSL_SET1_HOST
+#if !defined(HAVE_SSL_SET1_HOST) && !defined(HAVE_X509_VERIFY_PARAM_SET1_HOST)
 			if(auth_name)
 			  log_err("no name verification functionality in "
 				"ssl library, ignored name for %s", todo);

--- a/doc/unbound.conf.5.in
+++ b/doc/unbound.conf.5.in
@@ -1619,7 +1619,6 @@ the '@' and '#', the '@' comes first.
 At high verbosity it logs the TLS certificate, with TLS enabled.
 If you leave out the '#' and auth name from the forward\-addr, any
 name is accepted.  The cert must also match a CA from the tls\-cert\-bundle.
-The cert name match code needs OpenSSL 1.1.0 or later to be enabled.
 .TP
 .B forward\-first: \fI<yes or no>
 If a forwarded query is met with a SERVFAIL error, and this option is

--- a/iterator/iter_fwd.c
+++ b/iterator/iter_fwd.c
@@ -239,7 +239,7 @@ read_fwds_addr(struct config_stub* s, struct delegpt* dp)
 				s->name, p->str);
 			return 0;
 		}
-#ifndef HAVE_SSL_SET1_HOST
+#if !defined(HAVE_SSL_SET1_HOST) && !defined(HAVE_X509_VERIFY_PARAM_SET1_HOST)
 		if(tls_auth_name)
 			log_err("no name verification functionality in "
 				"ssl library, ignored name for %s", p->str);

--- a/iterator/iter_hints.c
+++ b/iterator/iter_hints.c
@@ -252,7 +252,7 @@ read_stubs_addr(struct config_stub* s, struct delegpt* dp)
 				s->name, p->str);
 			return 0;
 		}
-#ifndef HAVE_SSL_SET1_HOST
+#if !defined(HAVE_SSL_SET1_HOST) && !defined(HAVE_X509_VERIFY_PARAM_SET1_HOST)
 		if(auth_name)
 			log_err("no name verification functionality in "
 				"ssl library, ignored name for %s", p->str);


### PR DESCRIPTION
When bug #4206 was resolved, some bits remained that still indicate that OpenSSL 1.1.0 or later is required:

- Invalid error logging when name verification is enabled with older OpenSSL (or LibreSSL).
- Outdated note in the unbound.conf(5) man page.