### PR TITLE
unbound.service.in: stop binding pidfile inside chroot dir

### DIFF
--- a/contrib/unbound.service.in
+++ b/contrib/unbound.service.in
@@ -26,7 +26,6 @@ ReadWritePaths=/run @UNBOUND_RUN_DIR@ @UNBOUND_CHROOT_DIR@
 TemporaryFileSystem=@UNBOUND_CHROOT_DIR@/dev:ro
 TemporaryFileSystem=@UNBOUND_CHROOT_DIR@/run:ro
 BindReadOnlyPaths=-/run/systemd/notify:@UNBOUND_CHROOT_DIR@/run/systemd/notify
-BindPaths=-@UNBOUND_PIDFILE@:@UNBOUND_CHROOT_DIR@@UNBOUND_PIDFILE@
 BindReadOnlyPaths=-/dev/urandom:@UNBOUND_CHROOT_DIR@/dev/urandom
 BindPaths=-/dev/log:@UNBOUND_CHROOT_DIR@/dev/log
 RestrictAddressFamilies=AF_INET AF_INET6 AF_UNIX


### PR DESCRIPTION
Apparently pidfile isn't used inside chroot and binding it may cause some weird failures with older systemd.

Fixes https://github.com/NLnetLabs/unbound/issues/138