### PR TITLE
Fix OpenSSL cross-compaile warnings

### DIFF
--- a/contrib/android/15-android.conf
+++ b/contrib/android/15-android.conf
@@ -1,180 +1,37 @@
 #### Android...
 #
-# See NOTES.ANDROID for details, and don't miss platform-specific
-# comments below...
-
-{
-    use File::Spec::Functions;
-
-    my $android_ndk = {};
-    my %triplet = (
-        arm     => "arm-linux-androideabi",
-        arm64   => "aarch64-linux-android",
-        x86     => "i686-linux-android",
-        x86_64  => "x86_64-linux-android"
-    );
-
-    sub android_ndk {
-        unless (%$android_ndk) {
-            if ($now_printing =~ m|^android|) {
-                return $android_ndk = { bn_ops => "BN_AUTO" };
-            }
-
-            my $ndk_var;
-            my $ndk;
-            foreach (qw(ANDROID_NDK_ROOT)) {
-                $ndk_var = $_;
-                $ndk = $ENV{$ndk_var};
-                last if defined $ndk;
-            }
-            die "\$ANDROID_NDK_ROOT is not defined"  if (!$ndk);
-            if (!-d "$ndk/platforms" && !-f "$ndk/AndroidVersion.txt") {
-                # $ndk/platforms is traditional "all-inclusive" NDK, while
-                # $ndk/AndroidVersion.txt is so-called standalone toolchain
-                # tailored for specific target down to API level.
-                die "\$ANDROID_NDK_ROOT=$ndk is invalid";
-            }
-            $ndk = canonpath($ndk);
-
-            my $ndkver = undef;
-
-            if (open my $fh, "<$ndk/source.properties") {
-                local $_;
-                while(<$fh>) {
-                    if (m|Pkg\.Revision\s*=\s*([0-9]+)|) {
-                        $ndkver = $1;
-                        last;
-                    }
-                }
-                close $fh;
-            }
-
-            my ($sysroot, $api, $arch);
-
-            $config{target} =~ m|[^-]+-([^-]+)$|;	# split on dash
-            $arch = $1;
-
-            if ($arch = "armeabi") {
-                $arch = "arm";
-            }
-
-            if (-f "$ndk/AndroidVersion.txt") {
-                $sysroot = "$ndk/sysroot";
-            } else {
-                $api = "*";
-
-                # see if user passed -D__ANDROID_API__=N
-                foreach (@{$useradd{CPPDEFINES}}, @{$user{CPPFLAGS}}) {
-                    if (m|__ANDROID_API__=([0-9]+)|) {
-                        $api = $1;
-                        last;
-                    }
-                }
-
-                # list available platforms (numerically)
-                my @platforms = sort { $a =~ m/-([0-9]+)$/; my $aa = $1;
-                                       $b =~ m/-([0-9]+)$/; $aa <=> $1;
-                                     } glob("$ndk/platforms/android-$api");
-                die "no $ndk/platforms/android-$api" if ($#platforms < 0);
-
-                $sysroot = "@platforms[$#platforms]/arch-$arch";
-                $sysroot =~ m|/android-([0-9]+)/arch-$arch|;
-                $api = $1;
-            }
-            die "no sysroot=$sysroot"   if (!-d $sysroot);
-
-            my $triarch = $triplet{$arch};
-            my $cflags;
-            my $cppflags;
-
-            # see if there is NDK clang on $PATH, "universal" or "standalone"
-            if (which("clang") =~ m|^$ndk/.*/prebuilt/([^/]+)/|) {
-                my $host=$1;
-                # harmonize with gcc default
-                my $arm = $ndkver > 16 ? "armv7a" : "armv5te";
-                (my $tridefault = $triarch) =~ s/^arm-/$arm-/;
-                (my $tritools   = $triarch) =~ s/(?:x|i6)86(_64)?-.*/x86$1/;
-                $cflags .= " -target $tridefault ";
-                $user{CC} = "clang" if ($user{CC} !~ m|clang|);
-                $user{CROSS_COMPILE} = undef;
-                if (which("llvm-ar") =~ m|^$ndk/.*/prebuilt/([^/]+)/|) {
-                    $user{AR} = "llvm-ar";
-                    $user{ARFLAGS} = [ "rs" ];
-                    $user{RANLIB} = ":";
-                }
-            } elsif (-f "$ndk/AndroidVersion.txt") {    #"standalone toolchain"
-                my $cc = $user{CC} // "clang";
-                # One can probably argue that both clang and gcc should be
-                # probed, but support for "standalone toolchain" was added
-                # *after* announcement that gcc is being phased out, so
-                # favouring clang is considered adequate. Those who insist
-                # have option to enforce test for gcc with CC=gcc.
-                if (which("$triarch-$cc") !~ m|^$ndk|) {
-                    die "no NDK $triarch-$cc on \$PATH";
-                }
-                $user{CC} = $cc;
-                $user{CROSS_COMPILE} = "$triarch-";
-            } elsif ($user{CC} eq "clang") {
-                die "no NDK clang on \$PATH";
-            } else {
-                if (which("$triarch-gcc") !~ m|^$ndk/.*/prebuilt/([^/]+)/|) {
-                    die "no NDK $triarch-gcc on \$PATH";
-                }
-                $cflags .= " -mandroid";
-                $user{CROSS_COMPILE} = "$triarch-";
-            }
-
-            if (!-d "$sysroot/usr/include") {
-                my $incroot = "$ndk/sysroot/usr/include";
-                die "no $incroot"          if (!-d $incroot);
-                die "no $incroot/$triarch" if (!-d "$incroot/$triarch");
-                $incroot =~ s|^$ndk/||;
-                $cppflags  = "-D__ANDROID_API__=$api";
-            }
-
-            $sysroot =~ s|^$ndk/||;
-            $android_ndk = {
-                cppflags => $cppflags,
-                bn_ops   => $arch =~ m/64$/ ? "SIXTY_FOUR_BIT_LONG"
-                                            : "BN_LLONG",
-            };
-        }
-
-        return $android_ndk;
-    }
-}
+# Heavily hacked 15-android.conf based on OpenSSL's config file of the same name.
+# This 15-android.conf avoids compiler errors using NDK-r20. This 15-android.conf
+# requires an environment set (sourced) using setenv-android.sh.
 
 my %targets = (
     "android" => {
         inherit_from     => [ "linux-generic32" ],
         template         => 1,
-        cflags           => add(sub { android_ndk()->{cflags} }),
-        cppflags         => add(sub { android_ndk()->{cppflags} }),
-        cxxflags         => add(sub { android_ndk()->{cflags} }),
-        bn_ops           => sub { android_ndk()->{bn_ops} },
-        bin_cflags       => "-fPIE",
-        bin_lflags       => "-pie",
+        bin_cflags       => add("-fPIE"),
+        bin_lflags       => add("-pie"),
         enable           => [ ],
     },
+
     "android-arm" => {
         inherit_from     => [ "android", asm("armv4_asm") ],
-        bn_ops           => add("RC4_CHAR"),
+        bn_ops           => [ "BN_LLONG", "RC4_CHAR" ],
     },
     "android-arm64" => {
         inherit_from     => [ "android", asm("aarch64_asm") ],
-        bn_ops           => add("RC4_CHAR"),
+        bn_ops           => [ "SIXTY_FOUR_BIT_LONG", "RC4_CHAR" ],
         perlasm_scheme   => "linux64",
     },
 
     "android-x86" => {
         inherit_from     => [ "android", asm("x86_asm") ],
-        CFLAGS           => add(picker(release => "-fomit-frame-pointer")),
-        bn_ops           => add("RC4_INT"),
+        cflags           => add(picker(release => "-fomit-frame-pointer")),
+        bn_ops           => [ "BN_LLONG", "RC4_INT" ],
         perlasm_scheme   => "android",
     },
     "android-x86_64" => {
         inherit_from     => [ "android", asm("x86_64_asm") ],
-        bn_ops           => add("RC4_INT"),
+        bn_ops           => [ "SIXTY_FOUR_BIT_LONG", "RC4_INT" ],
         perlasm_scheme   => "elf",
     },
 );

--- a/contrib/android/setenv_android.sh
+++ b/contrib/android/setenv_android.sh
@@ -1,16 +1,43 @@
 #!/usr/bin/env bash
 
-# Error checking
+# ====================================================================
+# Sets the cross compile environment for Android
+#
+# Based upon OpenSSL's setenv-android.sh by TH, JW, and SM.
+# Heavily modified by JWW for Crypto++.
+# Updated by Skycoder42 for current recommendations for Android.
+# Modified by JWW for Unbound.
+# ====================================================================
+
+#########################################
+#####        Some validation        #####
+#########################################
+
+if [ -z "$ANDROID_API" ]; then
+    echo "ANDROID_API is not set. Please set it"
+    [[ "$0" = "${BASH_SOURCE[0]}" ]] && exit 1 || return 1
+fi
+
+if [ -z "$ANDROID_CPU" ]; then
+    echo "ANDROID_CPU is not set. Please set it"
+    [[ "$0" = "${BASH_SOURCE[0]}" ]] && exit 1 || return 1
+fi
+
 if [ ! -d "$ANDROID_NDK_ROOT" ]; then
     echo "ERROR: ANDROID_NDK_ROOT is not a valid path. Please set it."
     echo "NDK root is $ANDROID_NDK_ROOT"
     [ "$0" = "${BASH_SOURCE[0]}" ] && exit 1 || return 1
 fi
 
+# cryptest-android.sh may run this script without sourcing.
+if [ "$0" = "${BASH_SOURCE[0]}" ]; then
+    echo "setenv-android.sh is usually sourced, but not this time."
+fi
+
 #####################################################################
 
 # Need to set THIS_HOST to darwin-x86_64, linux-x86_64,
-# windows-x86_64 or windows.
+# windows, or windows-x86_64
 
 if [[ "$(uname -s | grep -i -c darwin)" -ne 0 ]]; then
     THIS_HOST=darwin-x86_64
@@ -21,38 +48,30 @@ else
     [ "$0" = "${BASH_SOURCE[0]}" ] && exit 1 || return 1
 fi
 
-AOSP_TOOLCHAIN_ROOT="$ANDROID_NDK_ROOT/toolchains/llvm/prebuilt/$THIS_HOST"
-AOSP_TOOLCHAIN_PATH="$AOSP_TOOLCHAIN_ROOT/bin"
-AOSP_SYSROOT="$AOSP_TOOLCHAIN_ROOT/sysroot"
+ANDROID_TOOLCHAIN="$ANDROID_NDK_ROOT/toolchains/llvm/prebuilt/$THIS_HOST/bin"
+ANDROID_SYSROOT="$ANDROID_NDK_ROOT/toolchains/llvm/prebuilt/$THIS_HOST/sysroot"
 
 # Error checking
-if [ ! -d "$AOSP_TOOLCHAIN_ROOT" ]; then
-    echo "ERROR: AOSP_TOOLCHAIN_ROOT is not a valid path. Please set it."
-    echo "Root is $AOSP_TOOLCHAIN_ROOT"
+if [ ! -d "$ANDROID_TOOLCHAIN" ]; then
+    echo "ERROR: ANDROID_TOOLCHAIN is not a valid path. Please set it."
+    echo "Path is $ANDROID_TOOLCHAIN"
     [ "$0" = "${BASH_SOURCE[0]}" ] && exit 1 || return 1
 fi
 
 # Error checking
-if [ ! -d "$AOSP_TOOLCHAIN_PATH" ]; then
-    echo "ERROR: AOSP_TOOLCHAIN_PATH is not a valid path. Please set it."
-    echo "Path is $AOSP_TOOLCHAIN_PATH"
-    [ "$0" = "${BASH_SOURCE[0]}" ] && exit 1 || return 1
-fi
-
-# Error checking
-if [ ! -d "$AOSP_SYSROOT" ]; then
-    echo "ERROR: AOSP_SYSROOT is not a valid path. Please set it."
-    echo "Path is $AOSP_SYSROOT"
+if [ ! -d "$ANDROID_SYSROOT" ]; then
+    echo "ERROR: ANDROID_SYSROOT is not a valid path. Please set it."
+    echo "Path is $ANDROID_SYSROOT"
     [ "$0" = "${BASH_SOURCE[0]}" ] && exit 1 || return 1
 fi
 
 #####################################################################
 
-AOSP_CPU=$(tr '[:upper:]' '[:lower:]' <<< "$ANDROID_CPU")
+THE_ARCH=$(tr '[:upper:]' '[:lower:]' <<< "$ANDROID_CPU")
 
 # https://developer.android.com/ndk/guides/abis.html
-case "$AOSP_CPU" in
-  armeabi|armv7a|armv7-a|armeabi-v7a)
+case "$THE_ARCH" in
+  armv7*|armeabi*)
     CC="armv7a-linux-androideabi$ANDROID_API-clang"
     CXX="armv7a-linux-androideabi$ANDROID_API-clang++"
     LD="arm-linux-androideabi-ld"
