### PR TITLE
contrib/libunbound.pc.in: Fixes to Libs/Requires for crypto library dependencies

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -761,6 +761,8 @@ AC_ARG_WITH([nss], AC_HELP_STRING([--with-nss=path],
 	fi
         LIBS="$LIBS -lnss3 -lnspr4"
 	SSLLIB=""
+	PC_CRYPTO_DEPENDENCY="nss nspr"
+	AC_SUBST(PC_CRYPTO_DEPENDENCY)
 	]
 )
 
@@ -781,6 +783,8 @@ AC_ARG_WITH([nettle], AC_HELP_STRING([--with-nettle=path],
 	fi
         LIBS="$LIBS -lhogweed -lnettle -lgmp"
 	SSLLIB=""
+	PC_CRYPTO_DEPENDENCY="hogweed nettle"
+	AC_SUBST(PC_CRYPTO_DEPENDENCY)
 	]
 )
 
@@ -789,6 +793,9 @@ if test $USE_NSS = "no" -a $USE_NETTLE = "no"; then
 ACX_WITH_SSL
 ACX_LIB_SSL
 SSLLIB="-lssl"
+
+PC_CRYPTO_DEPENDENCY="libcrypto libssl"
+AC_SUBST(PC_CRYPTO_DEPENDENCY)
 
 # check if -lcrypt32 is needed because CAPIENG needs that. (on windows)
 BAKLIBS="$LIBS"

--- a/contrib/libunbound.pc.in
+++ b/contrib/libunbound.pc.in
@@ -9,6 +9,6 @@ URL: http://www.unbound.net
 Version: @PACKAGE_VERSION@
 Requires: libcrypto libssl @PC_LIBEVENT_DEPENDENCY@
 Requires.private: @PC_PY_DEPENDENCY@
-Libs: -L${libdir} -lunbound -lssl -lcrypto
+Libs: -L${libdir} -lunbound
 Libs.private: @SSLLIB@ @LIBS@
-Cflags: -I${includedir} 
+Cflags: -I${includedir}

--- a/contrib/libunbound.pc.in
+++ b/contrib/libunbound.pc.in
@@ -7,7 +7,7 @@ Name: unbound
 Description: Library with validating, recursive, and caching DNS resolver
 URL: http://www.unbound.net
 Version: @PACKAGE_VERSION@
-Requires: libcrypto libssl @PC_LIBEVENT_DEPENDENCY@
+Requires: @PC_CRYPTO_DEPENDENCY@ @PC_LIBEVENT_DEPENDENCY@
 Requires.private: @PC_PY_DEPENDENCY@
 Libs: -L${libdir} -lunbound
 Libs.private: @SSLLIB@ @LIBS@


### PR DESCRIPTION
contrib/libunbound.pc.in: Only specify -lunbound for Libs

According to the pkg-config manpage, the "Libs" line in a .pc file should give the link flags "specific to your package", and specifically says not to include link flags for dependencies:

    Libs:  This line should give the link flags specific to your
           package.  Don't add any flags for required packages;
           pkg-config will add those automatically.

contrib/libunbound.pc.in: Embed the correct crypto dependencies

This commit removes the hardcoded dependency in the libunbound pkg-config .pc file on the libcrypto and libssl modules and instead populates the .pc file based on which crypto library was selected at configure time.

Note that the .pc file specifies pkg-config module names for the "Requires" line and this can vary from the library filename (e.g. "nss" is the pkg-config module name vs. "nss3" being the library name).