### PR TITLE
Add Android to Travis testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -80,6 +80,58 @@ jobs:
       compiler: clang
       arch: s390x
       dist: bionic
+    - os: linux
+      name: Android armv7a, Linux, Amd64
+      compiler: clang
+      arch: amd64
+      dist: bionic
+      env:
+        - TEST_ANDROID=yes
+        - AUTOTOOLS_HOST=armv7a-linux-androideabi
+        - OPENSSL_HOST=android-arm
+        - ANDROID_CPU=armv7a
+        - ANDROID_API=23
+        - ANDROID_SDK_ROOT="$HOME/android-sdk"
+        - ANDROID_NDK_ROOT="$HOME/android-ndk"
+    - os: linux
+      name: Android aarch64, Linux, Amd64
+      compiler: clang
+      arch: amd64
+      dist: bionic
+      env:
+        - TEST_ANDROID=yes
+        - AUTOTOOLS_HOST=aarch64-linux-android
+        - OPENSSL_HOST=android-arm64
+        - ANDROID_CPU=aarch64
+        - ANDROID_API=23
+        - ANDROID_SDK_ROOT="$HOME/android-sdk"
+        - ANDROID_NDK_ROOT="$HOME/android-ndk"
+    - os: linux
+      name: Android x86, Linux, Amd64
+      compiler: clang
+      arch: amd64
+      dist: bionic
+      env:
+        - TEST_ANDROID=yes
+        - AUTOTOOLS_HOST=i686-linux-android
+        - OPENSSL_HOST=android-x86
+        - ANDROID_CPU=x86
+        - ANDROID_API=23
+        - ANDROID_SDK_ROOT="$HOME/android-sdk"
+        - ANDROID_NDK_ROOT="$HOME/android-ndk"
+    - os: linux
+      name: Android x86_64, Linux, Amd64
+      compiler: clang
+      arch: amd64
+      dist: bionic
+      env:
+        - TEST_ANDROID=yes
+        - AUTOTOOLS_HOST=x86_64-linux-android
+        - OPENSSL_HOST=android-x86_64
+        - ANDROID_CPU=x86_64
+        - ANDROID_API=23
+        - ANDROID_SDK_ROOT="$HOME/android-sdk"
+        - ANDROID_NDK_ROOT="$HOME/android-ndk"
 
 script:
   - |
@@ -89,11 +141,43 @@ script:
     elif [ "$TEST_ASAN" = "yes" ]; then
       export CFLAGS="-DNDEBUG -g2 -O3 -fsanitize=address"
       ./configure
+    elif [ "$TEST_ANDROID" = "yes" ]; then
+      export AUTOTOOLS_BUILD="$(./config.guess)"
+      if ! ./android/install_ndk.sh ; then
+        echo "Failed to install Android SDK and NDK"
+        exit 1
+      fi
+      if ! source ./android/setenv_android.sh "$ANDROID_CPU"; then
+        echo "Failed to set Android environment"
+        exit 1
+      fi
+      if ! ./android/install_openssl.sh; then
+        echo "Failed to build and install OpenSSL"
+        exit 1
+      fi
+      if ! ./android/install_expat.sh; then
+        echo "Failed to build and install Expat"
+        exit 1
+      fi
+      if ! ./configure \
+        --build="$AUTOTOOLS_BUILD" --host="$AUTOTOOLS_HOST" \
+        --prefix="$ANDROID_SYSROOT" \
+        --with-ssl="$ANDROID_SYSROOT" --disable-gost \
+        --with-libexpat="$ANDROID_SYSROOT";
+      then
+        echo "Failed to configure Unbound"
+        exit 1
+      fi
+      if ! make -j 2; then
+        echo "Failed to build Unbound"
+        exit 1
+      fi
+      exit 0
     elif [ "$TRAVIS_OS_NAME" = "osx" ]; then
       ./configure --enable-debug --disable-flto --with-ssl=/usr/local/opt/openssl/
     else
       ./configure --enable-debug --disable-flto
     fi
-  - make -j 2
-  - make test
-  - (cd testdata/clang-analysis.tdir; bash clang-analysis.test)
+    if ! make -j 2; then exit 1; fi
+    if ! make test; then exit 1; fi
+    (cd testdata/clang-analysis.tdir; bash clang-analysis.test)

