### PR TITLE
Update iOS testing on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,12 @@ addons:
     - libevent-dev
     - libexpat-dev
     - clang
+  homebrew:
+    packages:
+      - openssl
+      - libevent
+      - expat
+    update: true
 
 jobs:
   include:
@@ -25,6 +31,7 @@ jobs:
       name: Clang on OS X, Amd64
       compiler: clang
       arch: amd64
+      env: TEST_OSX=yes
     - os: linux
       name: UBsan, GCC on Linux, Amd64
       compiler: gcc
@@ -81,7 +88,7 @@ jobs:
       dist: bionic
     - os: osx
       osx_image: xcode10
-      name: Apple iPhone, OS X, Amd64
+      name: Apple iPhone on iOS, armv7
       compiler: clang
       env:
         - TEST_IOS=yes
@@ -89,10 +96,10 @@ jobs:
         - OPENSSL_HOST=ios-cross
         - IOS_SDK=iPhoneOS
         - IOS_CPU=armv7s
-        - IOS_PREFIX="$HOME/iPhoneOS-$IOS_CPU"
+        - IOS_PREFIX="$HOME/$IOS_SDK-$IOS_CPU"
     - os: osx
       osx_image: xcode10
-      name: Apple iPad, OS X, Amd64
+      name: Apple iPhone on iOS, arm64
       compiler: clang
       env:
         - TEST_IOS=yes
@@ -100,27 +107,69 @@ jobs:
         - OPENSSL_HOST=ios64-cross
         - IOS_SDK=iPhoneOS
         - IOS_CPU=arm64
-        - IOS_PREFIX="$HOME/iPhoneOS-$IOS_CPU"
+        - IOS_PREFIX="$HOME/$IOS_SDK-$IOS_CPU"
     - os: osx
       osx_image: xcode10
-      name: Apple TV, OS X, Amd64
+      name: Apple TV on iOS, arm64
       compiler: clang
       env:
         - TEST_IOS=yes
         - AUTOTOOLS_HOST=aarch64-apple-ios
         - OPENSSL_HOST=ios64-cross
         - IOS_SDK=AppleTVOS
-        - IOS_PREFIX="$HOME/AppleTVOS"
+        - IOS_CPU=arm64
+        - IOS_PREFIX="$HOME/$IOS_SDK-$IOS_CPU"
     - os: osx
       osx_image: xcode10
-      name: Apple Watch, OS X, Amd64
+      name: Apple Watch on iOS, armv7
       compiler: clang
       env:
         - TEST_IOS=yes
         - AUTOTOOLS_HOST=armv7-apple-ios
         - OPENSSL_HOST=ios-cross
         - IOS_SDK=WatchOS
-        - IOS_PREFIX="$HOME/WatchOS"
+        - IOS_CPU=armv7k
+        - IOS_PREFIX="$HOME/$IOS_SDK-$IOS_CPU"
+    - os: osx
+      osx_image: xcode10
+      name: iPhoneSimulator on OS X, i386
+      env:
+        - TEST_IOS=yes
+        - AUTOTOOLS_HOST=i386-apple-ios
+        - OPENSSL_HOST=iphoneos-cross
+        - IOS_CPU=i386
+        - IOS_SDK=iPhoneSimulator
+        - IOS_PREFIX="$HOME/$IOS_SDK-$IOS_CPU"
+    - os: osx
+      osx_image: xcode10
+      name: iPhoneSimulator on OS X, x86_64
+      env:
+        - TEST_IOS=yes
+        - AUTOTOOLS_HOST=x86_64-apple-ios
+        - OPENSSL_HOST=iphoneos-cross
+        - IOS_CPU=x86_64
+        - IOS_SDK=iPhoneSimulator
+        - IOS_PREFIX="$HOME/$IOS_SDK-$IOS_CPU"
+    - os: osx
+      osx_image: xcode10
+      name: AppleTVSimulator on OS X, x86_64
+      env:
+        - TEST_IOS=yes
+        - AUTOTOOLS_HOST=x86_64-apple-ios
+        - OPENSSL_HOST=iphoneos-cross
+        - IOS_CPU=x86_64
+        - IOS_SDK=AppleTVSimulator
+        - IOS_PREFIX="$HOME/$IOS_SDK-$IOS_CPU"
+    - os: osx
+      osx_image: xcode10
+      name: WatchSimulator on OS X, i386
+      env:
+        - TEST_IOS=yes
+        - AUTOTOOLS_HOST=i386-apple-ios
+        - OPENSSL_HOST=iphoneos-cross
+        - IOS_CPU=i386
+        - IOS_SDK=WatchSimulator
+        - IOS_PREFIX="$HOME/$IOS_SDK-$IOS_CPU"
     - os: linux
       name: Android armv7a, Linux, Amd64
       compiler: clang
