### PR TITLE
Fix link error when OpenSSL is configured with no-engine (GH #175)

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -822,7 +822,7 @@ else
 	AC_MSG_RESULT([no])
 fi
 AC_CHECK_HEADERS([openssl/conf.h openssl/engine.h openssl/bn.h openssl/dh.h openssl/dsa.h openssl/rsa.h],,, [AC_INCLUDES_DEFAULT])
-AC_CHECK_FUNCS([OPENSSL_config EVP_sha1 EVP_sha256 EVP_sha512 FIPS_mode EVP_MD_CTX_new OpenSSL_add_all_digests OPENSSL_init_crypto EVP_cleanup ERR_load_crypto_strings CRYPTO_cleanup_all_ex_data ERR_free_strings RAND_cleanup DSA_SIG_set0 EVP_dss1 EVP_DigestVerify SSL_CTX_set_tlsext_ticket_key_cb EVP_aes_256_cbc EVP_EncryptInit_ex HMAC_Init_ex CRYPTO_THREADID_set_callback])
+AC_CHECK_FUNCS([OPENSSL_config EVP_sha1 EVP_sha256 EVP_sha512 FIPS_mode EVP_MD_CTX_new OpenSSL_add_all_digests OPENSSL_init_crypto EVP_cleanup ENGINE_cleanup ERR_load_crypto_strings CRYPTO_cleanup_all_ex_data ERR_free_strings RAND_cleanup DSA_SIG_set0 EVP_dss1 EVP_DigestVerify SSL_CTX_set_tlsext_ticket_key_cb EVP_aes_256_cbc EVP_EncryptInit_ex HMAC_Init_ex CRYPTO_THREADID_set_callback])
 
 # these check_funcs need -lssl
 BAKLIBS="$LIBS"

--- a/testcode/unitmain.c
+++ b/testcode/unitmain.c
@@ -917,7 +917,9 @@ main(int argc, char* argv[])
 #  ifdef HAVE_EVP_CLEANUP
 	EVP_cleanup();
 #  endif
+#  ifdef HAVE_ENGINE_CLEANUP
 	ENGINE_cleanup();
+#  endif
 	CONF_modules_free();
 #  endif
 #  ifdef HAVE_CRYPTO_CLEANUP_ALL_EX_DATA


### PR DESCRIPTION
Also see Issue 175, [.libs/unitmain.o:unitmain.c:function main: error: undefined reference to 'ENGINE_cleanup'](https://github.com/NLnetLabs/unbound/issues/175).

I believe a new `configure` should be generated if this PR is accepted.