@@ -65,7 +84,7 @@ case "$AOSP_CPU" in
     CXXFLAGS="-march=armv7-a -mthumb -mfloat-abi=softfp -funwind-tables -fexceptions -frtti"
     ;;
 
-  armv8|armv8a|aarch64|arm64|arm64-v8a)
+  armv8*|aarch64|arm64)
     CC="aarch64-linux-android$ANDROID_API-clang"
     CXX="aarch64-linux-android$ANDROID_API-clang++"
     LD="aarch64-linux-android-ld"
@@ -108,66 +127,67 @@ case "$AOSP_CPU" in
     echo "ERROR: Unknown architecture $ANDROID_CPU"
     [ "$0" = "${BASH_SOURCE[0]}" ] && exit 1 || return 1
     ;;
-
 esac
 
 #####################################################################
 
 # Error checking
-if [ ! -e "$AOSP_TOOLCHAIN_PATH/$CC" ]; then
+if [ ! -e "$ANDROID_TOOLCHAIN/$CC" ]; then
     echo "ERROR: Failed to find Android clang. Please edit this script."
     [ "$0" = "${BASH_SOURCE[0]}" ] && exit 1 || return 1
 fi
 
 # Error checking
-if [ ! -e "$AOSP_TOOLCHAIN_PATH/$CXX" ]; then
+if [ ! -e "$ANDROID_TOOLCHAIN/$CXX" ]; then
     echo "ERROR: Failed to find Android clang++. Please edit this script."
     [ "$0" = "${BASH_SOURCE[0]}" ] && exit 1 || return 1
 fi
 
 # Error checking