@@ -179,22 +228,22 @@ jobs:
         - ANDROID_NDK_ROOT="$HOME/android-ndk"
 
   allow_failures:
-    - os: osx
-      name: Apple TV, OS X, Amd64
-    - os: osx
-      name: Apple Watch, OS X, Amd64
     - os: linux
-      arch: amd64
       name: Android armv7a, Linux, Amd64
     - os: linux
-      arch: amd64
       name: Android aarch64, Linux, Amd64
     - os: linux
-      arch: amd64
       name: Android x86, Linux, Amd64
     - os: linux
-      arch: amd64
       name: Android x86_64, Linux, Amd64
+
+before_script:
+  - |
+    if [ "$TEST_ANDROID" = "yes" ]; then
+      ./contrib/android/install_tools.sh
+    elif [ "$TEST_IOS" = "yes" ]; then
+      ./contrib/ios/install_tools.sh
+    fi
 
 # The Travis docs say to avoid calling exit in the script. It leads to
 # some code duplication to avoid failures in cross-compiles. Also see
@@ -215,7 +264,6 @@ script:
       export AUTOTOOLS_BUILD="$(./config.guess)"
       export PKG_CONFIG_PATH="$IOS_PREFIX/lib/pkgconfig"
       source ./contrib/ios/setenv_ios.sh
-      ./contrib/ios/install_tools.sh
       ./contrib/ios/install_openssl.sh
       ./contrib/ios/install_expat.sh
       ./configure \
@@ -230,7 +278,6 @@ script:
       export PKG_CONFIG_PATH="$ANDROID_PREFIX/lib/pkgconfig"
       ./contrib/android/install_ndk.sh
       source ./contrib/android/setenv_android.sh
-      ./contrib/android/install_tools.sh
       ./contrib/android/install_openssl.sh
       ./contrib/android/install_expat.sh
       ./configure \
@@ -240,7 +287,7 @@ script:
         --with-libexpat="$ANDROID_PREFIX";
       make -j 2
       make install
-    elif [ "$TRAVIS_OS_NAME" = "osx" ]; then
+    elif [ "$TEST_OSX" = "yes" ]; then
       ./configure --enable-debug --disable-flto --with-ssl=/usr/local/opt/openssl/
       make -j 2
       make test

--- a/contrib/android/install_openssl.sh
+++ b/contrib/android/install_openssl.sh
@@ -24,7 +24,7 @@ fi
 
 echo "Configuring OpenSSL"
 if ! ./Configure "$OPENSSL_HOST" no-comp no-asm no-hw no-engine shared \
-     "$CFLAGS" --prefix="$ANDROID_PREFIX" --openssldir="$ANDROID_PREFIX"; then
+       --prefix="$ANDROID_PREFIX" --openssldir="$ANDROID_PREFIX"; then
     echo "Failed to configure OpenSSL"
     exit 1
 fi

--- a/contrib/android/install_tools.sh
+++ b/contrib/android/install_tools.sh
@@ -3,4 +3,4 @@
 # This step should install tools needed for all packages - OpenSSL, Expat and Unbound
 echo "Updating tools"
 sudo apt-get -qq update
-sudo apt-get -qq install --no-install-recommends curl tar zip unzip perl openjdk-8-jdk autoconf automake libtool pkgconfig
+sudo apt-get -qq install --no-install-recommends curl tar zip unzip perl openjdk-8-jdk autoconf automake libtool pkg-config

--- a/contrib/ios/15-ios.conf
+++ b/contrib/ios/15-ios.conf
@@ -14,11 +14,12 @@ my %targets = (
     },
     "ios-xcrun" => {
         inherit_from     => [ "ios-common", asm("armv4_asm") ],
+        bn_ops           => [ "BN_LLONG", "RC4_CHAR" ],
         perlasm_scheme   => "ios32",
     },
     "ios64-xcrun" => {
         inherit_from     => [ "ios-common", asm("aarch64_asm") ],
-        #bn_ops           => "SIXTY_FOUR_BIT_LONG RC4_CHAR",
+        bn_ops           => [ "SIXTY_FOUR_BIT_LONG", "RC4_CHAR" ],
         perlasm_scheme   => "ios64",
     },
     "iossimulator-xcrun" => {
@@ -35,7 +36,6 @@ my %targets = (
     },
     "ios64-cross" => {
         inherit_from     => [ "ios64-xcrun" ],
-        cppflags         => add("-DSIXTY_FOUR_BIT_LONG -DRC4_CHAR"),
         cflags           => add("-Wall -fno-common"),
     },
 );

