### PR TITLE
Update unbound.service.in

### DIFF
--- a/contrib/unbound.service.in
+++ b/contrib/unbound.service.in
@@ -9,8 +9,9 @@ Wants=nss-lookup.target
 WantedBy=multi-user.target
 
 [Service]
-ExecReload=+/bin/kill -HUP $MAINPID
 ExecStart=@UNBOUND_SBIN_DIR@/unbound -d
+ExecReload=+/bin/kill -HUP $MAINPID
+ExecStop=+/bin/kill -TERM $MAINPID
 NotifyAccess=main
 Type=notify
 CapabilityBoundingSet=CAP_IPC_LOCK CAP_NET_BIND_SERVICE CAP_SETGID CAP_SETUID CAP_SYS_CHROOT CAP_SYS_RESOURCE CAP_NET_RAW
@@ -22,12 +23,10 @@ ProtectHome=true
 ProtectControlGroups=true
 ProtectKernelModules=true
 ProtectSystem=strict
-ReadWritePaths=/run @UNBOUND_RUN_DIR@ @UNBOUND_CHROOT_DIR@
-TemporaryFileSystem=@UNBOUND_CHROOT_DIR@/dev:ro
-TemporaryFileSystem=@UNBOUND_CHROOT_DIR@/run:ro
-BindReadOnlyPaths=-/run/systemd/notify:@UNBOUND_CHROOT_DIR@/run/systemd/notify
-BindReadOnlyPaths=-/dev/urandom:@UNBOUND_CHROOT_DIR@/dev/urandom
-BindPaths=-/dev/log:@UNBOUND_CHROOT_DIR@/dev/log
+ConfigurationDirectory=unbound
+RuntimeDirectory=unbound
+BindReadOnlyPaths=/run/systemd/notify
+BindReadOnlyPaths=/dev/log /run/systemd/journal/socket /run/systemd/journal/stdout
 RestrictAddressFamilies=AF_INET AF_INET6 AF_UNIX
 RestrictRealtime=true
 SystemCallArchitectures=native


### PR DESCRIPTION
I'm trying to use (and deploy) unbound as a portable service. With the provided .service file, it seems very difficult, mostly because it puts everything under a `chroot` directory. The chroot thing seems a bit cumbersome though since we are using systemd to harden the environment unbound will run in.
So, here are a few changes I suggest to make things a bit more "standard" (IMHO). The changes are mostly inspired by what is provided by systemd in /usr/lib/systemd/portable/profile/default/service.conf.

I also added an `ExecStop=` directive because why not :)

The removed `ReadWritePaths=`, `TemporaryFileSystem=`, `BindReadOnlyPaths=` and `BindPaths=` directives have been replaced by `ConfigurationDirectory=` and `RuntimeDirectory=` which makes things clearer IMHO. Some of them were also already implied by `ProtectSystem=strict`.
I'll be happy to give some more precisions if needed.

These changes also require `chroot: ""` and `pidfile: /run/unbound/unbound.pid` but that might be something for the packagers to take care of when compiling (depending on the use of systemd in the distro ?) ?