### PR TITLE
Drop CAP_KILL, use + prefix for ExecReload= instead

### DIFF
--- a/contrib/unbound.service.in
+++ b/contrib/unbound.service.in
@@ -9,11 +9,11 @@ Wants=nss-lookup.target
 WantedBy=multi-user.target
 
 [Service]
-ExecReload=/bin/kill -HUP $MAINPID
+ExecReload=+/bin/kill -HUP $MAINPID
 ExecStart=@UNBOUND_SBIN_DIR@/unbound -d
 NotifyAccess=main
 Type=notify
-CapabilityBoundingSet=CAP_IPC_LOCK CAP_NET_BIND_SERVICE CAP_SETGID CAP_SETUID CAP_SYS_CHROOT CAP_SYS_RESOURCE CAP_NET_RAW CAP_KILL
+CapabilityBoundingSet=CAP_IPC_LOCK CAP_NET_BIND_SERVICE CAP_SETGID CAP_SETUID CAP_SYS_CHROOT CAP_SYS_RESOURCE CAP_NET_RAW
 MemoryDenyWriteExecute=true
 NoNewPrivileges=true
 PrivateDevices=true


### PR DESCRIPTION
CAP_KILL seems a bit too much privileges for the sole purpose of being able to make ExecReload= work.
Use the + prefix on ExecReload= instead to run "/bin/kill -HUP $MAINPID" with full privileges, ignoring the restrictions from CapabilityBoundingSet=.

See https://www.freedesktop.org/software/systemd/man/systemd.service.html#ExecStart= for further details about the + prefix in ExecReload=.