### PR TITLE
Fix OpenSSL -pie warning on Android

### DIFF
--- a/contrib/android/15-android.conf
+++ b/contrib/android/15-android.conf
@@ -9,8 +9,6 @@
     my $android_ndk = {};
     my %triplet = (
         arm     => "arm-linux-androideabi",
-        armeabi => "arm-linux-androideabi",
-        armv7a  => "arm-linux-androideabi",
         arm64   => "aarch64-linux-android",
         x86     => "i686-linux-android",
         x86_64  => "x86_64-linux-android"
@@ -150,15 +148,12 @@ my %targets = (
     "android" => {
         inherit_from     => [ "linux-generic32" ],
         template         => 1,
-        ################################################################
-        # Special note about -pie. The underlying reason is that
-        # Lollipop refuses to run non-PIE. But what about older systems
-        # and NDKs? -fPIC was never problem, so the only concern is -pie.
         cflags           => add(sub { android_ndk()->{cflags} }),
         cppflags         => add(sub { android_ndk()->{cppflags} }),
         cxxflags         => add(sub { android_ndk()->{cflags} }),
         bn_ops           => sub { android_ndk()->{bn_ops} },
-        bin_cflags       => "-pie",
+        bin_cflags       => "-fPIE",
+        bin_lflags       => "-pie",
         enable           => [ ],
     },
     "android-arm" => {


### PR DESCRIPTION
Also see https://github.com/openssl/openssl/issues/11237.