### PR TITLE
contrib/libunbound.pc.in: Do not use "Requires:"

### DIFF
--- a/contrib/libunbound.pc.in
+++ b/contrib/libunbound.pc.in
@@ -7,8 +7,7 @@ Name: unbound
 Description: Library with validating, recursive, and caching DNS resolver
 URL: http://www.unbound.net
 Version: @PACKAGE_VERSION@
-Requires: @PC_CRYPTO_DEPENDENCY@ @PC_LIBEVENT_DEPENDENCY@
-Requires.private: @PC_PY_DEPENDENCY@ @PC_LIBBSD_DEPENDENCY@
+Requires.private: @PC_PY_DEPENDENCY@ @PC_LIBBSD_DEPENDENCY@ @PC_CRYPTO_DEPENDENCY@ @PC_LIBEVENT_DEPENDENCY@
 Libs: -L${libdir} -lunbound
 Libs.private: @SSLLIB@ @LIBS@
 Cflags: -I${includedir}


### PR DESCRIPTION
This commit updates contrib/libunbound.pc.in to remove the "Requires:" directive and move its contents to "Requires.private:".

The pkg-config manpage documents the Requires/Libs fields as follows:

```
   Requires:
          This is a comma-separated list of packages that are required  by
          your package. Flags from dependent packages will be merged in to
          the flags reported for your package. Optionally, you can specify
          the  version  of the required package (using the operators =, <,
          >, >=, <=); specifying a version allows  pkg-config  to  perform
          extra  sanity  checks. You may only mention the same package one
          time on the Requires: line. If the version of a package  is  un‐
          specified, any version will be used with no checking.

   Requires.private:
          A list of packages required by this package. The difference from
          Requires is that the packages listed under Requires.private  are
          not  taken into account when a flag list is computed for dynami‐
          cally linked executable (i.e., when --static was not specified).
          In  the  situation where each .pc file corresponds to a library,
          Requires.private shall be used exclusively to specify the depen‐
          dencies between the libraries.

   Libs:  This  line  should give the link flags specific to your package.
          Don't add any flags for required packages; pkg-config  will  add
          those automatically.

   Libs.private:
          This line should list any private libraries in use.  Private li‐
          braries are libraries which are not  exposed  through  your  li‐
          brary,  but  are needed in the case of static linking. This dif‐
          fers from Requires.private in that it references libraries  that
          do not have package files installed.
```

In other words:

1) "Requires:" should specify the name of .pc packages that are required to be installed to compile and dynamically link against libunbound. This corresponds to needing the -dev (or -devel) package containing the .pc file to be installed on the system. Since libunbound's header files actually do not have any includes on any other library's headers, the "Requires:" directive should be empty.

2) "Requires.private:" specifies the name of .pc packages that correspond to libraries that are required to be installed to statically link against libunbound. E.g., if libunbound.a has undefined symbols event_* that are in libevent.a, statically linking against libunbound.a requires statically linking libevent.a, and because libevent has a .pc file, this means "libevent" should appear in libunbound.pc's "Requires.private:" directive.

3) "Libs:" specifies the link flags needed to link against libunbound, only, not including any dependencies.

4) "Libs.private:" specifies the link flags needed to statically link against libraries that libunbound depends on that do not have .pc files. I think it's possible for unbound's build system to actually declare link flags under "Libs.private:" for some libraries that do have .pc files (e.g. libcrypto/-lcrypto, libssl/-lssl, for OpenSSL) but in practice this appears to be harmless.

Given (1) above that libunbound does not have any header dependencies against any other packages it does not appear that "Requires:" is needed at all. See https://bugs.debian.org/958331 for an example of a bug report that this causes. We should not need to install the nettle-dev package only for building binaries that compile against the libunbound headers and link against the libunbound library.