### PR TITLE
Allow the kernel to provide random source ports.

### DIFF
--- a/config.h.in
+++ b/config.h.in
@@ -805,6 +805,10 @@
 /* Define to 1 to use ipset support */
 #undef USE_IPSET
 
+/* Define to 1 to disable explict UDP source port randomisation and rely on the
+   kernel to provide random source ports */
+#undef DISABLE_EXPLICIT_PORT_RANDOMISATION
+
 /* Define if you want to use internal select based events */
 #undef USE_MINI_EVENT
 

--- a/configure
+++ b/configure
@@ -890,6 +890,7 @@ enable_cachedb
 enable_ipsecmod
 enable_ipset
 with_libmnl
+enable_explicit_port_randomisation
 with_libunbound_only
 '
       ac_precious_vars='build_alias
@@ -1579,6 +1580,9 @@ Optional Features:
   --enable-ipsecmod       Enable ipsecmod module that facilitates
                           opportunistic IPsec
   --enable-ipset          enable ipset module
+  --disable-explicit-port-randomisation
+                          disable explicit source port randomisation and rely
+                          on the kernel to provide random source ports
 
 Optional Packages:
   --with-PACKAGE[=ARG]    use PACKAGE [ARG=yes]
@@ -21443,6 +21447,21 @@ $as_echo "found in $dir" >&6; }
     	# nothing
 		;;
 esac
+# Check whether --enable-explicit-port-randomisation was given.
+if test "${enable_explicit_port_randomisation+set}" = set; then :
+  enableval=$enable_explicit_port_randomisation;
+fi
+
+case "$enable_explicit_port_randomisation" in
+	no)
+
+$as_echo "#define DISABLE_EXPLICIT_PORT_RANDOMISATION 1" >>confdefs.h
+
+		;;
+	yes|*)
+		;;
+esac
+
 
 { $as_echo "$as_me:${as_lineno-$LINENO}: checking if ${MAKE:-make} supports $< with implicit rule in scope" >&5
 $as_echo_n "checking if ${MAKE:-make} supports $< with implicit rule in scope... " >&6; }

--- a/configure.ac
+++ b/configure.ac
@@ -1778,6 +1778,15 @@ case "$enable_ipset" in
     	# nothing
 		;;
 esac
+AC_ARG_ENABLE(explicit-port-randomisation, AC_HELP_STRING([--disable-explicit-port-randomisation], [disable explicit source port randomisation and rely on the kernel to provide random source ports]))
+case "$enable_explicit_port_randomisation" in
+	no)
+		AC_DEFINE([DISABLE_EXPLICIT_PORT_RANDOMISATION], [1], [Define this to enable kernel based UDP source port randomization.])
+		;;
+	yes|*)
+		;;
+esac
+
 
 AC_MSG_CHECKING([if ${MAKE:-make} supports $< with implicit rule in scope])
 # on openBSD, the implicit rule make $< work.

--- a/services/outside_network.h
+++ b/services/outside_network.h
@@ -172,11 +172,13 @@ struct port_if {
 	 * if 0, no randomisation. */
 	int pfxlen;
 
+#ifndef DISABLE_EXPLICIT_PORT_RANDOMISATION
 	/** the available ports array. These are unused.
 	 * Only the first total-inuse part is filled. */
 	int* avail_ports;
 	/** the total number of available ports (size of the array) */
 	int avail_total;
+#endif
 
 	/** array of the commpoints currently in use. 
 	 * allocated for max number of fds, first part in use. */


### PR DESCRIPTION
On some operating systems, for example OpenBSD since some decades, the
kernel binds to a random source port if asked for any port (port
number 0). There is no need to replicate this functionality in
userland.