### PR TITLE
Added -b / source address option to smallapp/unbound-anchor.c

### DIFF
--- a/doc/unbound-anchor.8.in
+++ b/doc/unbound-anchor.8.in
@@ -69,6 +69,10 @@ The server name, it connects to https://name.  Specify without https:// prefix.
 The default is "data.iana.org".  It connects to the port specified with \-P.
 You can pass an IPv4 address or IPv6 address (no brackets) if you want.
 .TP
+.B \-b \fIaddress
+The source address to bind to for domain resolution and contacting the server
+on https.  May be either an IPv4 address or IPv6 address (no brackets).
+.TP
 .B \-x \fIpath
 The pathname to the root\-anchors.xml file on the server. (forms URL with \-u).
 The default is /root\-anchors/root\-anchors.xml.


### PR DESCRIPTION
This is a patch which we need for the unbound server at a customer.

It allows you to specify the source address which unbound-anchor uses to connect to the root name servers. This is needed in our case as only the (additional) service ips on an interface are allowed to perform DNS queries, not the base ip of the interface.

Credit for developing this patch goes to Lukas Wunner <lukas@wunner.de>. I have just been maintaining this patch for the internal packages since 1.4, we just never got around to submit it upstream.

We hope to get this added to main stream unbound, as this is basically the last custom unbound patch we are maintaining.