### PR TITLE
Add missing prototype.

### DIFF
--- a/services/listen_dnsport.h
+++ b/services/listen_dnsport.h
@@ -384,5 +384,6 @@ size_t tcp_req_info_get_stream_buffer_size(void);
 
 char* set_ip_dscp(int socket, int addrfamily, int ds);
 char* sock_strerror(int errn);
+void sock_close(int socket);
 
 #endif /* LISTEN_DNSPORT_H */


### PR DESCRIPTION
sock_close() is currently unused so it might be better to remove the function in listen_dnsport.c