### PR TITLE
fix: adjust 'no fds available' log into NO_VERBOSE level.

### DIFF
--- a/services/outside_network.c
+++ b/services/outside_network.c
@@ -1253,7 +1253,7 @@ pending_udp_query(struct serviced_query* sq, struct sldns_buffer* packet,
 
 	if(sq->outnet->unused_fds == NULL) {
 		/* no unused fd, cannot create a new port (randomly) */
-		verbose(VERB_ALGO, "no fds available, udp query waiting");
+		verbose(NO_VERBOSE, "no fds available, udp query waiting");
 		pend->timeout = timeout;
 		pend->pkt_len = sldns_buffer_limit(packet);
 		pend->pkt = (uint8_t*)memdup(sldns_buffer_begin(packet),


### PR DESCRIPTION
when no unused fd, cannot create a new port (randomly), it is a critical
error. Because unbound cannot resolve any domains from authoritive
server, so it cannot response to new query.

It should be NO_VERBOSE level, such that administrator can easily get
the error message. In current situation, administrator cannot get the error
message, because the default value of verbosity is 0。