### PR TITLE
Fixes compile with srcdir overriden

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -812,7 +812,7 @@ config_file.lo config_file.o: $(srcdir)/util/config_file.c config.h $(srcdir)/ut
  $(srcdir)/util/data/dname.h $(srcdir)/util/rtt.h $(srcdir)/services/cache/infra.h \
  $(srcdir)/util/storage/dnstree.h $(srcdir)/sldns/wire2str.h $(srcdir)/sldns/parseutil.h \
  $(srcdir)/iterator/iterator.h $(srcdir)/services/outbound_list.h $(srcdir)/util/iana_ports.inc
-configlexer.lo configlexer.o: util/configlexer.c config.h $(srcdir)/util/configyyrename.h \
+configlexer.lo configlexer.o: $(srcdir)/util/configlexer.c config.h $(srcdir)/util/configyyrename.h \
  $(srcdir)/util/config_file.h util/configparser.h
 configparser.lo configparser.o: util/configparser.c config.h $(srcdir)/util/configyyrename.h \
  $(srcdir)/util/config_file.h $(srcdir)/util/net_help.h $(srcdir)/util/log.h


### PR DESCRIPTION
If not compiling within the source directory, overriding --srcdir to the configure script, make fails complaining about a missing source file. This patch includes the srcdir prefix to the file make complains about.