### PR TITLE
Avoid calling exit in Travis script

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -147,51 +147,41 @@ jobs:
       arch: amd64
       name: Android x86_64, Linux, Amd64
 
+# The Travis docs say to avoid calling exit in the script. It leads to
+# some code duplication to avoid failures in cross-compiles. Also see
+# https://docs.travis-ci.com/user/job-lifecycle/ in the Travis docs.
 script:
   - |
     if [ "$TEST_UBSAN" = "yes" ]; then
       export CFLAGS="-DNDEBUG -g2 -O3 -fsanitize=undefined -fno-sanitize-recover"
       ./configure
+      make -j 2
+      make test
     elif [ "$TEST_ASAN" = "yes" ]; then
       export CFLAGS="-DNDEBUG -g2 -O3 -fsanitize=address"
       ./configure
+      make -j 2
+      make test
     elif [ "$TEST_ANDROID" = "yes" ]; then
       export AUTOTOOLS_BUILD="$(./config.guess)"
-      if ! ./contrib/android/install_ndk.sh ; then
-        echo "Failed to install Android SDK and NDK"
-        exit 1
-      fi
-      if ! source ./contrib/android/setenv_android.sh "$ANDROID_CPU"; then
-        echo "Failed to set Android environment"
-        exit 1
-      fi
-      if ! ./contrib/android/install_openssl.sh; then
-        echo "Failed to build and install OpenSSL"
-        exit 1
-      fi
-      if ! ./contrib/android/install_expat.sh; then
-        echo "Failed to build and install Expat"
-        exit 1
-      fi
-      if ! ./configure \
+      ./contrib/android/install_ndk.sh
+      source ./contrib/android/setenv_android.sh "$ANDROID_CPU"
+      ./contrib/android/install_openssl.sh
+      ./contrib/android/install_expat.sh
+      ./configure \
         --build="$AUTOTOOLS_BUILD" --host="$AUTOTOOLS_HOST" \
         --prefix="$ANDROID_SYSROOT" \
         --with-ssl="$ANDROID_SYSROOT" --disable-gost \
         --with-libexpat="$ANDROID_SYSROOT";
-      then
-        echo "Failed to configure Unbound"
-        exit 1
-      fi
-      if ! make -j 2; then
-        echo "Failed to build Unbound"
-        exit 1
-      fi
-      exit 0
+      make -j 2
     elif [ "$TRAVIS_OS_NAME" = "osx" ]; then
       ./configure --enable-debug --disable-flto --with-ssl=/usr/local/opt/openssl/
+      make -j 2
+      make test
+      (cd testdata/clang-analysis.tdir; bash clang-analysis.test)
     else
       ./configure --enable-debug --disable-flto
+      make -j 2
+      make test
+      (cd testdata/clang-analysis.tdir; bash clang-analysis.test)
     fi
-    if ! make -j 2; then exit 1; fi
-    if ! make test; then exit 1; fi
-    (cd testdata/clang-analysis.tdir; bash clang-analysis.test)


### PR DESCRIPTION
The Travis docs state calling exit should not be done. Blame Jeffrey Walton. Sorry about that.

Also see https://docs.travis-ci.com/user/job-lifecycle/ in the Travis docs.