--- a/contrib/ios/install_openssl.sh
+++ b/contrib/ios/install_openssl.sh
@@ -22,9 +22,17 @@ if ! cp ../contrib/ios/15-ios.conf Configurations/; then
     exit 1
 fi
 
+# OpenSSL 1.1.1d patch. OK to remove once OpenSSL version is bumped.
+# ocsp.c:947:23: error: 'fork' is unavailable: not available on tvOS and watchOS.
+# Also see https://github.com/openssl/openssl/issues/7607.
+if ! patch -u -p0 < ../contrib/ios/openssl.patch; then
+    echo "Failed to patch OpenSSL"
+    exit 1
+fi
+
 echo "Configuring OpenSSL"
-if ! ./Configure "$OPENSSL_HOST" no-comp no-asm no-hw no-engine \
-     "$CFLAGS" --prefix="$IOS_PREFIX" --openssldir="$IOS_PREFIX"; then
+if ! ./Configure "$OPENSSL_HOST" -DNO_FORK no-comp no-asm no-hw no-engine no-tests no-unit-test \
+       --prefix="$IOS_PREFIX" --openssldir="$IOS_PREFIX"; then
     echo "Failed to configure OpenSSL"
     exit 1
 fi

--- a/contrib/ios/install_tools.sh
+++ b/contrib/ios/install_tools.sh
@@ -4,4 +4,4 @@
 echo "Updating tools"
 brew update 1>/dev/null
 echo "Installing tools"
-brew install autoconf automake libtool pkgconfig curl perl 1>/dev/null
+brew install autoconf automake libtool pkg-config curl perl 1>/dev/null

--- a/contrib/ios/openssl.patch
+++ b/contrib/ios/openssl.patch
@@ -1,0 +1,48 @@
+--- apps/speed.c
++++ apps/speed.c
+@@ -99,6 +99,13 @@
+ #endif
+ #include <openssl/modes.h>
+ 
++/* fork() breaks AppleTVOS, WatchOS, AppleTVSimulator and WatchSimulator */
++/* Users should configure with -DNO_FORK */
++#if defined(NO_FORK)
++# undef HAVE_FORK
++# define HAVE_FORK 0
++#endif
++
+ #ifndef HAVE_FORK
+ # if defined(OPENSSL_SYS_VMS) || defined(OPENSSL_SYS_WINDOWS) || defined(OPENSSL_SYS_VXWORKS)
+ #  define HAVE_FORK 0
+@@ -110,6 +117,7 @@
+ #if HAVE_FORK
+ # undef NO_FORK
+ #else
++# undef NO_FORK
+ # define NO_FORK
+ #endif
+ 
+--- apps/ocsp.c
++++ apps/ocsp.c
+@@ -36,6 +36,13 @@
+ # include <openssl/x509v3.h>
+ # include <openssl/rand.h>
+ 
++/* fork() breaks AppleTVOS, WatchOS, AppleTVSimulator and WatchSimulator */
++/* Users should configure with -DNO_FORK */
++#if defined(NO_FORK)
++# undef HAVE_FORK
++# define HAVE_FORK 0
++#endif
++
+ #ifndef HAVE_FORK
+ # if defined(OPENSSL_SYS_VMS) || defined(OPENSSL_SYS_WINDOWS)
+ #  define HAVE_FORK 0
+@@ -47,6 +54,7 @@
+ #if HAVE_FORK
+ # undef NO_FORK
+ #else
++# undef NO_FORK
+ # define NO_FORK
+ #endif
+ 

--- a/contrib/ios/setenv_ios.sh
+++ b/contrib/ios/setenv_ios.sh
@@ -1,8 +1,145 @@
 #!/usr/bin/env bash
 
