### PR TITLE
Make tvOS & watchOS checks verify truthiness as well as definedness.

### DIFF
--- a/daemon/unbound.c
+++ b/daemon/unbound.c
@@ -92,7 +92,7 @@
 #include <TargetConditionals.h>
 #endif
 
-#if defined(TARGET_OS_TV) || defined(TARGET_OS_WATCH)
+#if (defined(TARGET_OS_TV) && TARGET_OS_TV) || (defined(TARGET_OS_WATCH) && TARGET_OS_WATCH)
 #undef HAVE_FORK
 #endif
 

--- a/libunbound/libworker.c
+++ b/libunbound/libworker.c
@@ -78,7 +78,7 @@
 #include <TargetConditionals.h>
 #endif
 
-#if defined(TARGET_OS_TV) || defined(TARGET_OS_WATCH)
+#if (defined(TARGET_OS_TV) && TARGET_OS_TV) || (defined(TARGET_OS_WATCH) && TARGET_OS_WATCH)
 #undef HAVE_FORK
 #endif
 

--- a/smallapp/unbound-control.c
+++ b/smallapp/unbound-control.c
@@ -886,7 +886,7 @@ int main(int argc, char* argv[])
 	if(argc == 0)
 		usage();
 	if(argc >= 1 && strcmp(argv[0], "start")==0) {
-#if defined(TARGET_OS_TV) || defined(TARGET_OS_WATCH)
+#if (defined(TARGET_OS_TV) && TARGET_OS_TV) || (defined(TARGET_OS_WATCH) && TARGET_OS_WATCH)
 		fatal_exit("could not exec unbound: %s",
 			strerror(ENOSYS));
 #else


### PR DESCRIPTION
This fixes issue #279.