### PR TITLE
[stub] add stub_tcp_upstream support

### DIFF
--- a/daemon/worker.c
+++ b/daemon/worker.c
@@ -1935,8 +1935,8 @@ worker_delete(struct worker* worker)
 struct outbound_entry*
 worker_send_query(struct query_info* qinfo, uint16_t flags, int dnssec,
 	int want_dnssec, int nocaps, struct sockaddr_storage* addr,
-	socklen_t addrlen, uint8_t* zone, size_t zonelen, int ssl_upstream,
-	char* tls_auth_name, struct module_qstate* q)
+	socklen_t addrlen, uint8_t* zone, size_t zonelen, int tcp_upstream,
+	int ssl_upstream, char* tls_auth_name, struct module_qstate* q)
 {
 	struct worker* worker = q->env->worker;
 	struct outbound_entry* e = (struct outbound_entry*)regional_alloc(
@@ -1945,7 +1945,7 @@ worker_send_query(struct query_info* qinfo, uint16_t flags, int dnssec,
 		return NULL;
 	e->qstate = q;
 	e->qsent = outnet_serviced_query(worker->back, qinfo, flags, dnssec,
-		want_dnssec, nocaps, q->env->cfg->tcp_upstream,
+		want_dnssec, nocaps, tcp_upstream,
 		ssl_upstream, tls_auth_name, addr, addrlen, zone, zonelen, q,
 		worker_handle_service_reply, e, worker->back->udp_buff, q->env);
 	if(!e->qsent) {
@@ -1992,7 +1992,7 @@ struct outbound_entry* libworker_send_query(
 	uint16_t ATTR_UNUSED(flags), int ATTR_UNUSED(dnssec),
 	int ATTR_UNUSED(want_dnssec), int ATTR_UNUSED(nocaps),
 	struct sockaddr_storage* ATTR_UNUSED(addr), socklen_t ATTR_UNUSED(addrlen),
-	uint8_t* ATTR_UNUSED(zone), size_t ATTR_UNUSED(zonelen),
+	uint8_t* ATTR_UNUSED(zone), size_t ATTR_UNUSED(zonelen), int ATTR_UNUSED(tcp_upstream),
 	int ATTR_UNUSED(ssl_upstream), char* ATTR_UNUSED(tls_auth_name),
 	struct module_qstate* ATTR_UNUSED(q))
 {

--- a/iterator/iter_delegpt.c
+++ b/iterator/iter_delegpt.c
@@ -73,6 +73,7 @@ struct delegpt* delegpt_copy(struct delegpt* dp, struct regional* region)
 	copy->bogus = dp->bogus;
 	copy->has_parent_side_NS = dp->has_parent_side_NS;
 	copy->ssl_upstream = dp->ssl_upstream;
+	copy->tcp_upstream = dp->tcp_upstream;
 	for(ns = dp->nslist; ns; ns = ns->next) {
 		if(!delegpt_add_ns(copy, region, ns->name, ns->lame))
 			return NULL;

--- a/iterator/iter_delegpt.h
+++ b/iterator/iter_delegpt.h
@@ -83,6 +83,8 @@ struct delegpt {
 	uint8_t dp_type_mlc;
 	/** use SSL for upstream query */
 	uint8_t ssl_upstream;
+	/** use TCP for upstream query */
+	uint8_t tcp_upstream;
 	/** delegpt from authoritative zone that is locally hosted */
 	uint8_t auth_dp;
 	/*** no cache */

--- a/iterator/iter_fwd.c
+++ b/iterator/iter_fwd.c
@@ -276,6 +276,8 @@ read_forwards(struct iter_forwards* fwd, struct config_file* cfg)
 		dp->no_cache = s->no_cache;
 		/* use SSL for queries to this forwarder */
 		dp->ssl_upstream = (uint8_t)s->ssl_upstream;
+		/* use TCP for queries to this forwarder */
+		dp->tcp_upstream = (uint8_t)s->tcp_upstream;
 		verbose(VERB_QUERY, "Forward zone server list:");
 		delegpt_log(VERB_QUERY, dp);
 		if(!forwards_insert(fwd, LDNS_RR_CLASS_IN, dp))

--- a/iterator/iter_hints.c
+++ b/iterator/iter_hints.c
@@ -287,6 +287,8 @@ read_stubs(struct iter_hints* hints, struct config_file* cfg)
 		dp->no_cache = s->no_cache;
 		/* ssl_upstream */
 		dp->ssl_upstream = (uint8_t)s->ssl_upstream;
+		/* tcp_upstream */
+		dp->tcp_upstream = (uint8_t)s->tcp_upstream;
 		delegpt_log(VERB_QUERY, dp);
 		if(!hints_insert(hints, LDNS_RR_CLASS_IN, dp, !s->isprime))
 			return 0;

--- a/iterator/iterator.c
+++ b/iterator/iterator.c
@@ -2526,6 +2526,7 @@ processQueryTargets(struct module_qstate* qstate, struct iter_qstate* iq,
 		iq->dnssec_expected, iq->caps_fallback || is_caps_whitelisted(
 		ie, iq), &target->addr, target->addrlen,
 		iq->dp->name, iq->dp->namelen,
+		(iq->dp->tcp_upstream || qstate->env->cfg->tcp_upstream),
 		(iq->dp->ssl_upstream || qstate->env->cfg->ssl_upstream),
 		target->tls_auth_name, qstate);
 	if(!outq) {

--- a/libunbound/libworker.c
+++ b/libunbound/libworker.c
@@ -852,7 +852,7 @@ void libworker_alloc_cleanup(void* arg)
 struct outbound_entry* libworker_send_query(struct query_info* qinfo,
 	uint16_t flags, int dnssec, int want_dnssec, int nocaps,
 	struct sockaddr_storage* addr, socklen_t addrlen, uint8_t* zone,
-	size_t zonelen, int ssl_upstream, char* tls_auth_name,
+	size_t zonelen, int tcp_upstream, int ssl_upstream, char* tls_auth_name,
 	struct module_qstate* q)
 {
 	struct libworker* w = (struct libworker*)q->env->worker;
@@ -862,7 +862,7 @@ struct outbound_entry* libworker_send_query(struct query_info* qinfo,
 		return NULL;
 	e->qstate = q;
 	e->qsent = outnet_serviced_query(w->back, qinfo, flags, dnssec,
-		want_dnssec, nocaps, q->env->cfg->tcp_upstream, ssl_upstream,
+		want_dnssec, nocaps, tcp_upstream, ssl_upstream,
 		tls_auth_name, addr, addrlen, zone, zonelen, q,
 		libworker_handle_service_reply, e, w->back->udp_buff, q->env);
 	if(!e->qsent) {
@@ -983,7 +983,7 @@ struct outbound_entry* worker_send_query(struct query_info* ATTR_UNUSED(qinfo),
 	uint16_t ATTR_UNUSED(flags), int ATTR_UNUSED(dnssec),
 	int ATTR_UNUSED(want_dnssec), int ATTR_UNUSED(nocaps),
 	struct sockaddr_storage* ATTR_UNUSED(addr), socklen_t ATTR_UNUSED(addrlen),
-	uint8_t* ATTR_UNUSED(zone), size_t ATTR_UNUSED(zonelen),
+	uint8_t* ATTR_UNUSED(zone), size_t ATTR_UNUSED(zonelen), int ATTR_UNUSED(tcp_upstream),
 	int ATTR_UNUSED(ssl_upstream), char* ATTR_UNUSED(tls_auth_name),
 	struct module_qstate* ATTR_UNUSED(q))
 {

--- a/libunbound/worker.h
+++ b/libunbound/worker.h
@@ -72,7 +72,7 @@ struct query_info;
 struct outbound_entry* libworker_send_query(struct query_info* qinfo,
 	uint16_t flags, int dnssec, int want_dnssec, int nocaps,
 	struct sockaddr_storage* addr, socklen_t addrlen, uint8_t* zone,
-	size_t zonelen, int ssl_upstream, char* tls_auth_name,
+	size_t zonelen, int tcp_upstream, int ssl_upstream, char* tls_auth_name,
 	struct module_qstate* q);
 
 /** process incoming replies from the network */
@@ -127,7 +127,7 @@ void worker_sighandler(int sig, void* arg);
 struct outbound_entry* worker_send_query(struct query_info* qinfo,
 	uint16_t flags, int dnssec, int want_dnssec, int nocaps,
 	struct sockaddr_storage* addr, socklen_t addrlen, uint8_t* zone,
-	size_t zonelen, int ssl_upstream, char* tls_auth_name,
+	size_t zonelen, int tcp_upstream, int ssl_upstream, char* tls_auth_name,
 	struct module_qstate* q);
 
 /** 

--- a/smallapp/worker_cb.c
+++ b/smallapp/worker_cb.c
@@ -104,7 +104,7 @@ struct outbound_entry* worker_send_query(
 	int ATTR_UNUSED(dnssec), int ATTR_UNUSED(want_dnssec),
 	int ATTR_UNUSED(nocaps), struct sockaddr_storage* ATTR_UNUSED(addr),
 	socklen_t ATTR_UNUSED(addrlen), uint8_t* ATTR_UNUSED(zone),
-	size_t ATTR_UNUSED(zonelen), int ATTR_UNUSED(ssl_upstream),
+	size_t ATTR_UNUSED(zonelen), int ATTR_UNUSED(tcp_upstream), int ATTR_UNUSED(ssl_upstream),
 	char* ATTR_UNUSED(tls_auth_name), struct module_qstate* ATTR_UNUSED(q))
 {
 	log_assert(0);
@@ -136,7 +136,7 @@ struct outbound_entry* libworker_send_query(
 	int ATTR_UNUSED(dnssec), int ATTR_UNUSED(want_dnssec),
 	int ATTR_UNUSED(nocaps), struct sockaddr_storage* ATTR_UNUSED(addr),
 	socklen_t ATTR_UNUSED(addrlen), uint8_t* ATTR_UNUSED(zone),
-	size_t ATTR_UNUSED(zonelen), int ATTR_UNUSED(ssl_upstream),
+	size_t ATTR_UNUSED(zonelen), int ATTR_UNUSED(tcp_upstream), int ATTR_UNUSED(ssl_upstream),
 	char* ATTR_UNUSED(tls_auth_name), struct module_qstate* ATTR_UNUSED(q))
 {
 	log_assert(0);

--- a/util/config_file.h
+++ b/util/config_file.h
@@ -614,6 +614,8 @@ struct config_stub {
 	int isfirst;
 	/** use SSL for queries to this stub */
 	int ssl_upstream;
+	/** use TCP for queries to this stub */
+	int tcp_upstream;
 	/*** no cache */
 	int no_cache;
 };

--- a/util/configlexer.lex
+++ b/util/configlexer.lex
@@ -308,6 +308,7 @@ stub-first{COLON}		{ YDVAR(1, VAR_STUB_FIRST) }
 stub-no-cache{COLON}		{ YDVAR(1, VAR_STUB_NO_CACHE) }
 stub-ssl-upstream{COLON}	{ YDVAR(1, VAR_STUB_SSL_UPSTREAM) }
 stub-tls-upstream{COLON}	{ YDVAR(1, VAR_STUB_SSL_UPSTREAM) }
+stub-tcp-upstream{COLON}       { YDVAR(1, VAR_STUB_TCP_UPSTREAM) }
 forward-zone{COLON}		{ YDVAR(0, VAR_FORWARD_ZONE) }
 forward-addr{COLON}		{ YDVAR(1, VAR_FORWARD_ADDR) }
 forward-host{COLON}		{ YDVAR(1, VAR_FORWARD_HOST) }

--- a/util/configparser.y
+++ b/util/configparser.y
@@ -110,7 +110,7 @@ extern struct config_parser_state* cfg_parser;
 %token VAR_IGNORE_CD_FLAG VAR_LOG_QUERIES VAR_LOG_REPLIES VAR_LOG_LOCAL_ACTIONS
 %token VAR_TCP_UPSTREAM VAR_SSL_UPSTREAM
 %token VAR_SSL_SERVICE_KEY VAR_SSL_SERVICE_PEM VAR_SSL_PORT VAR_FORWARD_FIRST
-%token VAR_STUB_SSL_UPSTREAM VAR_FORWARD_SSL_UPSTREAM VAR_TLS_CERT_BUNDLE
+%token VAR_STUB_SSL_UPSTREAM VAR_STUB_TCP_UPSTREAM VAR_FORWARD_SSL_UPSTREAM VAR_TLS_CERT_BUNDLE
 %token VAR_STUB_FIRST VAR_MINIMAL_RESPONSES VAR_RRSET_ROUNDROBIN
 %token VAR_MAX_UDP_SIZE VAR_DELAY_CLOSE
 %token VAR_UNBLOCK_LAN_ZONES VAR_INSECURE_LAN_ZONES
@@ -285,7 +285,7 @@ stubstart: VAR_STUB_ZONE
 contents_stub: contents_stub content_stub 
 	| ;
 content_stub: stub_name | stub_host | stub_addr | stub_prime | stub_first |
-	stub_no_cache | stub_ssl_upstream
+	stub_no_cache | stub_ssl_upstream | stub_tcp_upstream
 	;
 forwardstart: VAR_FORWARD_ZONE
 	{
@@ -2295,6 +2295,16 @@ stub_ssl_upstream: VAR_STUB_SSL_UPSTREAM STRING_ARG
 		if(strcmp($2, "yes") != 0 && strcmp($2, "no") != 0)
 			yyerror("expected yes or no.");
 		else cfg_parser->cfg->stubs->ssl_upstream = 
+			(strcmp($2, "yes")==0);
+		free($2);
+	}
+	;
+stub_tcp_upstream: VAR_STUB_TCP_UPSTREAM STRING_ARG
+	{
+		OUTYY(("P(stub-tcp-upstream:%s)\n", $2));
+		if(strcmp($2, "yes") != 0 && strcmp($2, "no") != 0)
+			yyerror("expected yes or no.");
+		else cfg_parser->cfg->stubs->tcp_upstream = 
 			(strcmp($2, "yes")==0);
 		free($2);
 	}

--- a/util/fptr_wlist.c
+++ b/util/fptr_wlist.c
@@ -318,7 +318,7 @@ int
 fptr_whitelist_modenv_send_query(struct outbound_entry* (*fptr)(
 	struct query_info* qinfo, uint16_t flags, int dnssec, int want_dnssec,
 	int nocaps, struct sockaddr_storage* addr, socklen_t addrlen,
-	uint8_t* zone, size_t zonelen, int ssl_upstream, char* tls_auth_name,
+	uint8_t* zone, size_t zonelen, int tcp_upstream, int ssl_upstream, char* tls_auth_name,
 	struct module_qstate* q))
 {
 	if(fptr == &worker_send_query) return 1;

--- a/util/fptr_wlist.h
+++ b/util/fptr_wlist.h
@@ -212,7 +212,7 @@ int fptr_whitelist_hash_markdelfunc(lruhash_markdelfunc_type fptr);
 int fptr_whitelist_modenv_send_query(struct outbound_entry* (*fptr)(
 	struct query_info* qinfo, uint16_t flags, int dnssec, int want_dnssec,
 	int nocaps, struct sockaddr_storage* addr, socklen_t addrlen,
-	uint8_t* zone, size_t zonelen, int ssl_upstream, char* tls_auth_name,
+	uint8_t* zone, size_t zonelen, int tcp_upstream, int ssl_upstream, char* tls_auth_name,
 	struct module_qstate* q));
 
 /**

--- a/util/module.h
+++ b/util/module.h
@@ -343,6 +343,7 @@ struct module_env {
 	 * @param addrlen: length of addr.
 	 * @param zone: delegation point name.
 	 * @param zonelen: length of zone name.
+	 * @param tcp_upstream: use TCP for upstream queries.
 	 * @param ssl_upstream: use SSL for upstream queries.
 	 * @param tls_auth_name: if ssl_upstream, use this name with TLS
 	 * 	authentication.
@@ -355,7 +356,7 @@ struct module_env {
 	struct outbound_entry* (*send_query)(struct query_info* qinfo,
 		uint16_t flags, int dnssec, int want_dnssec, int nocaps,
 		struct sockaddr_storage* addr, socklen_t addrlen,
-		uint8_t* zone, size_t zonelen, int ssl_upstream,
+		uint8_t* zone, size_t zonelen, int tcp_upstream, int ssl_upstream,
 		char* tls_auth_name, struct module_qstate* q);
 
 	/**


### PR DESCRIPTION
This allows using TCP instead of UDP for a specific stub zone

Fixes #94