### PR TITLE
contrib: Fix wrong comparison judgment before copying

### DIFF
--- a/contrib/unbound.init
+++ b/contrib/unbound.init
@@ -39,13 +39,13 @@ start() {
     # setup root jail
     if [ -s /etc/localtime ]; then 
 	[ -d ${rootdir}/etc ] || mkdir -p ${rootdir}/etc ;
-	if [ ! -e ${rootdir}/etc/localtime ] || /usr/bin/cmp -s /etc/localtime ${rootdir}/etc/localtime; then
+	if [ ! -e ${rootdir}/etc/localtime ] || ! /usr/bin/cmp -s /etc/localtime ${rootdir}/etc/localtime; then
 	    cp -fp /etc/localtime ${rootdir}/etc/localtime
 	fi;
     fi;
     if [ -s /etc/resolv.conf ]; then
 	[ -d ${rootdir}/etc ] || mkdir -p ${rootdir}/etc ;
-	if [ ! -e ${rootdir}/etc/resolv.conf ] || /usr/bin/cmp -s /etc/resolv.conf ${rootdir}/etc/resolv.conf; then
+	if [ ! -e ${rootdir}/etc/resolv.conf ] || ! /usr/bin/cmp -s /etc/resolv.conf ${rootdir}/etc/resolv.conf; then
 	    cp -fp /etc/resolv.conf ${rootdir}/etc/resolv.conf
 	fi;
     fi;


### PR DESCRIPTION
copy when file changed; linux shell treats 0 as true.