### PR TITLE
net_help: Rename EVP_MAC_set_ctx_params to EVP_MAC_CTX_set_params

### DIFF
--- a/util/net_help.c
+++ b/util/net_help.c
@@ -1478,7 +1478,7 @@ int tls_session_ticket_key_cb(SSL *ATTR_UNUSED(sslctx), unsigned char* key_name,
 		params[1] = OSSL_PARAM_construct_utf8_string(OSSL_MAC_PARAM_DIGEST,
 			"sha256", 0);
 		params[2] = OSSL_PARAM_construct_end();
-		EVP_MAC_set_ctx_params(hmac_ctx, params);
+		EVP_MAC_CTX_set_params(hmac_ctx, params);
 #elif !defined(HMAC_INIT_EX_RETURNS_VOID)
 		if (HMAC_Init_ex(hmac_ctx, ticket_keys->hmac_key, 32, digest, NULL) != 1) {
 			verbose(VERB_CLIENT, "HMAC_Init_ex failed");
@@ -1509,7 +1509,7 @@ int tls_session_ticket_key_cb(SSL *ATTR_UNUSED(sslctx), unsigned char* key_name,
 		params[1] = OSSL_PARAM_construct_utf8_string(OSSL_MAC_PARAM_DIGEST,
 			"sha256", 0);
 		params[2] = OSSL_PARAM_construct_end();
-		EVP_MAC_set_ctx_params(hmac_ctx, params);
+		EVP_MAC_CTX_set_params(hmac_ctx, params);
 #elif !defined(HMAC_INIT_EX_RETURNS_VOID)
 		if (HMAC_Init_ex(hmac_ctx, key->hmac_key, 32, digest, NULL) != 1) {
 			verbose(VERB_CLIENT, "HMAC_Init_ex failed");


### PR DESCRIPTION
This fixes build with OpenSSL 3.0.0 Alpha 5.
EVP_MAC_set_ctx_params got renamed back to EVP_MAC_CTX_set_params
in https://github.com/openssl/openssl/pull/12186