### PR TITLE
Add libevent testing to Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,11 @@ addons:
     - libevent-dev
     - libexpat-dev
     - clang
+  homebrew:
+    packages:
+      - openssl
+      - libevent
+    update: true
 
 jobs:
   include:
@@ -17,68 +22,109 @@ jobs:
       name: GCC on Linux, Amd64
       compiler: gcc
       arch: amd64
+      env:
+        - CONFIG_OPTS="--enable-debug --disable-flto"
     - os: linux
       name: Clang on Linux, Amd64
       compiler: clang
       arch: amd64
+      env:
+        - CONFIG_OPTS="--enable-debug --disable-flto"
     - os: osx
       name: Clang on OS X, Amd64
       compiler: clang
       arch: amd64
+      env:
+        - CONFIG_OPTS="--enable-debug --disable-flto --with-ssl=/usr/local/opt/openssl/"
+    - os: linux
+      name: Libevent, GCC on Linux, Amd64
+      compiler: gcc
+      arch: amd64
+      env:
+        - TEST_LIBEVENT=yes
+        - CONFIG_OPTS="--with-libevent"
+    - os: linux
+      name: Libevent, Clang on Linux, Amd64
+      compiler: clang
+      arch: amd64
+        - TEST_LIBEVENT=yes
+        - CONFIG_OPTS="--with-libevent"
+    - os: osx
+      name: Libevent, Clang on OS X, Amd64
+      compiler: clang
+      arch: amd64
+        - TEST_LIBEVENT=yes
+        - CONFIG_OPTS="--with-ssl=/usr/local/opt/openssl/ --with-libevent=/usr/local/opt/libevent/"
     - os: linux
       name: UBsan, GCC on Linux, Amd64
       compiler: gcc
       arch: amd64
       dist: bionic
-      env: TEST_UBSAN=yes
+      env:
+        - TEST_UBSAN=yes
     - os: linux
       name: UBsan, Clang on Linux, Amd64
       compiler: clang
       arch: amd64
       dist: bionic
-      env: TEST_UBSAN=yes
+      env:
+        - TEST_UBSAN=yes
     - os: linux
       name: Asan, GCC on Linux, Amd64
       compiler: gcc
       arch: amd64
       dist: bionic
-      env: TEST_ASAN=yes
+      env:
+        - TEST_ASAN=yes
     - os: linux
       name: Asan, Clang on Linux, Amd64
       compiler: clang
       arch: amd64
       dist: bionic
-      env: TEST_ASAN=yes
+      env:
+        - TEST_ASAN=yes
     - os: linux
       name: GCC on Linux, Aarch64
       compiler: gcc
       arch: arm64
       dist: bionic
+      env:
+        - CONFIG_OPTS="--enable-debug --disable-flto"
     - os: linux
       name: Clang on Linux, Aarch64
       compiler: clang
       arch: arm64
       dist: bionic
+      env:
+        - CONFIG_OPTS="--enable-debug --disable-flto"
     - os: linux
       name: GCC on Linux, PowerPC64
       compiler: gcc
       arch: ppc64le
       dist: bionic
+      env:
+        - CONFIG_OPTS="--enable-debug --disable-flto"
     - os: linux
       name: Clang on Linux, PowerPC64
       compiler: clang
       arch: ppc64le
       dist: bionic
+      env:
+        - CONFIG_OPTS="--enable-debug --disable-flto"
     - os: linux
       name: GCC on Linux, s390x
       compiler: gcc
       arch: s390x
       dist: bionic
+      env:
+        - CONFIG_OPTS="--enable-debug --disable-flto"
     - os: linux
       name: Clang on Linux, s390x
       compiler: clang
       arch: s390x
       dist: bionic
+      env:
+        - CONFIG_OPTS="--enable-debug --disable-flto"
     - os: osx
       osx_image: xcode10
       name: Apple iPhone, OS X, Amd64
@@ -196,6 +242,14 @@ jobs:
       arch: amd64
       name: Android x86_64, Linux, Amd64
 
+before_script:
+  - |
+    if [ "$TEST_ANDROID" = "yes" ]; then
+      ./contrib/android/install_tools.sh
+    elif [ "$TEST_IOS" = "yes" ]; then
+      ./contrib/ios/install_tools.sh
+    fi
+
 # The Travis docs say to avoid calling exit in the script. It leads to
 # some code duplication to avoid failures in cross-compiles. Also see
 # https://docs.travis-ci.com/user/job-lifecycle/ in the Travis docs.
@@ -215,7 +269,6 @@ script:
       export AUTOTOOLS_BUILD="$(./config.guess)"
       export PKG_CONFIG_PATH="$IOS_PREFIX/lib/pkgconfig"
       source ./contrib/ios/setenv_ios.sh
-      ./contrib/ios/install_tools.sh
       ./contrib/ios/install_openssl.sh
       ./contrib/ios/install_expat.sh
       ./configure \
@@ -230,7 +283,6 @@ script:
       export PKG_CONFIG_PATH="$ANDROID_PREFIX/lib/pkgconfig"
       ./contrib/android/install_ndk.sh
       source ./contrib/android/setenv_android.sh
-      ./contrib/android/install_tools.sh
       ./contrib/android/install_openssl.sh
       ./contrib/android/install_expat.sh
       ./configure \
@@ -240,13 +292,8 @@ script:
         --with-libexpat="$ANDROID_PREFIX";
       make -j 2
       make install
