### PR TITLE
Fix python module len() implementations

### DIFF
--- a/pythonmod/interface.i
+++ b/pythonmod/interface.i
@@ -314,16 +314,16 @@ struct packed_rrset_data {
     class RRSetData_RRLen:
         def __init__(self, obj): self.obj = obj
         def __getitem__(self, index): return _unboundmodule._get_data_rr_len(self.obj, index)
-        def __len__(self): return obj.count + obj.rrsig_count
+        def __len__(self): return self.obj.count + self.obj.rrsig_count
     class RRSetData_RRTTL:
         def __init__(self, obj): self.obj = obj
         def __getitem__(self, index): return _unboundmodule._get_data_rr_ttl(self.obj, index)
         def __setitem__(self, index, value): _unboundmodule._set_data_rr_ttl(self.obj, index, value)
-        def __len__(self): return obj.count + obj.rrsig_count
+        def __len__(self): return self.obj.count + self.obj.rrsig_count
     class RRSetData_RRData:
         def __init__(self, obj): self.obj = obj
         def __getitem__(self, index): return _unboundmodule._get_data_rr_data(self.obj, index)
-        def __len__(self): return obj.count + obj.rrsig_count
+        def __len__(self): return self.obj.count + self.obj.rrsig_count
 %}
 
 %inline %{
@@ -404,12 +404,12 @@ struct dns_msg {
     class ReplyInfo_RRSet:
         def __init__(self, obj): self.obj = obj
         def __getitem__(self, index): return _unboundmodule._rrset_rrsets_get(self.obj, index)
-        def __len__(self): return obj.rrset_count
+        def __len__(self): return self.obj.rrset_count
 
     class ReplyInfo_Ref:
         def __init__(self, obj): self.obj = obj
         def __getitem__(self, index): return _unboundmodule._rrset_ref_get(self.obj, index)
-        def __len__(self): return obj.rrset_count
+        def __len__(self): return self.obj.rrset_count
 %}
 
 %inline %{


### PR DESCRIPTION
They were all missing the `self.` prefix when accessing the `obj`
instance variable, causing the following exception when attempting to
call `len()` on (for example) a `ReplyInfo_RRSet`:

```
  File "/usr/lib/python3.7/site-packages/unboundmodule.py", line 377, in __len__
    def __len__(self): return obj.rrset_count
NameError: name 'obj' is not defined
```