### PR TITLE
Improve wording in man page

### DIFF
--- a/doc/unbound.conf.5.in
+++ b/doc/unbound.conf.5.in
@@ -775,7 +775,7 @@ wise to send these, and could be necessary for operation if TSIG or EDNS
 payload is very large.
 .TP
 .B harden\-glue: \fI<yes or no>
-Will trust glue only if it is within the servers authority. Default is on.
+Will trust glue only if it is within the servers authority. Default is yes.
 .TP
 .B harden\-dnssec\-stripped: \fI<yes or no>
 Require DNSSEC data for trust\-anchored zones, if such data is absent,
@@ -785,7 +785,7 @@ this behaves like there is no trust anchor. You could turn this off if
 you are sometimes behind an intrusive firewall (of some sort) that
 removes DNSSEC data from packets, or a zone changes from signed to
 unsigned to badly signed often. If turned off you run the risk of a
-downgrade attack that disables security for a zone. Default is on.
+downgrade attack that disables security for a zone. Default is yes.
 .TP
 .B harden\-below\-nxdomain: \fI<yes or no>
 From RFC 8020 (with title "NXDOMAIN: There Really Is Nothing Underneath"),
@@ -795,7 +795,7 @@ noerror for empty nonterminals, hence this is possible.  Very old software
 might return nxdomain for empty nonterminals (that usually happen for reverse
 IP address lookups), and thus may be incompatible with this.  To try to avoid
 this only DNSSEC-secure nxdomains are used, because the old software does not
-have DNSSEC.  Default is on.
+have DNSSEC.  Default is yes.
 The nxdomain must be secure, this means nsec3 with optout is insufficient.
 .TP
 .B harden\-referral\-path: \fI<yes or no>
@@ -974,10 +974,10 @@ It is possible to use wildcards with this statement, the wildcard is
 expanded on start and on reload.
 .TP
 .B trust\-anchor\-signaling: \fI<yes or no>
-Send RFC8145 key tag query after trust anchor priming. Default is on.
+Send RFC8145 key tag query after trust anchor priming. Default is yes.
 .TP
 .B root\-key\-sentinel: \fI<yes or no>
-Root key trust anchor sentinel. Default is on.
+Root key trust anchor sentinel. Default is yes.
 .TP
 .B dlv\-anchor\-file: \fI<filename>
 This option was used during early days DNSSEC deployment when no parent-side


### PR DESCRIPTION
Make it more consistent throughout the man page.
If a config option can either be **yes** or **no** use exact these terms and not something like **on** which could be easily read as **no**.