### PR TITLE
Consistently use /dev/urandom instead of /dev/random in scripts and docs

### DIFF
--- a/contrib/unbound.init
+++ b/contrib/unbound.init
@@ -54,10 +54,10 @@ start() {
 	[ -e ${rootdir}/dev/log ] || touch ${rootdir}/dev/log
 	mount --bind -n /dev/log ${rootdir}/dev/log >/dev/null 2>&1;
     fi;
-    if ! egrep -q '^/[^[:space:]]+[[:space:]]+'${rootdir}'/dev/random' /proc/mounts; then
+    if ! egrep -q '^/[^[:space:]]+[[:space:]]+'${rootdir}'/dev/urandom' /proc/mounts; then
 	[ -d ${rootdir}/dev ] || mkdir -p ${rootdir}/dev ;
-	[ -e ${rootdir}/dev/random ] || touch ${rootdir}/dev/random
-	mount --bind -n /dev/random ${rootdir}/dev/random >/dev/null 2>&1;
+	[ -e ${rootdir}/dev/urandom ] || touch ${rootdir}/dev/urandom
+	mount --bind -n /dev/urandom ${rootdir}/dev/urandom >/dev/null 2>&1;
     fi;
 
     # if not running, start it up here
@@ -78,8 +78,8 @@ stop() {
     if egrep -q '^/[^[:space:]]+[[:space:]]+'${rootdir}'/dev/log' /proc/mounts; then
 	umount ${rootdir}/dev/log >/dev/null 2>&1
     fi;
-    if egrep -q '^/[^[:space:]]+[[:space:]]+'${rootdir}'/dev/random' /proc/mounts; then
-	umount ${rootdir}/dev/random >/dev/null 2>&1
+    if egrep -q '^/[^[:space:]]+[[:space:]]+'${rootdir}'/dev/urandom' /proc/mounts; then
+	umount ${rootdir}/dev/urandom >/dev/null 2>&1
     fi;
     return $retval
 }

--- a/contrib/unbound.init_fedora
+++ b/contrib/unbound.init_fedora
@@ -42,7 +42,7 @@ start() {
 	    cp -fp /etc/localtime ${rootdir}/etc/localtime
 	fi;
 	mount --bind -n /dev/log ${rootdir}/dev/log >/dev/null 2>&1;
-	mount --bind -n /dev/random ${rootdir}/dev/random >/dev/null 2>&1;
+	mount --bind -n /dev/urandom ${rootdir}/dev/urandom >/dev/null 2>&1;
 	mount --bind -n /var/run/unbound ${rootdir}/var/run/unbound >/dev/null 2>&1;
 
     # if not running, start it up here
@@ -58,7 +58,7 @@ stop() {
     killproc -p $pidfile unbound
     retval=$?
     [ $retval -eq 0 ] && rm -f $lockfile
-    for mountfile in /dev/log /dev/random /etc/localtime /etc/resolv.conf /var/run/unbound
+    for mountfile in /dev/log /dev/urandom /etc/localtime /etc/resolv.conf /var/run/unbound
     do
     if egrep -q '^/[^[:space:]]+[[:space:]]+'${rootdir}''${mountfile}'' /proc/mounts; then
 	umount ${rootdir}$mountfile >/dev/null 2>&1

--- a/daemon/daemon.c
+++ b/daemon/daemon.c
@@ -248,7 +248,7 @@ daemon_init(void)
 	/* init timezone info while we are not chrooted yet */
 	tzset();
 #endif
-	/* open /dev/random if needed */
+	/* open /dev/urandom if needed */
 	ub_systemseed((unsigned)time(NULL)^(unsigned)getpid()^0xe67);
 	daemon->need_to_exit = 0;
 	modstack_init(&daemon->mods);

--- a/dnscrypt/dnscrypt.c
+++ b/dnscrypt/dnscrypt.c
@@ -877,7 +877,7 @@ sodium_misuse_handler(void)
 	fatal_exit(
 		"dnscrypt: libsodium could not be initialized, this typically"
 		" happens when no good source of entropy is found. If you run"
-		" unbound in a chroot, make sure /dev/random is available. See"
+		" unbound in a chroot, make sure /dev/urandom is available. See"
 		" https://www.unbound.net/documentation/unbound.conf.html");
 }
 

--- a/doc/README
+++ b/doc/README
@@ -99,7 +99,7 @@ o If you are not receiving the correct source IP address on replies (e.g.
   the config file is an alternative. The interface-automatic option uses
   non portable socket options, Linux and FreeBSD should work fine.
 o The warning 'openssl has no entropy, seeding with time', with chroot 
-  enabled, may be solved with a symbolic link to /dev/random from <chrootdir>.
+  enabled, may be solved with a symbolic link to /dev/urandom from <chrootdir>.
 o On Solaris 5.10 some libtool packages from repositories do not work with
   gcc, showing errors gcc: unrecognized option `-KPIC'
   To solve this do ./configure libtool=./libtool [your options...].

--- a/doc/TODO
+++ b/doc/TODO
@@ -29,7 +29,7 @@ o support OPT record placement on recv anywhere in the additional section.
 o add local-file: config with authority features.
 o (option) to make local-data answers be secure for libunbound (default=no)
 o (option) to make chroot: copy all needed files into jail (or make jail)
-	perhaps also print reminder to link /dev/random and sysloghack.
+	perhaps also print reminder to link /dev/urandom and sysloghack.
 o overhaul outside-network servicedquery to merge with udpwait and tcpwait,
   to make timers in servicedquery independent of udpwait queues.
 o check into rebinding ports for efficiency, configure time test.

--- a/doc/example.conf.in
+++ b/doc/example.conf.in
@@ -286,7 +286,7 @@ server:
 	# The pid file can be absolute and outside of the chroot, it is
 	# written just prior to performing the chroot and dropping permissions.
 	#
-	# Additionally, unbound may need to access /dev/random (for entropy).
+	# Additionally, unbound may need to access /dev/urandom (for entropy).
 	# How to do this is specific to your OS.
 	#
 	# If you give "" no chroot is performed. The path must not end in a /.

--- a/doc/unbound.conf.5.in
+++ b/doc/unbound.conf.5.in
@@ -50,7 +50,7 @@ server:
 	username: unbound
 	# make sure unbound can access entropy from inside the chroot.
 	# e.g. on linux the use these commands (on BSD, devfs(8) is used):
-	#      mount \-\-bind \-n /dev/random /etc/unbound/dev/random
+	#      mount \-\-bind \-n /dev/urandom /etc/unbound/dev/urandom
 	# and  mount \-\-bind \-n /dev/log /etc/unbound/dev/log
 	chroot: "/etc/unbound"
 	# logfile: "/etc/unbound/unbound.log"  #uncomment to use logfile.
@@ -633,7 +633,7 @@ to chroot and dropping permissions. This allows the pidfile to be
 Unbound is not able to remove the pidfile after termination when it is located
 outside of the chroot directory.
 .IP
-Additionally, unbound may need to access /dev/random (for entropy)
+Additionally, unbound may need to access /dev/urandom (for entropy)
 from inside the chroot.
 .IP
 If given a chroot is done to the given directory. By default chroot is


### PR DESCRIPTION
Unbound code call /dev/urandom (see below)  but various docs and scripts mention /dev/random which may be confusing.

https://github.com/NLnetLabs/unbound/blob/release-1.9.3/compat/arc4random.c#L107
https://github.com/NLnetLabs/unbound/blob/release-1.9.3/compat/getentropy_linux.c#L251
https://github.com/NLnetLabs/unbound/blob/release-1.9.3/compat/getentropy_osx.c
https://github.com/NLnetLabs/unbound/blob/release-1.9.3/compat/getentropy_solaris.c#L116

@wcawijngaards 