### PR TITLE
Add IBM s390x arch for testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -70,10 +70,20 @@ jobs:
       compiler: clang
       arch: ppc64le
       dist: bionic
+    - os: linux
+      name: GCC on Linux, s390x
+      compiler: gcc
+      arch: s390x
+      dist: bionic
+    - os: linux
+      name: Clang on Linux, s390x
+      compiler: clang
+      arch: s390x
+      dist: bionic
 
 script:
   - |
-    if [ "$TEST_UBSAN" = "yes"  ]; then
+    if [ "$TEST_UBSAN" = "yes" ]; then
       export CFLAGS="-DNDEBUG -g2 -O3 -fsanitize=undefined -fno-sanitize-recover"
       ./configure
     elif [ "$TEST_ASAN" = "yes" ]; then


### PR DESCRIPTION
This is a big-endian platform, so it is nice to have for insurance. The change [tested OK on my fork](https://github.com/noloader/unbound/runs/472974384).

This was not included in the original PR because I wanted to ensure the big-endian tests did not become a deal breaker.

This should be the last of my meddling with Unbound (for now :).