### PR TITLE
munin plugin: always exit 0 in autoconf

### DIFF
--- a/contrib/unbound_munin_
+++ b/contrib/unbound_munin_
@@ -174,11 +174,11 @@ get_state ( ) {
 if test "$1" = "autoconf" ; then
 	if test ! -f $conf; then
 		echo no "($conf does not exist)"
-		exit 1
+		exit 0
 	fi
 	if test ! -d `dirname $state`; then
 		echo no "(`dirname $state` directory does not exist)"
-		exit 1
+		exit 0
 	fi
 	echo yes
 	exit 0


### PR DESCRIPTION
The autoconf operation should always exit 0, also in case the answer in "no",
see https://guide.munin-monitoring.org/en/latest/develop/plugins/plugin-concise.html#autoconf