### PR TITLE
minor #1344 change rfc reference for reserved top level dns names

### DIFF
--- a/doc/unbound.conf.5.in
+++ b/doc/unbound.conf.5.in
@@ -1296,7 +1296,7 @@ local\-data: "onion. 10800 IN
     SOA localhost. nobody.invalid. 1 3600 1200 604800 10800"
 .fi
 .TP 10
-\h'5'\fItest (RFC 2606)\fR
+\h'5'\fItest (RFC 6761)\fR
 Default content:
 .nf
 local\-zone: "test." static
@@ -1305,7 +1305,7 @@ local\-data: "test. 10800 IN
     SOA localhost. nobody.invalid. 1 3600 1200 604800 10800"
 .fi
 .TP 10
-\h'5'\fIinvalid (RFC 2606)\fR
+\h'5'\fIinvalid (RFC 6761)\fR
 Default content:
 .nf
 local\-zone: "invalid." static

--- a/services/localzone.c
+++ b/services/localzone.c
@@ -823,12 +823,12 @@ int local_zone_enter_defaults(struct local_zones* zones, struct config_file* cfg
 		log_err("out of memory adding default zone");
 		return 0;
 	}
-	/* test. zone (RFC 7686) */
+	/* test. zone (RFC 6761) */
 	if(!add_empty_default(zones, cfg, "test.")) {
 		log_err("out of memory adding default zone");
 		return 0;
 	}
-	/* invalid. zone (RFC 7686) */
+	/* invalid. zone (RFC 6761) */
 	if(!add_empty_default(zones, cfg, "invalid.")) {
 		log_err("out of memory adding default zone");
 		return 0;


### PR DESCRIPTION
[RFC 7686](https://tools.ietf.org/html/) covers only `.onion` domain.

[RFC 2606](https://tools.ietf.org/html/rfc2606) covers four others:
* test
* example
* invalid
* localhost

Why `example` and `localhost` not set empty by default?

P.S.: issue link #1344 was taken from historical commit, where this comment was specified