### PR TITLE
Declare lz_enter_rr_into_zone() static, it's only used in this file.

### DIFF
--- a/services/localzone.c
+++ b/services/localzone.c
@@ -518,7 +518,7 @@ local_zone_enter_rr(struct local_zone* z, uint8_t* nm, size_t nmlen,
 }
 
 /** enter data RR into auth zone */
-int
+static int
 lz_enter_rr_into_zone(struct local_zone* z, const char* rrstr)
 {
 	uint8_t* nm;


### PR DESCRIPTION
Pointed out by clang with -Wmissing-prototypes