+# ====================================================================
+# Sets the cross compile environment for Xcode/iOS
+#
+# Based upon OpenSSL's setenv-ios.sh  by TH, JW, and SM.
+# Heavily modified by JWW for Crypto++.
+# Modified by JWW for Unbound.
+# ====================================================================
+
+#########################################
+#####        Some validation        #####
+#########################################
+
+# In the past we could mostly infer arch or cpu from the SDK (and
+# mostly vice-versa). Nowadays we need it set for us because Apple
+# platforms can be either 32-bit or 64-bit.
+
+if [ -z "$IOS_SDK" ]; then
+    echo "IOS_SDK is not set. Please set it"
+    [[ "$0" = "${BASH_SOURCE[0]}" ]] && exit 1 || return 1
+fi
+
+if [ -z "$IOS_CPU" ]; then
+    echo "IOS_CPU is not set. Please set it"
+    [[ "$0" = "${BASH_SOURCE[0]}" ]] && exit 1 || return 1
+fi
+
+# cryptest-ios.sh may run this script without sourcing.
+if [ "$0" = "${BASH_SOURCE[0]}" ]; then
+    echo "setenv-ios.sh is usually sourced, but not this time."
+fi
+
+#########################################
+#####    Small Fixups, if needed    #####
+#########################################
+
+if [[ "$IOS_SDK" == "iPhone" ]]; then
+    IOS_SDK=iPhoneOS
+fi
+
+if [[ "$IOS_SDK" == "iPhoneOSSimulator" ]]; then
+    IOS_SDK=iPhoneSimulator
+fi
+
+if [[ "$IOS_SDK" == "TV" || "$IOS_SDK" == "AppleTV" ]]; then
+    IOS_SDK=AppleTVOS
+fi
+
+if [[ "$IOS_SDK" == "Watch" || "$IOS_SDK" == "AppleWatch" ]]; then
+    IOS_SDK=WatchOS
+fi
+
+if [[ "$IOS_CPU" == "aarch64" || "$IOS_CPU" == "armv8"* ]] ; then
+    IOS_CPU=arm64
+fi
+
+########################################
+#####         Environment          #####
+########################################
+
+# The flags below were tested with Xcode 8 on Travis. If
+# you use downlevel versions of Xcode, then you can push
+# xxx-version-min=n lower. For example, Xcode 6 can use
+# -miphoneos-version-min=5.
+
+# iPhones can be either 32-bit or 64-bit
+if [[ "$IOS_SDK" == "iPhoneOS" && "$IOS_CPU" == "armv7"* ]]; then
+    MIN_VER=-miphoneos-version-min=6
+elif [[ "$IOS_SDK" == "iPhoneOS" && "$IOS_CPU" == "arm64" ]]; then
+    MIN_VER=-miphoneos-version-min=6
+
+# Fixups for convenience
+elif [[ "$IOS_SDK" == "iPhoneOS" && "$IOS_CPU" == "i386" ]]; then
+    IOS_SDK=iPhoneSimulator
+    # MIN_VER=-miphoneos-version-min=6
+    MIN_VER=-miphonesimulator-version-min=6
+elif [[ "$IOS_SDK" == "iPhoneOS" && "$IOS_CPU" == "x86_64" ]]; then
+    IOS_SDK=iPhoneSimulator
+    # MIN_VER=-miphoneos-version-min=6
+    MIN_VER=-miphonesimulator-version-min=6
+
+# Simulator builds
+elif [[ "$IOS_SDK" == "iPhoneSimulator" && "$IOS_CPU" == "i386" ]]; then
+    MIN_VER=-miphonesimulator-version-min=6
+elif [[ "$IOS_SDK" == "iPhoneSimulator" && "$IOS_CPU" == "x86_64" ]]; then
+    MIN_VER=-miphonesimulator-version-min=6
+
+# Apple TV can be 32-bit Intel (1st gen), 32-bit ARM (2nd, 3rd gen) or 64-bit ARM (4th gen)
+elif [[ "$IOS_SDK" == "AppleTVOS" && "$IOS_CPU" == "i386" ]]; then
+    MIN_VER=-mappletvos-version-min=6
+elif [[ "$IOS_SDK" == "AppleTVOS" && "$IOS_CPU" == "armv7"* ]]; then
+    MIN_VER=-mappletvos-version-min=6
+elif [[ "$IOS_SDK" == "AppleTVOS" && "$IOS_CPU" == "arm64" ]]; then
+    MIN_VER=-mappletvos-version-min=6
+
+# Simulator builds
+elif [[ "$IOS_SDK" == "AppleTVSimulator" && "$IOS_CPU" == "i386" ]]; then
+    MIN_VER=-mappletvsimulator-version-min=6
+elif [[ "$IOS_SDK" == "AppleTVSimulator" && "$IOS_CPU" == "x86_64" ]]; then
+    MIN_VER=-mappletvsimulator-version-min=6
+
+# Watch can be either 32-bit or 64-bit ARM. TODO: figure out which
+# -mwatchos-version-min=n is needed for arm64. 9 is not enough.
+elif [[ "$IOS_SDK" == "WatchOS" && "$IOS_CPU" == "armv7"* ]]; then
+    MIN_VER=-mwatchos-version-min=6
+elif [[ "$IOS_SDK" == "WatchOS" && "$IOS_CPU" == "arm64" ]]; then
+    MIN_VER=-mwatchos-version-min=10
+
+# Simulator builds. TODO: figure out which -watchos-version-min=n
+# is needed for arm64. 6 compiles and links, but is it correct?
+elif [[ "$IOS_SDK" == "WatchSimulator" && "$IOS_CPU" == "i386" ]]; then
+    MIN_VER=-mwatchsimulator-version-min=6
+elif [[ "$IOS_SDK" == "WatchSimulator" && "$IOS_CPU" == "x86_64" ]]; then
+    MIN_VER=-mwatchsimulator-version-min=6
+
+# And the final catch-all
+else
+    echo "IOS_SDK and IOS_CPU are not valid. Please fix them"
+    [[ "$0" = "${BASH_SOURCE[0]}" ]] && exit 1 || return 1
+fi
+
 #####################################################################
 
