### PR TITLE
Update Travis build process

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -399,6 +399,9 @@ PKG_PROG_PKG_CONFIG
 # Checks for header files.
 AC_CHECK_HEADERS([stdarg.h stdbool.h netinet/in.h netinet/tcp.h sys/param.h sys/socket.h sys/un.h sys/uio.h sys/resource.h arpa/inet.h syslog.h netdb.h sys/wait.h pwd.h glob.h grp.h login_cap.h winsock2.h ws2tcpip.h endian.h sys/endian.h libkern/OSByteOrder.h sys/ipc.h sys/shm.h],,, [AC_INCLUDES_DEFAULT])
 
+# Check for Apple header. This uncovers TARGET_OS_IPHONE, TARGET_OS_TV or TARGET_OS_WATCH 
+AC_CHECK_HEADERS([TargetConditionals.h])
+
 # check for types.  
 # Using own tests for int64* because autoconf builtin only give 32bit.
 AC_CHECK_TYPE(int8_t, signed char)

--- a/smallapp/unbound-control.c
+++ b/smallapp/unbound-control.c
@@ -74,6 +74,10 @@
 #include <sys/un.h>
 #endif
 
+#ifdef HAVE_TARGETCONDITIONALS_H
+#include <TargetConditionals.h>
+#endif
+
 static void usage(void) ATTR_NORETURN;
 static void ssl_err(const char* s) ATTR_NORETURN;
 static void ssl_path_err(const char* s, const char *path) ATTR_NORETURN;
@@ -879,11 +883,16 @@ int main(int argc, char* argv[])
 	if(argc == 0)
 		usage();
 	if(argc >= 1 && strcmp(argv[0], "start")==0) {
+#if defined(TARGET_OS_TV) || defined(TARGET_OS_WATCH)
+			fatal_exit("could not exec unbound: %s",
+				strerror(ENOSYS));
+#else
 		if(execlp("unbound", "unbound", "-c", cfgfile, 
 			(char*)NULL) < 0) {
 			fatal_exit("could not exec unbound: %s",
 				strerror(errno));
 		}
+#endif
 	}
 	if(argc >= 1 && strcmp(argv[0], "stats_shm")==0) {
 		print_stats_shm(cfgfile);


### PR DESCRIPTION
This change came about due to LDNS. LDNS needs an Autotools bootstrap, so steps were re-arranged in LDNS. Then, for consistency, Unbound changed its process to match LDNS.

OpenSSL's `15-android.conf` was also cleaned up to remove the unneeded android_ndk perl function.

Travis added iOS simulator testing. iPhoneSimulator, AppleTVSimulator and WatchSimulator tests are now performed.

`setenv-ios.sh` and `15-ios.conf` were changed to cleanup the OpenSSL gear. Finally, iOS Aarch64 was fixed. We were missing `-mios-version-min=6` in `CFLAGS` and `CXXFLAGS`.