-if [ ! -e "$AOSP_TOOLCHAIN_PATH/$RANLIB" ]; then
+if [ ! -e "$ANDROID_TOOLCHAIN/$RANLIB" ]; then
     echo "ERROR: Failed to find Android ranlib. Please edit this script."
     [ "$0" = "${BASH_SOURCE[0]}" ] && exit 1 || return 1
 fi
 
 # Error checking
-if [ ! -e "$AOSP_TOOLCHAIN_PATH/$AR" ]; then
+if [ ! -e "$ANDROID_TOOLCHAIN/$AR" ]; then
     echo "ERROR: Failed to find Android ar. Please edit this script."
     [ "$0" = "${BASH_SOURCE[0]}" ] && exit 1 || return 1
 fi
 
 # Error checking
-if [ ! -e "$AOSP_TOOLCHAIN_PATH/$AS" ]; then
+if [ ! -e "$ANDROID_TOOLCHAIN/$AS" ]; then
     echo "ERROR: Failed to find Android as. Please edit this script."
     [ "$0" = "${BASH_SOURCE[0]}" ] && exit 1 || return 1
 fi
 
 # Error checking
-if [ ! -e "$AOSP_TOOLCHAIN_PATH/$LD" ]; then
+if [ ! -e "$ANDROID_TOOLCHAIN/$LD" ]; then
     echo "ERROR: Failed to find Android ld. Please edit this script."
     [ "$0" = "${BASH_SOURCE[0]}" ] && exit 1 || return 1
 fi
 
 #####################################################################
 