-# Allow a user override? I think we should be doing this. The use case is:
+# Xcode 6 and below cannot handle -miphonesimulator-version-min
+# Fix it so the simulator will compile as expected. This trick
+# may work on other SDKs, but it was not tested.
+
+if [ -n "$(command -v xcodebuild 2>/dev/null)" ]; then
+    # Output of xcodebuild is similar to "Xcode 6.2". The first cut gets
+    # the dotted decimal value. The second cut gets the major version.
+    XCODE_VERSION=$(xcodebuild -version 2>/dev/null | head -n 1 | cut -f2 -d" " | cut -f1 -d".")
+    if [ -z "$XCODE_VERSION" ]; then XCODE_VERSION=100; fi
+
+    if [ "$XCODE_VERSION" -le 6 ]; then
+        MIN_VER="${MIN_VER//iphonesimulator/iphoneos}"
+    fi
+fi
+
+#####################################################################
+
+# Allow a user override? I think we should be doing this. The use case is,
 # move /Applications/Xcode somewhere else for a side-by-side installation.
 if [ -z "${XCODE_DEVELOPER-}" ]; then
   XCODE_DEVELOPER=$(xcode-select -print-path 2>/dev/null)
@@ -13,43 +150,34 @@ if [ ! -d "$XCODE_DEVELOPER" ]; then
   [ "$0" = "${BASH_SOURCE[0]}" ] && exit 1 || return 1
 fi
 
-# Default toolchain location
-XCODE_TOOLCHAIN="$XCODE_DEVELOPER/usr/bin"
+# XCODE_DEVELOPER_SDK is the SDK location.
+XCODE_DEVELOPER_SDK="$XCODE_DEVELOPER/Platforms/$IOS_SDK.platform"
 
-if [ ! -d "$XCODE_TOOLCHAIN" ]; then
-  echo "ERROR: unable to find XCODE_TOOLCHAIN directory."
+if [ ! -d "$XCODE_DEVELOPER_SDK" ]; then
+  echo "ERROR: unable to find XCODE_DEVELOPER_SDK directory."
+  echo "       Is the SDK supported by Xcode and installed?"
   [ "$0" = "${BASH_SOURCE[0]}" ] && exit 1 || return 1
 fi
 
-# XCODE_DEVELOPER_TOP is the top of the development tools tree
-XCODE_DEVELOPER_TOP="$XCODE_DEVELOPER/Platforms/$IOS_SDK.platform/Developer"
-
-if [ ! -d "$XCODE_DEVELOPER_TOP" ]; then
-  echo "ERROR: unable to find XCODE_DEVELOPER_TOP directory."
-  [ "$0" = "${BASH_SOURCE[0]}" ] && exit 1 || return 1
-fi
-
-# IOS_TOOLCHAIN_PATH is the location of the actual compiler tools.
+# XCODE_TOOLCHAIN is the location of the actual compiler tools.
 if [ -d "$XCODE_DEVELOPER/Toolchains/XcodeDefault.xctoolchain/usr/bin/" ]; then
-  IOS_TOOLCHAIN_PATH="$XCODE_DEVELOPER/Toolchains/XcodeDefault.xctoolchain/usr/bin/"
-elif [ -d "$XCODE_DEVELOPER_TOP/usr/bin/" ]; then
-  IOS_TOOLCHAIN_PATH="$XCODE_DEVELOPER_TOP/usr/bin/"
+  XCODE_TOOLCHAIN="$XCODE_DEVELOPER/Toolchains/XcodeDefault.xctoolchain/usr/bin/"
+elif [ -d "$XCODE_DEVELOPER_SDK/Developer/usr/bin/" ]; then
+  XCODE_TOOLCHAIN="$XCODE_DEVELOPER_SDK/Developer/usr/bin/"
 fi
 