--- a/README-Travis.md
+++ b/README-Travis.md
@@ -1,0 +1,157 @@
+# Travis Testing
+
+Unbound 1.11 and above leverage Travis CI to increase coverage of compilers and platforms. Compilers include Clang and GCC; while platforms include Android, Linux, and OS X on AMD64, Aarch64, PowerPC and s390x hardware.
+
+Android is tested on armv7a, aarch64, x86 and x86_64. Mips and Mips64 is no longer supported under current NDKs. The Android recipes build and install OpenSSL and Expat, and then builds Unbound. The testing is tailored for Android NDK-r19 and above, and includes NDK-r20 and NDK-r21. Due to Android NDK directory structure, the switch from GCC to Clang, and the tool names, the script will only work with NDK-r19 and above. And in the future it will likely break when the Android NDK team changes the directory structure and tools again (it happens every 2 or 3 years).
+
+The Unbound Travis configuration file `.travis.yml` does not use top-level keys like `os:` and `compiler:` so there is no matrix expansion. Instead Unbound specifies the exact job to run under the `jobs:` and `include:` keys.
+
+## Typical recipe
+
+A typical recipe tests Clang and GCC on various hardware. The hardware includes AMD64, Aarch64, PowerPC and s390x. PowerPC is a little-endian platform, and s390x is a big-endian platform. There are pairs of recipes that are similar to the following.
+
+```
+- os: linux
+  name: GCC on Linux, Aarch64
+  compiler: gcc
+  arch: arm64
+  dist: bionic
+- os: linux
+  name: Clang on Linux, Aarch64
+  compiler: clang
+  arch: arm64
+  dist: bionic
+```
+
+OS X provides a single recipe to test Clang. GCC is not tested because GCC is an alias for Clang.
+
+## Sanitizer builds
+
+Two sanitizer builds are tested using Clang and GCC, for a total of four builds. The first sanitizer is Undefined Behavior sanitizer (UBsan), and the second is Address sanitizer (Asan). The sanitizers are only run on AMD64 hardware. Note the environment includes `TEST_UBSAN=yes` or `TEST_ASAN=yes` for the sanitizer builds.
+
+The recipes are similar to the following.
+
+```
+- os: linux
+  name: UBsan, GCC on Linux, Amd64
+  compiler: gcc
+  arch: amd64
+  dist: bionic
+  env: TEST_UBSAN=yes
+- os: linux
+  name: UBsan, Clang on Linux, Amd64
+  compiler: clang
+  arch: amd64
+  dist: bionic
+  env: TEST_UBSAN=yes
+```
+
+When the Travis script encounters a sanitizer it uses different `CFLAGS` and configuration string.
+
+```
+if [ "$TEST_UBSAN" = "yes" ]; then
+  export CFLAGS="-DNDEBUG -g2 -O3 -fsanitize=undefined -fno-sanitize-recover"
+  ./configure
+elif [ "$TEST_ASAN" = "yes" ]; then
+  export CFLAGS="-DNDEBUG -g2 -O3 -fsanitize=address"
+  ./configure
+...
+```
+
+## Android builds
+
+Android builds test compiles under armv7a, aarch64, x86 and x86_64. The builds are trickier than other builds for several reasons. The testing requires installation of the Android NDK and SDK, it requires a cross-compile, and requires OpenSSL and Expat prerequisites. The Android cross-compiles also require care to set the Autotools triplet, the OpenSSL triplet, the toolchain path, the tool variables, and the sysroot. The steps below detail the pieces of the Android recipes.
+
+The first step for Android is to set the environmental variables `ANDROID_NDK_ROOT` and `ANDROID_SDK_ROOT`. This is an important step because the NDK and SDK use the variables internally to locate their own tools. Also see [Recommended NDK Directory?](https://groups.google.com/forum/#!topic/android-ndk/qZjhOaynHXc) on the android-ndk mailing list. (Many folks botch this step, and use incorrect variables like `ANDROID_NDK_HOME` or `ANDROID_SDK_HOME`).
+
+Unbound exports the variables in the Travis configuration script for the Android recipe:
+
+```
+export ANDROID_SDK_ROOT="$HOME/android-sdk"
+export ANDROID_NDK_ROOT="$HOME/android-ndk"
+```
+
+The second step installs the NDK and SDK. This step is handled in by the script `android/install_ndk.sh`. The script uses `ANDROID_NDK_ROOT` and `ANDROID_SDK_ROOT` to place the NDK and SDK in the `$HOME` directory.
+
+The third step sets the cross-compile environment using the script `android/setenv_android.sh`. The script is `sourced` so the variables set in the script are available to the calling shell. The script sets variables like `CC`, `CXX`, `AS` and `AR`; sets `CFLAGS` and `CXXFLAGS`; sets a `sysroot` so Android headers and libraries are found; and adds the path to the toolchain to `PATH`.
+
+`setenv_android.sh` knows which toolchain and architecture to select by inspecting environmental variables set by Travis for the job. In particular, the variables `ANDROID_CPU` and `ANDROID_API` tell `setenv_android.sh` what tools and libraries to select. For example, below is part of the Aarch64 recipe.
+
+```
+- os: linux
+  name: Android aarch64, Linux, Amd64
+  compiler: clang
+  arch: amd64
+  dist: bionic
+  env:
+    - TEST_ANDROID=yes
+    - AUTOTOOLS_HOST=aarch64-linux-android
+    - OPENSSL_CPU=arm64
+    - ANDROID_CPU=arm64-v8a
+    - ANDROID_API=23
+```
+
+The `setenv_android.sh` script specifies the tools in a `case` statement like the following. There is a case for each of the architectures armv7a, aarch64, x86 and x86_64.
+
+```
+armv8a|aarch64|arm64|arm64-v8a)
+  CC="aarch64-linux-android$ANDROID_API-clang"
+  CXX="aarch64-linux-android$ANDROID_API-clang++"
+  LD="aarch64-linux-android-ld"
+  AS="aarch64-linux-android-as"
+  AR="aarch64-linux-android-ar"
+  RANLIB="aarch64-linux-android-ranlib"
+  STRIP="aarch64-linux-android-strip"
+
+  CFLAGS="-funwind-tables -fexceptions"
+  CXXFLAGS="-funwind-tables -fexceptions -frtti"
+```
+
+Finally, once all the variables are set the Travis script cross-compiles OpenSSL and Expat, and then configures and builds Unbound. The recipe looks as follows.
+
+```
+elif [ "$TEST_ANDROID" = "yes" ]; then
+  # AUTOTOOLS_HOST is set in the job
+  export AUTOTOOLS_BUILD="$(./config.guess)"
+  if ! ./android/install_ndk.sh ; then
+      echo "Failed to install Android SDK and NDK"
+      exit 1
+  fi
+  if ! source ./android/setenv_android.sh "$ANDROID_CPU"; then
+      echo "Failed to set Android environment"
+      exit 1
+  fi
+  if ! ./android/install_openssl.sh; then
+      echo "Failed to build and install OpenSSL"
+      exit 1
+  fi
+  if ! ./android/install_expat.sh; then
+      echo "Failed to build and install Expat"
+      exit 1
+  fi
+  if ! ./configure \
+      --build="$AUTOTOOLS_BUILD" --host="$AUTOTOOLS_HOST" \
+      --prefix="$ANDROID_SYSROOT" \
+      --with-ssl="$ANDROID_SYSROOT" --disable-gost \
+      --with-libexpat="$ANDROID_SYSROOT";
+  then
+      echo "Failed to configure Unbound"
+      exit 1
+  fi
+  if ! make -j 2; then
+      echo "Failed to build Unbound"
+      exit 1
+  fi
+```
+
+Unbound only smoke tests a build using a compile and link. The self tests are not run. TODO: figure out how to fire up an emulator, push the tests to the device and run them.
+
+Note the `--prefix="$ANDROID_SYSROOT"` used by OpenSSL, Expat and Unbound. This makes it easy to find libraries and headers because `CFLAGS` and `CXXFLAGS` already use `--sysroot="$ANDROID_SYSROOT"`. By performing a `make install` and installing into `$ANDROID_SYSROOT`, all the libraries needed by Unbound are present without extra flags or searching.
+
+## Android flags
+
+`android/setenv_android.sh` uses specific flags for `CFLAGS` and `CXXFLAGS`. The flags are not arbitrary; they are taken from the `ndk-build` tool. It is important to use the same flags across projects to avoid subtle problems due to mixing and matching different flags.
+
+`CXXFLAGS` includes `-fexceptions` because exceptions are disabled by default. `CFLAGS` include `-funwind-tables` and `-fexceptions` to ensure C++ exceptions pass through C code, if needed. Also see `docs/CPLUSPLUS—SUPPORT.html` in the NDK docs.
+
+To inspect the flags used by `ndk-build` for a platform clone ASOP's [ndk-samples](https://github.com/android/ndk-samples/tree/master/hello-jni) and build the `hello-jni` project. Use the `V=1` flag to see the full compiler output.

--- a/android/15-android.conf
+++ b/android/15-android.conf
@@ -1,0 +1,185 @@
+#### Android...
+#
+# See NOTES.ANDROID for details, and don't miss platform-specific
+# comments below...
+
+{
+    use File::Spec::Functions;
+
+    my $android_ndk = {};
+    my %triplet = (
+        arm     => "arm-linux-androideabi",
+        armeabi => "arm-linux-androideabi",
+        armv7a  => "arm-linux-androideabi",
+        arm64   => "aarch64-linux-android",
+        x86     => "i686-linux-android",
+        x86_64  => "x86_64-linux-android"
+    );
+
+    sub android_ndk {
+        unless (%$android_ndk) {
+            if ($now_printing =~ m|^android|) {
+                return $android_ndk = { bn_ops => "BN_AUTO" };
+            }
+
+            my $ndk_var;
+            my $ndk;
+            foreach (qw(ANDROID_NDK_ROOT)) {
+                $ndk_var = $_;
+                $ndk = $ENV{$ndk_var};
+                last if defined $ndk;
+            }
+            die "\$ANDROID_NDK_ROOT is not defined"  if (!$ndk);
+            if (!-d "$ndk/platforms" && !-f "$ndk/AndroidVersion.txt") {
+                # $ndk/platforms is traditional "all-inclusive" NDK, while
+                # $ndk/AndroidVersion.txt is so-called standalone toolchain
+                # tailored for specific target down to API level.
+                die "\$ANDROID_NDK_ROOT=$ndk is invalid";
+            }
+            $ndk = canonpath($ndk);
+
+            my $ndkver = undef;
+
+            if (open my $fh, "<$ndk/source.properties") {
+                local $_;
+                while(<$fh>) {
+                    if (m|Pkg\.Revision\s*=\s*([0-9]+)|) {
+                        $ndkver = $1;
+                        last;
+                    }
+                }
+                close $fh;
+            }
+
+            my ($sysroot, $api, $arch);
+
+            $config{target} =~ m|[^-]+-([^-]+)$|;	# split on dash
+            $arch = $1;
+
+            if ($arch = "armeabi") {
+                $arch = "arm";
+            }
+
+            if (-f "$ndk/AndroidVersion.txt") {
+                $sysroot = "$ndk/sysroot";
+            } else {
+                $api = "*";
+
+                # see if user passed -D__ANDROID_API__=N
+                foreach (@{$useradd{CPPDEFINES}}, @{$user{CPPFLAGS}}) {
+                    if (m|__ANDROID_API__=([0-9]+)|) {
+                        $api = $1;
+                        last;
+                    }
+                }
+
+                # list available platforms (numerically)
+                my @platforms = sort { $a =~ m/-([0-9]+)$/; my $aa = $1;
+                                       $b =~ m/-([0-9]+)$/; $aa <=> $1;
+                                     } glob("$ndk/platforms/android-$api");
+                die "no $ndk/platforms/android-$api" if ($#platforms < 0);
+
+                $sysroot = "@platforms[$#platforms]/arch-$arch";
+                $sysroot =~ m|/android-([0-9]+)/arch-$arch|;
+                $api = $1;
+            }
+            die "no sysroot=$sysroot"   if (!-d $sysroot);
+
+            my $triarch = $triplet{$arch};
+            my $cflags;
+            my $cppflags;
+
+            # see if there is NDK clang on $PATH, "universal" or "standalone"
+            if (which("clang") =~ m|^$ndk/.*/prebuilt/([^/]+)/|) {
+                my $host=$1;
+                # harmonize with gcc default
+                my $arm = $ndkver > 16 ? "armv7a" : "armv5te";
+                (my $tridefault = $triarch) =~ s/^arm-/$arm-/;
+                (my $tritools   = $triarch) =~ s/(?:x|i6)86(_64)?-.*/x86$1/;
+                $cflags .= " -target $tridefault ";
+                $user{CC} = "clang" if ($user{CC} !~ m|clang|);
+                $user{CROSS_COMPILE} = undef;
+                if (which("llvm-ar") =~ m|^$ndk/.*/prebuilt/([^/]+)/|) {
+                    $user{AR} = "llvm-ar";
+                    $user{ARFLAGS} = [ "rs" ];
+                    $user{RANLIB} = ":";
+                }
+            } elsif (-f "$ndk/AndroidVersion.txt") {    #"standalone toolchain"
+                my $cc = $user{CC} // "clang";
+                # One can probably argue that both clang and gcc should be
+                # probed, but support for "standalone toolchain" was added
+                # *after* announcement that gcc is being phased out, so
+                # favouring clang is considered adequate. Those who insist
+                # have option to enforce test for gcc with CC=gcc.
+                if (which("$triarch-$cc") !~ m|^$ndk|) {
+                    die "no NDK $triarch-$cc on \$PATH";
+                }
+                $user{CC} = $cc;
+                $user{CROSS_COMPILE} = "$triarch-";
+            } elsif ($user{CC} eq "clang") {
+                die "no NDK clang on \$PATH";
+            } else {
+                if (which("$triarch-gcc") !~ m|^$ndk/.*/prebuilt/([^/]+)/|) {
+                    die "no NDK $triarch-gcc on \$PATH";
+                }
+                $cflags .= " -mandroid";
+                $user{CROSS_COMPILE} = "$triarch-";
+            }
+
+            if (!-d "$sysroot/usr/include") {
+                my $incroot = "$ndk/sysroot/usr/include";
+                die "no $incroot"          if (!-d $incroot);
+                die "no $incroot/$triarch" if (!-d "$incroot/$triarch");
+                $incroot =~ s|^$ndk/||;
+                $cppflags  = "-D__ANDROID_API__=$api";
+            }
+
+            $sysroot =~ s|^$ndk/||;
+            $android_ndk = {
+                cppflags => $cppflags,
+                bn_ops   => $arch =~ m/64$/ ? "SIXTY_FOUR_BIT_LONG"
+                                            : "BN_LLONG",
+            };
+        }
+
+        return $android_ndk;
+    }
+}
+
+my %targets = (
+    "android" => {
+        inherit_from     => [ "linux-generic32" ],
+        template         => 1,
+        ################################################################
+        # Special note about -pie. The underlying reason is that
+        # Lollipop refuses to run non-PIE. But what about older systems
+        # and NDKs? -fPIC was never problem, so the only concern is -pie.
+        cflags           => add(sub { android_ndk()->{cflags} }),
+        cppflags         => add(sub { android_ndk()->{cppflags} }),
+        cxxflags         => add(sub { android_ndk()->{cflags} }),
+        bn_ops           => sub { android_ndk()->{bn_ops} },
+        bin_cflags       => "-pie",
+        enable           => [ ],
+    },
+    "android-arm" => {
+        inherit_from     => [ "android", asm("armv4_asm") ],
+        bn_ops           => add("RC4_CHAR"),
+    },
+    "android-arm64" => {
+        inherit_from     => [ "android", asm("aarch64_asm") ],
+        bn_ops           => add("RC4_CHAR"),
+        perlasm_scheme   => "linux64",
+    },
+
+    "android-x86" => {
+        inherit_from     => [ "android", asm("x86_asm") ],
+        CFLAGS           => add(picker(release => "-fomit-frame-pointer")),
+        bn_ops           => add("RC4_INT"),
+        perlasm_scheme   => "android",
+    },
+    "android-x86_64" => {
+        inherit_from     => [ "android", asm("x86_64_asm") ],
+        bn_ops           => add("RC4_INT"),
+        perlasm_scheme   => "elf",
+    },
+);

--- a/android/install_expat.sh
+++ b/android/install_expat.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+
+# install android deps
+sudo apt-get -qq update
+sudo apt-get -qq install --no-install-recommends curl tar
+
+echo "Downloading Expat"
+if ! curl -L -k -s -o expat-2.2.9.tar.gz https://github.com/libexpat/libexpat/releases/download/R_2_2_9/expat-2.2.9.tar.gz;
+then
+    echo "Failed to download Expat"
+    exit 1
+fi
+
+echo "Unpacking Expat"
+rm -rf ./expat-2.2.9
+if ! tar -xf expat-2.2.9.tar.gz;
+then
+    echo "Failed to unpack Expat"
+    exit 1
+fi
+
+cd expat-2.2.9 || exit 1
+
+echo "Configuring Expat"
+if ! ./configure --build="$AUTOTOOLS_BUILD" --host="$AUTOTOOLS_HOST" --prefix="$ANDROID_SYSROOT"; then
+    echo "Error: Failed to configure Expat"
+    exit 1
+fi
+
+# Cleanup warnings, https://github.com/libexpat/libexpat/issues/383
+echo "Fixing Makefiles..."
+(IFS="" find "$PWD" -name 'Makefile' -print | while read -r file
+do
+    cp -p "$file" "$file.fixed"
+    sed 's|-Wduplicated-cond ||g; s|-Wduplicated-branches ||g; s|-Wlogical-op ||g' "$file" > "$file.fixed"
+    mv "$file.fixed" "$file"
+
+    cp -p "$file" "$file.fixed"
+    sed 's|-Wrestrict ||g; s|-Wjump-misses-init ||g; s|-Wmisleading-indentation ||g' "$file" > "$file.fixed"
+    mv "$file.fixed" "$file"
+done)
+
+echo "Building Expat"
+if ! make; then
+    echo "Failed to build Expat"
+    exit 1
+fi
+
+echo "Installing Expat"
+if ! make install; then
+    echo "Failed to install Expat"
+    exit 1
+fi
+
+exit 0

--- a/android/install_ndk.sh
+++ b/android/install_ndk.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+
+# install android deps
+sudo apt-get -qq update
+sudo apt-get -qq install --no-install-recommends curl openjdk-8-jdk zip unzip
+
+if [ -z "$ANDROID_SDK_ROOT" ]; then
+    echo "ERROR: ANDROID_SDK_ROOT is not a valid path. Please set it."
+    echo "SDK root is $ANDROID_SDK_ROOT"
+    exit 1
+fi
+
+if [ -z "$ANDROID_NDK_ROOT" ]; then
+    echo "ERROR: ANDROID_NDK_ROOT is not a valid path. Please set it."
+    echo "NDK root is $ANDROID_NDK_ROOT"
+    exit 1
+fi
+
+echo "Using ANDROID_SDK_ROOT: $ANDROID_SDK_ROOT"
+echo "Using ANDROID_NDK_ROOT: $ANDROID_NDK_ROOT"
+
+echo "Downloading SDK"
+if ! curl -L -k -s -o "$HOME/android-sdk.zip" https://dl.google.com/android/repository/commandlinetools-linux-6200805_latest.zip;
+then
+    echo "Failed to download SDK"
+    exit 1
+fi
+
+echo "Downloading NDK"
+if ! curl -L -k -s -o "$HOME/android-ndk.zip" https://dl.google.com/android/repository/android-ndk-r20b-linux-x86_64.zip;
+then
+    echo "Failed to download NDK"
+    exit 1
+fi
+
+echo "Unpacking SDK to $ANDROID_SDK_ROOT"
+if ! unzip -qq "$HOME/android-sdk.zip" -d "$ANDROID_SDK_ROOT";
+then
+    echo "Failed to unpack SDK"
+    exit 1
+fi
+
+echo "Unpacking NDK to $ANDROID_NDK_ROOT"
+if ! unzip -qq "$HOME/android-ndk.zip" -d "$HOME";
+then
+    echo "Failed to unpack NDK"
+    exit 1
+fi
+
+if ! mv "$HOME/android-ndk-r20b" "$ANDROID_NDK_ROOT";
+then
+    echo "Failed to move $HOME/android-ndk-r20b to $ANDROID_NDK_ROOT"
+    exit 1
+fi
+
+rm -f "$HOME/android-sdk.zip"
+rm -f "$HOME/android-ndk.zip"
+
+# https://stackoverflow.com/a/47028911/608639
+touch "$ANDROID_SDK_ROOT/repositories.cfg"
+
+echo "Finished installing SDK and NDK"
+
+exit 0

--- a/android/install_openssl.sh
+++ b/android/install_openssl.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+
+# install android deps
+sudo apt-get -qq update
+sudo apt-get -qq install --no-install-recommends curl tar perl
+
+echo "Downloading OpenSSL"
+if ! curl -L -k -s -o openssl-1.1.1d.tar.gz https://www.openssl.org/source/openssl-1.1.1d.tar.gz;
+then
+    echo "Failed to download OpenSSL"
+    exit 1
+fi
+
+echo "Unpacking OpenSSL"
+rm -rf ./openssl-1.1.1d
+if ! tar -xf openssl-1.1.1d.tar.gz;
+then
+    echo "Failed to unpack OpenSSL"
+    exit 1
+fi
+
+cd openssl-1.1.1d || exit 1
+
+# Damn OpenSSL devs... They just make the shit up as they go...
+if ! cp ../android/15-android.conf Configurations/; then
+    echo "Failed to copy OpenSSL Android config"
+    exit 1
+fi
+
+echo "Configuring OpenSSL"
+if ! ./Configure "$OPENSSL_HOST" no-comp no-asm no-hw no-engine shared \
+     "$CFLAGS" --prefix="$ANDROID_SYSROOT" --openssldir="$ANDROID_SYSROOT"; then
+    echo "Failed to configure OpenSSL"
+    exit 1
+fi
+
+echo "Building OpenSSL"
+if ! make; then
+    echo "Failed to build OpenSSL"
+    exit 1
+fi
+
+echo "Installing OpenSSL"
+if ! make install_sw; then
+    echo "Failed to install OpenSSL"
+    exit 1
+fi
+
+exit 0

--- a/android/setenv_android.sh
+++ b/android/setenv_android.sh
@@ -1,0 +1,190 @@
+#!/usr/bin/env bash
+
+# Error checking
+if [ ! -d "$ANDROID_NDK_ROOT" ]; then
+    echo "ERROR: ANDROID_NDK_ROOT is not a valid path. Please set it."
+    echo "NDK root is $ANDROID_NDK_ROOT"
+    [ "$0" = "${BASH_SOURCE[0]}" ] && exit 1 || return 1
+fi
+
+#####################################################################
+
+# Need to set THIS_HOST to darwin-x86_64, linux-x86_64,
+# windows-x86_64 or windows.
+
+if [[ "$(uname -s | grep -i -c darwin)" -ne 0 ]]; then
+    THIS_HOST=darwin-x86_64
+elif [[ "$(uname -s | grep -i -c linux)" -ne 0 ]]; then
+    THIS_HOST=linux-x86_64
+else
+    echo "ERROR: Unknown host"
+    [ "$0" = "${BASH_SOURCE[0]}" ] && exit 1 || return 1
+fi
+
+AOSP_TOOLCHAIN_ROOT="$ANDROID_NDK_ROOT/toolchains/llvm/prebuilt/$THIS_HOST"
+AOSP_TOOLCHAIN_PATH="$AOSP_TOOLCHAIN_ROOT/bin"
+AOSP_SYSROOT="$AOSP_TOOLCHAIN_ROOT/sysroot"
+
+# Error checking
+if [ ! -d "$AOSP_TOOLCHAIN_ROOT" ]; then
+    echo "ERROR: AOSP_TOOLCHAIN_ROOT is not a valid path. Please set it."
+    echo "Root is $AOSP_TOOLCHAIN_ROOT"
+    [ "$0" = "${BASH_SOURCE[0]}" ] && exit 1 || return 1
+fi
+
+# Error checking
+if [ ! -d "$AOSP_TOOLCHAIN_PATH" ]; then
+    echo "ERROR: AOSP_TOOLCHAIN_PATH is not a valid path. Please set it."
+    echo "Path is $AOSP_TOOLCHAIN_PATH"
+    [ "$0" = "${BASH_SOURCE[0]}" ] && exit 1 || return 1
+fi
+
+# Error checking
+if [ ! -d "$AOSP_SYSROOT" ]; then
+    echo "ERROR: AOSP_SYSROOT is not a valid path. Please set it."
+    echo "Path is $AOSP_SYSROOT"
+    [ "$0" = "${BASH_SOURCE[0]}" ] && exit 1 || return 1
+fi
+
+#####################################################################
+
+if [ "$#" -lt 1 ]; then
+    AOSP_ARCH=armeabi-v7a
+else
+    AOSP_ARCH=$(tr '[:upper:]' '[:upper:]' <<< "$1")
+fi
+
+# https://developer.android.com/ndk/guides/abis.html
+case "$AOSP_ARCH" in
+  armeabi|armv7a|armv7-a|armeabi-v7a)
+    CC="armv7a-linux-androideabi$ANDROID_API-clang"
+    CXX="armv7a-linux-androideabi$ANDROID_API-clang++"
+    LD="arm-linux-androideabi-ld"
+    AS="arm-linux-androideabi-as"
+    AR="arm-linux-androideabi-ar"
+    RANLIB="arm-linux-androideabi-ranlib"
+    STRIP="arm-linux-androideabi-strip"
+
+    CFLAGS="-march=armv7-a -mthumb -mfloat-abi=softfp -funwind-tables -fexceptions"
+    CXXFLAGS="-march=armv7-a -mthumb -mfloat-abi=softfp -funwind-tables -fexceptions -frtti"
+    ;;
+
+  armv8|armv8a|aarch64|arm64|arm64-v8a)
+    CC="aarch64-linux-android$ANDROID_API-clang"
+    CXX="aarch64-linux-android$ANDROID_API-clang++"
+    LD="aarch64-linux-android-ld"
+    AS="aarch64-linux-android-as"
+    AR="aarch64-linux-android-ar"
+    RANLIB="aarch64-linux-android-ranlib"
+    STRIP="aarch64-linux-android-strip"
+
+    CFLAGS="-funwind-tables -fexceptions"
+    CXXFLAGS="-funwind-tables -fexceptions -frtti"
+    ;;
+
+  x86)
+    CC="i686-linux-android$ANDROID_API-clang"
+    CXX="i686-linux-android$ANDROID_API-clang++"
+    LD="i686-linux-android-ld"
+    AS="i686-linux-android-as"
+    AR="i686-linux-android-ar"
+    RANLIB="i686-linux-android-ranlib"
+    STRIP="i686-linux-android-strip"
+
+    CFLAGS="-mtune=intel -mssse3 -mfpmath=sse -funwind-tables -fexceptions"
+    CXXFLAGS="-mtune=intel -mssse3 -mfpmath=sse -funwind-tables -fexceptions -frtti"
+    ;;
+
+  x86_64|x64)
+    CC="x86_64-linux-android$ANDROID_API-clang"
+    CXX="x86_64-linux-android$ANDROID_API-clang++"
+    LD="x86_64-linux-android-ld"
+    AS="x86_64-linux-android-as"
+    AR="x86_64-linux-android-ar"
+    RANLIB="x86_64-linux-android-ranlib"
+    STRIP="x86_64-linux-android-strip"
+
+    CFLAGS="-march=x86-64 -msse4.2 -mpopcnt -mtune=intel -funwind-tables -fexceptions"
+    CXXFLAGS="-march=x86-64 -msse4.2 -mpopcnt -mtune=intel -funwind-tables -fexceptions -frtti"
+    ;;
+
+  *)
+    echo "ERROR: Unknown architecture $1"
+    [ "$0" = "${BASH_SOURCE[0]}" ] && exit 1 || return 1
+    ;;
+
+esac
+
+#####################################################################
+
+# Error checking
+if [ ! -e "$AOSP_TOOLCHAIN_PATH/$CC" ]; then
+    echo "ERROR: Failed to find Android clang. Please edit this script."
+    [ "$0" = "${BASH_SOURCE[0]}" ] && exit 1 || return 1
+fi
+
+# Error checking
+if [ ! -e "$AOSP_TOOLCHAIN_PATH/$CXX" ]; then
+    echo "ERROR: Failed to find Android clang++. Please edit this script."
+    [ "$0" = "${BASH_SOURCE[0]}" ] && exit 1 || return 1
+fi
+
+# Error checking
+if [ ! -e "$AOSP_TOOLCHAIN_PATH/$RANLIB" ]; then
+    echo "ERROR: Failed to find Android ranlib. Please edit this script."
+    [ "$0" = "${BASH_SOURCE[0]}" ] && exit 1 || return 1
+fi
+
+# Error checking
+if [ ! -e "$AOSP_TOOLCHAIN_PATH/$AR" ]; then
+    echo "ERROR: Failed to find Android ar. Please edit this script."
+    [ "$0" = "${BASH_SOURCE[0]}" ] && exit 1 || return 1
+fi
+
+# Error checking
+if [ ! -e "$AOSP_TOOLCHAIN_PATH/$AS" ]; then
+    echo "ERROR: Failed to find Android as. Please edit this script."
+    [ "$0" = "${BASH_SOURCE[0]}" ] && exit 1 || return 1
+fi
+
+# Error checking
+if [ ! -e "$AOSP_TOOLCHAIN_PATH/$LD" ]; then
+    echo "ERROR: Failed to find Android ld. Please edit this script."
+    [ "$0" = "${BASH_SOURCE[0]}" ] && exit 1 || return 1
+fi
+
+#####################################################################
+
+# Only modify/export PATH if AOSP_TOOLCHAIN_PATH good
+if [ -d "$AOSP_TOOLCHAIN_PATH" ]; then
+    # And only modify PATH if AOSP_TOOLCHAIN_PATH is not present
+    LEN=${#AOSP_TOOLCHAIN_PATH}
+    SUBSTR=${PATH:0:$LEN}
+    if [ "$SUBSTR" != "$AOSP_TOOLCHAIN_PATH" ]; then
+        export PATH="$AOSP_TOOLCHAIN_PATH:$PATH"
+    fi
+fi
+
+#####################################################################
+
+export CPP CC CXX LD AS AR RANLIB STRIP
+export ANDROID_SYSROOT="$AOSP_SYSROOT"
+export CFLAGS="-D__ANDROID_API__=$ANDROID_API $CFLAGS --sysroot=$AOSP_SYSROOT"
+export CXXFLAGS="-D__ANDROID_API__=$ANDROID_API $CXXFLAGS --sysroot=$AOSP_SYSROOT"
+
+#####################################################################
+
+echo "AOSP_TOOLCHAIN_PATH: $AOSP_TOOLCHAIN_PATH"
+
+echo "CC: $CC"
+echo "CXX: $CXX"
+echo "LD: $LD"
+echo "AS: $AS"
+echo "AR: $AR"
+
+echo "ANDROID_SYSROOT: $ANDROID_SYSROOT"
+
+echo "CFLAGS: $CFLAGS"
+echo "CXXFLAGS: $CXXFLAGS"
+
+[ "$0" = "${BASH_SOURCE[0]}" ] && exit 0 || return 0


### PR DESCRIPTION
Add Android armv7a, aarch64, x86 and x86_64 to Travis testing.

This rig will work for Android NDK-r19c, NDK-r20b and NDK-r21. The Android folks will probably break it some time in the future. The Android folks change tools and directories so we have to fix our scripts. It happens every two or three years or so.

The Android tests are failing at the moment due to [GH #175](https://github.com/NLnetLabs/unbound/issues/175). In the 175 issue, OpenSSL was configured with `no-engine`. I believe [PR #176](https://github.com/NLnetLabs/unbound/pull/176) fixes it.

The Unbound folks will need to add the copyright and license information if the PR is accepted.