### PR TITLE
Added unbound-control view_local_datas_remove command

### DIFF
--- a/daemon/remote.c
+++ b/daemon/remote.c
@@ -1479,6 +1479,27 @@ do_view_data_remove(RES* ssl, struct worker* worker, char* arg)
 	lock_rw_unlock(&v->lock);
 }
 
+/** Remove RR data from stdin from view */
+static void
+do_view_datas_remove(RES* ssl, struct worker* worker, char* arg)
+{
+	struct view* v;
+	v = views_find_view(worker->daemon->views,
+		arg, 1 /* get write lock*/);
+	if(!v) {
+		ssl_printf(ssl,"no view with name: %s\n", arg);
+		return;
+	}
+	if(!v->local_zones){
+		lock_rw_unlock(&v->lock);
+		ssl_printf(ssl, "removed 0 datas\n");
+		return;
+	}
+
+	do_datas_remove(ssl, v->local_zones);
+	lock_rw_unlock(&v->lock);
+}
+
 /** cache lookup of nameservers */
 static void
 do_lookup(RES* ssl, struct worker* worker, char* arg)
@@ -2989,6 +3010,8 @@ execute_cmd(struct daemon_remote* rc, RES* ssl, char* cmd,
 		do_view_zone_add(ssl, worker, skipwhite(p+15));
 	} else if(cmdcmp(p, "view_local_data_remove", 22)) {
 		do_view_data_remove(ssl, worker, skipwhite(p+22));
+	} else if(cmdcmp(p, "view_local_datas_remove", 23)){
+		do_view_datas_remove(ssl, worker, skipwhite(p+23));
 	} else if(cmdcmp(p, "view_local_data", 15)) {
 		do_view_data_add(ssl, worker, skipwhite(p+15));
 	} else if(cmdcmp(p, "view_local_datas", 16)) {

--- a/doc/unbound-control.8.in
+++ b/doc/unbound-control.8.in
@@ -323,6 +323,9 @@ serial check).  And then the zone is transferred for a newer zone version.
 .B view_local_data_remove \fIview\fR \fIname
 \fIlocal_data_remove\fR for given view.
 .TP
+.B view_local_datas_remove \fIview\fR
+Remove a list of \fIlocal_data\fR for given view from stdin. Like local_datas_remove.
+.TP
 .B view_local_datas \fIview\fR
 Add a list of \fIlocal_data\fR for given view from stdin.  Like local_datas.
 .SH "EXIT CODE"

--- a/smallapp/unbound-control.c
+++ b/smallapp/unbound-control.c
@@ -157,6 +157,8 @@ usage(void)
 	printf("  view_local_datas view 		add list of local-data to view\n");
 	printf("  					one entry per line read from stdin\n");
 	printf("  view_local_data_remove view name  	remove local-data in view\n");
+	printf("  view_local_datas_remove view 		remove list of local-data from view\n");
+	printf("  					one entry per line read from stdin\n");
 	printf("Version %s\n", PACKAGE_VERSION);
 	printf("BSD licensed, see LICENSE in source package for details.\n");
 	printf("Report bugs to %s\n", PACKAGE_BUGREPORT);
@@ -706,7 +708,8 @@ check_args_for_listcmd(int argc, char* argv[])
 		fatal_exit("too many arguments for command '%s', "
 			"content is piped in from stdin", argv[0]);
 	}
-	if(argc >= 1 && strcmp(argv[0], "view_local_datas") == 0 &&
+	if(argc >= 1 && (strcmp(argv[0], "view_local_datas") == 0 ||
+		strcmp(argv[0], "view_local_datas_remove") == 0) &&
 		argc >= 3) {
 		fatal_exit("too many arguments for command '%s', "
 			"content is piped in from stdin", argv[0]);
@@ -755,7 +758,8 @@ go_cmd(SSL* ssl, int fd, int quiet, int argc, char* argv[])
 		strcmp(argv[0], "local_zones_remove") == 0 ||
 		strcmp(argv[0], "local_datas") == 0 ||
 		strcmp(argv[0], "view_local_datas") == 0 ||
-		strcmp(argv[0], "local_datas_remove") == 0)) {
+		strcmp(argv[0], "local_datas_remove") == 0) ||
+		strcmp(argv[0], "view_local_datas_remove") == 0) {
 		send_file(ssl, fd, stdin, buf, sizeof(buf));
 		send_eof(ssl, fd);
 	}


### PR DESCRIPTION
I thought this would be a neat feature, to be able to bulk remove local_data from a view.