-if [ -z "$IOS_TOOLCHAIN_PATH" ] || [ ! -d "$IOS_TOOLCHAIN_PATH" ]; then
+if [ -z "$XCODE_TOOLCHAIN" ] || [ ! -d "$XCODE_TOOLCHAIN" ]; then
   echo "ERROR: unable to find Xcode cross-compiler tools."
   [ "$0" = "${BASH_SOURCE[0]}" ] && exit 1 || return 1
 fi
 
-#####################################################################
-
-# XCODE_SDK is the SDK name/version being used. Adjust the list as appropriate.
+# XCODE_SDK is the SDK name/version being used - adjust the list as appropriate.
 # For example, remove 4.3, 6.2, and 6.1 if they are not installed. We go back to
 # the 1.0 SDKs because Apple WatchOS uses low numbers, like 2.0 and 2.1.
-unset XCODE_SDK
+XCODE_SDK=
 for i in $(seq -f "%.1f" 30.0 -0.1 1.0)
 do
-    if [ -d "$XCODE_DEVELOPER/Platforms/$IOS_SDK.platform/Developer/SDKs/$IOS_SDK$i.sdk" ]; then
+    if [ -d "$XCODE_DEVELOPER_SDK/Developer/SDKs/$IOS_SDK$i.sdk" ]; then
         XCODE_SDK="$IOS_SDK$i.sdk"
         break
     fi
@@ -61,7 +189,7 @@ if [ -z "$XCODE_SDK" ]; then
     [ "$0" = "${BASH_SOURCE[0]}" ] && exit 1 || return 1
 fi
 
-IOS_SYSROOT="$XCODE_DEVELOPER_TOP/SDKs/$XCODE_SDK"
+IOS_SYSROOT="$XCODE_DEVELOPER_SDK/Developer/SDKs/$XCODE_SDK"
 
 if [ -z "$IOS_SYSROOT" ] || [ ! -d "$IOS_SYSROOT" ]; then
   echo "ERROR: unable to find IOS_SYSROOT directory."
@@ -70,143 +198,67 @@ fi
 
 #####################################################################
 
-XCODE_SDK=$(tr '[:upper:]' '[:lower:]' <<< "$IOS_SDK")
+# We want to set AR=libtool and ARFLAGS="-static -o",
+# but I am not sure Autotools can handle it.
+CPP=cpp; CC=clang; CXX=clang++; LD=ld
+AS=as; AR=ar; RANLIB=ranlib; STRIP=strip
 
-case "$XCODE_SDK" in
-  iphone|iphoneos)
-    CPP="cpp"
-    CC="clang"
-    CXX="clang++"
-    LD="ld"
-    AS="as"
-    AR="ar"
-    RANLIB="ranlib"
-    STRIP="strip"
-
-    # Default armv7. Also allowed armv7a, armv7s, arm64
-    if [ -z "$IOS_CPU" ]; then IOS_CPU=armv7; fi
-
-    if [ "$IOS_CPU" = "arm64" ]; then
-      CFLAGS="-arch $IOS_CPU -mios-version-min=7"
-      CXXFLAGS="-arch $IOS_CPU -stdlib=libc++ -mios-version-min=7"
-    else
-      CFLAGS="-arch $IOS_CPU -mios-version-min=6"
-      CXXFLAGS="-arch $IOS_CPU -stdlib=libc++ -mios-version-min=6"
-    fi
-    ;;
-
-  iphonesimulator)
-    CPP="cpp"
-    CC="clang"
-    CXX="clang++"
-    LD="ld"
-    AS="as"
-    AR="ar"
-    RANLIB="ranlib"
-    STRIP="strip"
-
-    # Default i386.
-    if [ -z "$IOS_CPU" ]; then IOS_CPU=i386; fi
-
-    CFLAGS="-arch $IOS_CPU -mios-version-min=5"
-    CXXFLAGS="-arch $IOS_CPU -stdlib=libc++ -mios-version-min=5"
-    ;;
-
-  watch|watchos|applewatch)
-    CPP="cpp"
-    CC="clang"
-    CXX="clang++"
-    LD="ld"
-    AS="as"
-    AR="ar"
-    RANLIB="ranlib"
-    STRIP="strip"
-
-    # Default armv7. Also allowed armv7a, armv7s
-    if [ -z "$IOS_CPU" ]; then IOS_CPU=armv7; fi
-
-    CFLAGS="-arch $IOS_CPU -mios-version-min=7"
-    CXXFLAGS="-arch $IOS_CPU -stdlib=libc++ -mios-version-min=7"
-    ;;
-
-  watchsimulator|watchossimulator)
-    CPP="cpp"
-    CC="clang"
-    CXX="clang++"
-    LD="ld"
-    AS="as"
-    AR="ar"
-    RANLIB="ranlib"
-    STRIP="strip"
-
-    # Default i386.
-    if [ -z "$IOS_CPU" ]; then IOS_CPU=i386; fi
-
-    CFLAGS="-arch $IOS_CPU"
-    CXXFLAGS="-arch $IOS_CPU -stdlib=libc++"
-    ;;
-
-  appletv|appletvos)
-    CPP="cpp"
-    CC="clang"
-    CXX="clang++"
-    LD="ld"
-    AS="as"
-    AR="ar"
-    RANLIB="ranlib"
-    STRIP="strip"
-
-    # Default arm64.
-    if [ -z "$IOS_CPU" ]; then IOS_CPU=arm64; fi
-
-    CFLAGS="-arch $IOS_CPU"
-    CXXFLAGS="-arch $IOS_CPU -stdlib=libc++"
-    ;;
-
-  appletvsimulator|appletvossimulator)
-    CPP="cpp"
-    CC="clang"
-    CXX="clang++"
-    LD="ld"
-    AS="as"
-    AR="ar"
-    RANLIB="ranlib"
-    STRIP="strip"
-
-    # Default x86_64,
-    if [ -z "$IOS_CPU" ]; then IOS_CPU=x86_64; fi
-
-    CFLAGS="-arch $IOS_CPU"
-    CXXFLAGS="-arch $IOS_CPU -stdlib=libc++"
-    ;;
-
-  *)
-    echo "ERROR: Unknown architecture $IOS_SDK"
+# Error checking
+if [ ! -e "$XCODE_TOOLCHAIN/$CC" ]; then
+    echo "ERROR: Failed to find iOS clang. Please edit this script."
     [ "$0" = "${BASH_SOURCE[0]}" ] && exit 1 || return 1
