### PR TITLE
manpage: Add missing word on unbound.conf

### DIFF
--- a/doc/unbound.conf.5.in
+++ b/doc/unbound.conf.5.in
@@ -949,7 +949,7 @@ Default is "", or no trust anchor file.
 .TP
 .B auto\-trust\-anchor\-file: \fI<filename>
 File with trust anchor for one zone, which is tracked with RFC5011 probes.
-The probes are several times per month, thus the machine must be online
+The probes are run several times per month, thus the machine must be online
 frequently.  The initial file can be one with contents as described in
 \fBtrust\-anchor\-file\fR.  The file is written to when the anchor is updated,
 so the unbound user must have write permission.  Write permission to the file,


### PR DESCRIPTION
After having a quick glance on the RFC 5011 document, I'm assuming this is what is implied here.