### PR TITLE
Fixing use-after-free issue which raised up while fixing issue #99

### DIFF
--- a/libunbound/libunbound.c
+++ b/libunbound/libunbound.c
@@ -217,15 +217,22 @@ ub_ctx_create_event(struct event_base* eb)
 	ctx->created_bg = 0;
 	ctx->dothread = 1; /* the processing is in the same process,
 		makes ub_cancel and ub_ctx_delete do the right thing */
-	ctx->event_base = ub_libevent_event_base(eb);
+	if(eb) {
+		ctx->event_base = ub_libevent_event_base(eb);
+		ctx->event_base_malloced = 1;
+	} else {
+		ctx->event_base = ub_libevent_event_base(NULL);
+		ctx->event_base_malloced = 0;
+	}
+
 	if (!ctx->event_base) {
 		ub_ctx_delete(ctx);
 		return NULL;
 	}
-	ctx->event_base_malloced = 1;
+
 	return ctx;
 }
-	
+
 /** delete q */
 static void
 delq(rbnode_type* n, void* ATTR_UNUSED(arg))

--- a/libunbound/libunbound.c
+++ b/libunbound/libunbound.c
@@ -217,19 +217,16 @@ ub_ctx_create_event(struct event_base* eb)
 	ctx->created_bg = 0;
 	ctx->dothread = 1; /* the processing is in the same process,
 		makes ub_cancel and ub_ctx_delete do the right thing */
-	if(eb) {
-		ctx->event_base = ub_libevent_event_base(eb);
-		ctx->event_base_malloced = 1;
-	} else {
-		ctx->event_base = ub_libevent_event_base(NULL);
-		ctx->event_base_malloced = 0;
-	}
 
+	bool eb_malloced = !eb;
+
+	ctx->event_base = ub_libevent_event_base(eb);
 	if (!ctx->event_base) {
 		ub_ctx_delete(ctx);
 		return NULL;
 	}
 
+	ctx->event_base_malloced = eb_malloced;
 	return ctx;
 }
 


### PR DESCRIPTION
Fixed the use-after-free issue within the libevent part of unbound.
This issue raised while attempting to fix issue #99.