-LENGTH=${#AOSP_TOOLCHAIN_PATH}
+LENGTH=${#ANDROID_TOOLCHAIN}
 SUBSTR=${PATH:0:$LENGTH}
-if [ "$SUBSTR" != "$AOSP_TOOLCHAIN_PATH" ]; then
-    export PATH="$AOSP_TOOLCHAIN_PATH:$PATH"
+if [ "$SUBSTR" != "$ANDROID_TOOLCHAIN" ]; then
+    export PATH="$ANDROID_TOOLCHAIN:$PATH"
 fi
 
 #####################################################################
 
 export CPP CC CXX LD AS AR RANLIB STRIP
 export ANDROID_SYSROOT="$AOSP_SYSROOT"
-export CFLAGS="-D__ANDROID_API__=$ANDROID_API $CFLAGS --sysroot=$AOSP_SYSROOT"
-export CXXFLAGS="-D__ANDROID_API__=$ANDROID_API $CXXFLAGS --sysroot=$AOSP_SYSROOT"
+export CPPFLAGS="-D__ANDROID_API__=$ANDROID_API"
+export CFLAGS="$CFLAGS --sysroot=$AOSP_SYSROOT"
+export CXXFLAGS="$CXXFLAGS -stdlib=libc++ --sysroot=$AOSP_SYSROOT"
 
 #####################################################################
 
-echo "AOSP_TOOLCHAIN_PATH: $AOSP_TOOLCHAIN_PATH"
+echo "ANDROID_TOOLCHAIN: $ANDROID_TOOLCHAIN"
 
+echo "CPP: $(command -v "$CPP")"
 echo "CC: $(command -v "$CC")"
 echo "CXX: $(command -v "$CXX")"
 echo "LD: $(command -v "$LD")"
@@ -176,6 +196,7 @@ echo "AR: $(command -v "$AR")"
 
 echo "ANDROID_SYSROOT: $ANDROID_SYSROOT"
 
+echo "CPPFLAGS: $CPPFLAGS"
 echo "CFLAGS: $CFLAGS"
 echo "CXXFLAGS: $CXXFLAGS"
 


### PR DESCRIPTION
This PR cleans up OpenSSL warnings when cross-compiling. It also uses the same `15-android.conf` and `setenv-android.sh` as Unbound.

OpenSSL has a penchant for ignoring user flags. When Travis jobs were added that used `ANDROID_API=23` (the minimum) it produced warnings like the following because OpenSSL stomped on Unbound's flags.

```
armv7a-linux-androideabi23-clang  -I. -Iinclude -fPIC -pthread -D__ANDROID_API__
=23 -march=armv7-a -mthumb -mfloat-abi=softfp -funwind-tables -fexceptions --sys
root=/home/travis/android-ndk/toolchains/llvm/prebuilt/linux-x86_64/sysroot -DOP
ENSSL_USE_NODELETE -DOPENSSL_PIC -DOPENSSLDIR="\"/home/travis/android23-armv7a\"
" -DENGINESDIR="\"/home/travis/android23-armv7a/lib/engines-1.1\"" -D__ANDROID_A
PI__=29 -DNDEBUG  -MMD -MF apps/app_rand.d.tmp -MT apps/app_rand.o -c -o apps/ap
p_rand.o apps/app_rand.c

In file included from <built-in>:374:
<command line>:6:9: warning: '__ANDROID_API__' macro redefined
      [-Wmacro-redefined]
#define __ANDROID_API__ 29
        ^
<command line>:1:9: note: previous definition is here
#define __ANDROID_API__ 23
        ^
```

The issue is cleared by removing the function `android_ndk` from `15-android.conf`.

A sample build with the noisy warnings is available [here](https://travis-ci.org/github/noloader/unbound/jobs/666678999)