### PR TITLE
Allow use of libbsd functions with configure option --with-libbsd

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -881,6 +881,19 @@ fi
 fi
 AC_SUBST(SSLLIB)
 
+# libbsd
+AC_ARG_WITH([libbsd], AC_HELP_STRING([--with-libbsd], [Use portable libbsd functions]), [
+	AC_CHECK_HEADERS([bsd/string.h bsd/stdlib.h],,, [AC_INCLUDES_DEFAULT])
+	if test "x$ac_cv_header_bsd_string_h" = xyes -a "x$ac_cv_header_bsd_stdlib_h" = xyes; then
+		for func in strlcpy strlcat arc4random arc4random_uniform reallocarray; do
+			AC_SEARCH_LIBS([$func], [bsd], [
+				AC_DEFINE(HAVE_LIBBSD, 1, [Use portable libbsd functions])
+				PC_LIBBSD_DEPENDENCY=libbsd
+				AC_SUBST(PC_LIBBSD_DEPENDENCY)
+			])
+		done
+	fi
+])
 
 AC_ARG_ENABLE(sha1, AC_HELP_STRING([--disable-sha1], [Disable SHA1 RRSIG support, does not disable nsec3 support]))
 case "$enable_sha1" in
@@ -1944,6 +1957,11 @@ char *strptime(const char *s, const char *format, struct tm *tm);
 
 #if !HAVE_DECL_REALLOCARRAY
 void *reallocarray(void *ptr, size_t nmemb, size_t size);
+#endif
+
+#ifdef HAVE_LIBBSD
+#include <bsd/string.h>
+#include <bsd/stdlib.h>
 #endif
 
 #ifdef HAVE_LIBRESSL

--- a/contrib/libunbound.pc.in
+++ b/contrib/libunbound.pc.in
@@ -8,7 +8,7 @@ Description: Library with validating, recursive, and caching DNS resolver
 URL: http://www.unbound.net
 Version: @PACKAGE_VERSION@
 Requires: libcrypto libssl @PC_LIBEVENT_DEPENDENCY@
-Requires.private: @PC_PY_DEPENDENCY@
+Requires.private: @PC_PY_DEPENDENCY@ @PC_LIBBSD_DEPENDENCY@
 Libs: -L${libdir} -lunbound -lssl -lcrypto
 Libs.private: @SSLLIB@ @LIBS@
 Cflags: -I${includedir} 

--- a/util/random.c
+++ b/util/random.c
@@ -78,7 +78,7 @@
  */
 #define MAX_VALUE 0x7fffffff
 
-#if defined(HAVE_SSL)
+#if defined(HAVE_SSL) || defined(HAVE_LIBBSD)
 struct ub_randstate* 
 ub_initstate(struct ub_randstate* ATTR_UNUSED(from))
 {
@@ -183,10 +183,10 @@ long int ub_random(struct ub_randstate* s)
 	}
 	return x & MAX_VALUE;
 }
-#endif /* HAVE_SSL or HAVE_NSS or HAVE_NETTLE */
+#endif /* HAVE_SSL or HAVE_LIBBSD or HAVE_NSS or HAVE_NETTLE */
 
 
-#if defined(HAVE_NSS) || defined(HAVE_NETTLE)
+#if defined(HAVE_NSS) || defined(HAVE_NETTLE) && !defined(HAVE_LIBBSD)
 long int
 ub_random_max(struct ub_randstate* state, long int x)
 {
@@ -198,7 +198,7 @@ ub_random_max(struct ub_randstate* state, long int x)
 		v = ub_random(state);
 	return (v % x);
 }
-#endif /* HAVE_NSS or HAVE_NETTLE */
+#endif /* HAVE_NSS or HAVE_NETTLE and !HAVE_LIBBSD */
 
 void 
 ub_randfree(struct ub_randstate* s)


### PR DESCRIPTION
Hi,

This pull request is for a patch developed by @stevenc99 and shipped in the Debian package of unbound ≥ 1.6.4. It adds a `--with-libbsd` configure option for using some functions shipped in the libbsd library rather than the implementations in unbound's `compat/` directory. We meant to submit this patch upstream back in 2017 but it looks like that never happened.

There are further details here:

• https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=853751

• https://wiki.debian.org/arc4random

I've refreshed the patch so that it is up-to-date with the Unbound master branch.

Thanks!