### PR TITLE
Use passed in neg and key cache if non-NULL.

### DIFF
--- a/validator/validator.c
+++ b/validator/validator.c
@@ -121,6 +121,8 @@ val_apply_cfg(struct module_env* env, struct val_env* val_env,
 		log_err("out of memory");
 		return 0;
 	}
+	if (env->key_cache)
+		val_env->kcache = env->key_cache;
 	if(!val_env->kcache)
 		val_env->kcache = key_cache_create(cfg);
 	if(!val_env->kcache) {
@@ -146,6 +148,8 @@ val_apply_cfg(struct module_env* env, struct val_env* val_env,
 		log_err("validator: cannot apply nsec3 key iterations");
 		return 0;
 	}
+	if (env->neg_cache)
+		val_env->neg_cache = env->neg_cache;
 	if(!val_env->neg_cache)
 		val_env->neg_cache = val_neg_create(cfg,
 			val_env->nsec3_maxiter[val_env->nsec3_keyiter_count-1]);


### PR DESCRIPTION
With this the neg and key caches can be shared between multiple
libunbound contexts.

The msg and rrset caches already allowed this since context_finalize()
did not touch those if they are already available and have the correct
size.

Care must be taken to properly unhook the caches from the validator
environment before calling ub_ctx_delete() otherwise one risks double
free or use after free bugs.