### PR TITLE
KSK-2010 has been revoked

### DIFF
--- a/smallapp/unbound-anchor.c
+++ b/smallapp/unbound-anchor.c
@@ -246,9 +246,7 @@ get_builtin_ds(void)
 	return
 /* The anchors must start on a new line with ". IN DS and end with \n"[;]
  * because the makedist script greps on the source here */
-/* anchor 19036 is from 2010 */
 /* anchor 20326 is from 2017 */
-". IN DS 19036 8 2 49AAC11D7B6F6446702E54A1607371607A1A41855200FD2CE1CDDE32F24E8FB5\n"
 ". IN DS 20326 8 2 E06D44B80B8F1D39A95C0B0D7C65D08458E880409BBC683457104237C7F8EC8D\n";
 }
 


### PR DESCRIPTION
KSK-2010 is already revoked by ICANN: https://www.icann.org/news/blog/icann-is-revoking-the-old-key-signing-key-this-week