### PR TITLE
Add modern X.509v3 extensions to unbound-control TLS certificates

### DIFF
--- a/smallapp/unbound-control-setup.sh.in
+++ b/smallapp/unbound-control-setup.sh.in
@@ -124,8 +124,14 @@ default_bits=$BITS
 default_md=$HASH
 prompt=no
 distinguished_name=req_distinguished_name
+x509_extensions=v3_ca
 [req_distinguished_name]
 commonName=$SERVERNAME
+[v3_ca]
+subjectKeyIdentifier=hash
+authorityKeyIdentifier=keyid:always,issuer:always
+basicConstraints=critical,CA:TRUE,pathlen:0
+subjectAltName=DNS:$SERVERNAME
 EOF
 
 [ -f server.cnf ] || fatal "cannot create openssl configuration"
@@ -156,8 +162,12 @@ default_bits=$BITS
 default_md=$HASH
 prompt=no
 distinguished_name=req_distinguished_name
+req_extensions=v3_req
 [req_distinguished_name]
 commonName=$CLIENTNAME
+[v3_req]
+basicConstraints=critical,CA:FALSE
+subjectAltName=DNS:$CLIENTNAME
 EOF
 
 [ -f client.cnf ] || fatal "cannot create openssl configuration"


### PR DESCRIPTION
Fixes #316 

Add modern X.509v3 extensions to the TLS certificates generated by unbound-control-setup. This is required by certain modern TLS clients, including unbound_exporter for Prometheus when using Golang 1.15+.

Tested with OpenSSL 1.0.2k (CentOS 7) and 1.1.1c (CentOS 8).

Many thanks to @bastelfreak for identifying the problem and starting a patch.