### PR TITLE
Add additional compilers and platforms to Travis testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,6 +22,10 @@ jobs:
       name: Clang on Linux, Amd64
       compiler: clang
       arch: amd64
+    - os: osx
+      name: Clang on OS X, Amd64
+      compiler: clang
+      arch: amd64
     - os: linux
       name: UBsan, GCC on Linux, Amd64
       compiler: gcc
@@ -46,10 +50,6 @@ jobs:
       arch: amd64
       dist: bionic
       env: TEST_ASAN=yes
-    - os: osx
-      name: Clang on OS X, Amd64
-      compiler: clang
-      arch: amd64
     - os: linux
       name: GCC on Linux, Aarch64
       compiler: gcc
@@ -70,6 +70,13 @@ jobs:
       compiler: clang
       arch: ppc64le
       dist: bionic
+
+before_install:
+  - |
+    if [ "$TRAVIS_OS_NAME" = "osx" ]; then
+        brew update
+        brew install openssl
+    fi
 
 script:
   - |

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,9 @@
-sudo: false
 language: c
-compiler:
-  - gcc
+sudo: false
+
+git:
+  depth: 5
+
 addons:
   apt:
     packages:
@@ -9,8 +11,77 @@ addons:
     - libevent-dev
     - libexpat-dev
     - clang
+
+jobs:
+  include:
+    - os: linux
+      name: GCC on Linux, Amd64
+      compiler: gcc
+      arch: amd64
+    - os: linux
+      name: Clang on Linux, Amd64
+      compiler: clang
+      arch: amd64
+    - os: linux
+      name: UBsan, GCC on Linux, Amd64
+      compiler: gcc
+      arch: amd64
+      dist: bionic
+      env: TEST_UBSAN=yes
+    - os: linux
+      name: UBsan, Clang on Linux, Amd64
+      compiler: clang
+      arch: amd64
+      dist: bionic
+      env: TEST_UBSAN=yes
+    - os: linux
+      name: Asan, GCC on Linux, Amd64
+      compiler: gcc
+      arch: amd64
+      dist: bionic
+      env: TEST_ASAN=yes
+    - os: linux
+      name: Asan, Clang on Linux, Amd64
+      compiler: clang
+      arch: amd64
+      dist: bionic
+      env: TEST_ASAN=yes
+    - os: osx
+      name: Clang on OS X, Amd64
+      compiler: clang
+      arch: amd64
+    - os: linux
+      name: GCC on Linux, Aarch64
+      compiler: gcc
+      arch: arm64
+      dist: bionic
+    - os: linux
+      name: Clang on Linux, Aarch64
+      compiler: clang
+      arch: arm64
+      dist: bionic
+    - os: linux
+      name: GCC on Linux, PowerPC64
+      compiler: gcc
+      arch: ppc64le
+      dist: bionic
+    - os: linux
+      name: Clang on Linux, PowerPC64
+      compiler: clang
+      arch: ppc64le
+      dist: bionic
+
 script:
-  - ./configure --enable-debug --disable-flto
-  - make
+  - |
+    if [ "$TEST_UBSAN" = "yes"  ]; then
+      export CFLAGS="-DNDEBUG -g2 -O3 -fsanitize=undefined -fno-sanitize-recover"
+      ./configure
+    elif [ "$TEST_ASAN" = "yes" ]; then
+      export CFLAGS="-DNDEBUG -g2 -O3 -fsanitize=address"
+      ./configure
+    else
+      ./configure --enable-debug --disable-flto
+    fi
+  - make -j 2
   - make test
   - (cd testdata/clang-analysis.tdir; bash clang-analysis.test)


### PR DESCRIPTION
Hi Everyone,

This PR adds additional compiler and platform testing to Travis. It will probably help avoid surprises in the future. It is an inexpensive insurance policy that takes nearly no effort once setup. The trick is digging into the Travis docs to set it up. (It is a lot easier when someone provides a Travis config as a starting point).

We use a similar Travis config for [Crypto++](https://github.com/weidai11/cryptopp/blob/master/.travis.yml). I know Jack Lloyd uses a similar Travis config for [Botan](https://github.com/randombit/botan/blob/master/src/scripts/ci/travis.yml). In fact, Crypto++ uses Travis for Linux, OS X, Android and iOS testing.

On the downside, I have not been able to fully test it. I think GitHub is having some problems. When I try to enable Unbound testing on my GitHub fork, I get an error *"An error happened when we tried to alter settings on GitHub. It may be caused by API restrictions, please review and add your authorized Orgs."*

Travis is generous with opens source projects. They provide containers with two cores, and ask we keep jobs below about 80 or 100 or so. Unbound will be fine with a dozen jobs.