-    ;;
+fi
 
-esac
+# Error checking
+if [ ! -e "$XCODE_TOOLCHAIN/$CXX" ]; then
+    echo "ERROR: Failed to find iOS clang++. Please edit this script."
+    [ "$0" = "${BASH_SOURCE[0]}" ] && exit 1 || return 1
+fi
+
+# Error checking
+if [ ! -e "$XCODE_TOOLCHAIN/$RANLIB" ]; then
+    echo "ERROR: Failed to find iOS ranlib. Please edit this script."
+    [ "$0" = "${BASH_SOURCE[0]}" ] && exit 1 || return 1
+fi
+
+# Error checking
+if [ ! -e "$XCODE_TOOLCHAIN/$AR" ]; then
+    echo "ERROR: Failed to find iOS ar. Please edit this script."
+    [ "$0" = "${BASH_SOURCE[0]}" ] && exit 1 || return 1
+fi
+
+# Error checking
+if [ ! -e "$XCODE_TOOLCHAIN/$AS" ]; then
+    echo "ERROR: Failed to find iOS as. Please edit this script."
+    [ "$0" = "${BASH_SOURCE[0]}" ] && exit 1 || return 1
+fi
+
+# Error checking
+if [ ! -e "$XCODE_TOOLCHAIN/$LD" ]; then
+    echo "ERROR: Failed to find iOS ld. Please edit this script."
+    [ "$0" = "${BASH_SOURCE[0]}" ] && exit 1 || return 1
+fi
 
 #####################################################################
 