-    elif [ "$TRAVIS_OS_NAME" = "osx" ]; then
-      ./configure --enable-debug --disable-flto --with-ssl=/usr/local/opt/openssl/
-      make -j 2
-      make test
-      (cd testdata/clang-analysis.tdir; bash clang-analysis.test)
     else
-      ./configure --enable-debug --disable-flto
+      ./configure ${CONFIG_OPTS}
       make -j 2
       make test
       (cd testdata/clang-analysis.tdir; bash clang-analysis.test)

--- a/configure.ac
+++ b/configure.ac
@@ -1218,28 +1218,29 @@ esac
 # check for libevent
 AC_ARG_WITH(libevent, AC_HELP_STRING([--with-libevent=pathname],
     [use libevent (will check /usr/local /opt/local /usr/lib /usr/pkg /usr/sfw /usr  or you can specify an explicit path). Slower, but allows use of large outgoing port ranges.]),
-    [ ],[ withval="no" ])
-if test x_$withval = x_yes -o x_$withval != x_no; then
+    [ ],[ with_libevent="no" ])
+if test "x_$with_libevent" != x_no; then
+        AC_DEFINE([USE_LIBEVENT], [1], [Define if you enable libevent])
         AC_MSG_CHECKING(for libevent)
-        if test x_$withval = x_ -o x_$withval = x_yes; then
-            withval="/usr/local /opt/local /usr/lib /usr/pkg /usr/sfw /usr"
+        if test "x_$with_libevent" = x_ -o "x_$with_libevent" = x_yes; then
+            with_libevent="/usr/local /opt/local /usr/lib /usr/pkg /usr/sfw /usr"
         fi
-        for dir in $withval; do
+        for dir in $with_libevent; do
             thedir="$dir"
             if test -f "$dir/include/event.h" -o -f "$dir/include/event2/event.h"; then
                 found_libevent="yes"
-		dnl assume /usr is in default path.
-		if test "$thedir" != "/usr"; then
-                    CPPFLAGS="$CPPFLAGS -I$thedir/include"
-		fi
-                break;
-            fi
+				dnl assume /usr is in default path.
+				if test "$thedir" != "/usr"; then
+				    CPPFLAGS="$CPPFLAGS -I$thedir/include"
+				fi
+				break;
+		    fi
         done
         if test x_$found_libevent != x_yes; then
 		if test -f "$dir/event.h" -a \( -f "$dir/libevent.la" -o -f "$dir/libev.la" \) ; then
 			# libevent source directory
-            		AC_MSG_RESULT(found in $thedir)
-                	CPPFLAGS="$CPPFLAGS -I$thedir -I$thedir/include"
+			AC_MSG_RESULT(found in $thedir)
+			CPPFLAGS="$CPPFLAGS -I$thedir -I$thedir/include"
 			BAK_LDFLAGS_SET="1"
 			BAK_LDFLAGS="$LDFLAGS"
 			# remove evdns from linking
@@ -1252,10 +1253,10 @@ if test x_$withval = x_yes -o x_$withval != x_no; then
 			cp $ev_files_o build/libevent
 			cp $ev_files_lo build/libevent
 			cp $ev_files_libso build/libevent/.libs
-            		LATE_LDFLAGS="build/libevent/*.lo -lm"
+			LATE_LDFLAGS="build/libevent/*.lo -lm"
 			LDFLAGS="build/libevent/*.o $LDFLAGS -lm"
 		else
-            		AC_MSG_ERROR([Cannot find the libevent library in $withval
+            AC_MSG_ERROR([Cannot find the libevent library in $with_libevent
 You can restart ./configure --with-libevent=no to use a builtin alternative.
 Please note that this alternative is not as capable as libevent when using
 large outgoing port ranges.  ])

--- a/contrib/android/install_tools.sh
+++ b/contrib/android/install_tools.sh
@@ -3,4 +3,4 @@
 # This step should install tools needed for all packages - OpenSSL, Expat and Unbound
 echo "Updating tools"
 sudo apt-get -qq update
-sudo apt-get -qq install --no-install-recommends curl tar zip unzip perl openjdk-8-jdk autoconf automake libtool pkgconfig
+sudo apt-get -qq install --no-install-recommends curl tar zip unzip perl openjdk-8-jdk autoconf automake libtool pkg-config

--- a/testcode/unitmain.c
+++ b/testcode/unitmain.c
@@ -867,7 +867,11 @@ main(int argc, char* argv[])
 		printf("\tperforms unit tests.\n");
 		return 1;
 	}
+#ifdef USE_LIBEVENT
+	printf("Start of %s+libevent unit test.\n", PACKAGE_STRING);
+#else
 	printf("Start of %s unit test.\n", PACKAGE_STRING);
+#endif
 #ifdef HAVE_SSL
 #  ifdef HAVE_ERR_LOAD_CRYPTO_STRINGS
 	ERR_load_crypto_strings();


### PR DESCRIPTION
This PR adds libevent testing to Travis.

* Add three Travis jobs for GCC on Linux, Clang on Linux and Clang on OS X
* Add Homebrew recipe to install OpenSSL and libevent on OS X
* Fix `pkg-config` package name
* Refactor Travis `jobs:` to use `CONFIG_OPTS`
* Refactor Android tools install into `before_script:`
* Some whitespace cleanup in `configure.ac`
* Add libevent testing feedback to `unitmain.c`