-TOOLCHAIN_PATH="$IOS_TOOLCHAIN_PATH:$XCODE_TOOLCHAIN"
-LENGTH=${#TOOLCHAIN_PATH}
+LENGTH=${#XCODE_TOOLCHAIN}
 SUBSTR=${PATH:0:$LENGTH}
-if [ "$SUBSTR" != "$TOOLCHAIN_PATH" ]; then
-    export PATH="$TOOLCHAIN_PATH":"$PATH"
+if [ "$SUBSTR" != "$XCODE_TOOLCHAIN" ]; then
+    export PATH="$XCODE_TOOLCHAIN":"$PATH"
 fi
 
 #####################################################################
 
 export CPP CC CXX LD AS AR RANLIB STRIP
 export IOS_SYSROOT
-export CFLAGS="$CFLAGS --sysroot=$IOS_SYSROOT"
-export CXXFLAGS="$CXXFLAGS --sysroot=$IOS_SYSROOT"
+export CFLAGS="-arch $IOS_CPU $MIN_VER --sysroot=$IOS_SYSROOT"
+export CXXFLAGS="-arch $IOS_CPU $MIN_VER -stdlib-libc++ --sysroot=$IOS_SYSROOT"
 
 #####################################################################
 
-echo "IOS_TOOLCHAIN_PATH: $IOS_TOOLCHAIN_PATH"
+echo "XCODE_TOOLCHAIN: $XCODE_TOOLCHAIN"
 
+echo "CPP: $(command -v "$CPP")"
 echo "CC: $(command -v "$CC")"
 echo "CXX: $(command -v "$CXX")"
 echo "LD: $(command -v "$LD")"
@@ -215,6 +267,7 @@ echo "AR: $(command -v "$AR")"
 
 echo "IOS_SYSROOT: $IOS_SYSROOT"
 
+echo "CPPFLAGS: $CPPFLAGS"
 echo "CFLAGS: $CFLAGS"
 echo "CXXFLAGS: $CXXFLAGS"
 

--- a/daemon/unbound.c
+++ b/daemon/unbound.c
@@ -88,6 +88,14 @@
 #  include "nss.h"
 #endif
 
+#ifdef HAVE_TARGETCONDITIONALS_H
+#include <TargetConditionals.h>
+#endif
+
+#if defined(TARGET_OS_TV) || defined(TARGET_OS_WATCH)
+#undef HAVE_FORK
+#endif
+
 /** print build options. */
 static void
 print_build_options(void)

--- a/libunbound/libworker.c
+++ b/libunbound/libworker.c
@@ -74,6 +74,14 @@
 #include "sldns/sbuffer.h"
 #include "sldns/str2wire.h"
 
+#ifdef HAVE_TARGETCONDITIONALS_H
+#include <TargetConditionals.h>
+#endif
+
+#if defined(TARGET_OS_TV) || defined(TARGET_OS_WATCH)
+#undef HAVE_FORK
+#endif
+
 /** handle new query command for bg worker */
 static void handle_newq(struct libworker* w, uint8_t* buf, uint32_t len);
 

--- a/smallapp/unbound-control.c
+++ b/smallapp/unbound-control.c
@@ -74,8 +74,8 @@
 #include <sys/un.h>
 #endif
 
-#ifdef HAVE_TARGETCONDITIONAL_H
-#include <TargetConditional.h>
+#ifdef HAVE_TARGETCONDITIONALS_H
+#include <TargetConditionals.h>
 #endif
 
 static void usage(void) ATTR_NORETURN;
@@ -884,8 +884,8 @@ int main(int argc, char* argv[])
 		usage();
 	if(argc >= 1 && strcmp(argv[0], "start")==0) {
 #if defined(TARGET_OS_TV) || defined(TARGET_OS_WATCH)
-			fatal_exit("could not exec unbound: %s",
-				strerror(ENOSYS));
+		fatal_exit("could not exec unbound: %s",
+			strerror(ENOSYS));
 #else
 		if(execlp("unbound", "unbound", "-c", cfgfile, 
 			(char*)NULL) < 0) {


### PR DESCRIPTION
This PR updates Travis testing for OS X and iOS.

The two big changes were updating `setenv-ios.sh` to use a specific `-mxxx-min-ver`, which allowed iSO simulator testing. Without `-mxxx-min-ver` changes the simulators would fail to compile under current versions of Xcode.

* Update Brew packages in `.travis.yml`
* Add `TEST_OSX=yes` to differentiate between OS X and iOS in `.travis.yml`
* Use more consistent `name:` in `.travis.yml`
* Switch to `IOS_PREFIX="$HOME/$IOS_SDK-$IOS_CPU"` due to sdk/cpu combos
* Add iPhoneSimulator, AppleTVSimulator and WatchSimulator testing
* Install Android and iOS tools using `before_script` in `.travis.yml`
* Remove `"$CFLAGS"` from `install_openssl.sh`. OpenSSL already includes them.
* Add `no-tests` and `no-unit-tests` to `install_openssl.sh`. OpenSSL was calling `fork` in several places
* Patch OpenSSL in `install_openssl.sh`. OpenSSL was still calling `fork` in several places
* Use `pkg-config` name rather than `pkgconfig`. It was causing a failure in `apt-get`
* Update `15-ios.conf` for OpenSSL. Flags are now added in the base recipe
* Update `setenv_ios.sh`. It avoids `-mios-version-min` used in earlier Xcodes. It now uses a specific flag, like `-miphoneos-version-min`, `-miphonesimulator-version-min`, `-mappletvos-version-min`, `-mappletvsimulator-version-min`, `-mwatchos-version-min` and `-mwatchsimulator-version-min`
* Use `XCODE_` prefix consistently in `setenv_ios.sh`
* Guard use of `fork` and `execlp` in `daemon/unbound.c`, `libunbound/libworker.c` and `smallapp/unbound-control.c`

Travis is kind of slow today. You can see the result of the iOS changes at [Job 152871267](https://travis-ci.com/github/noloader/unbound/builds/152871267).