### PR TITLE
If upstream responds with NOTIMPL we do not "throwaway" the request; meaning go to the next available resolver until nothing else is available, finally responding with a SERVFAIL if all servers fail to respond

### DIFF
--- a/iterator/iter_resptype.c
+++ b/iterator/iter_resptype.c
@@ -134,7 +134,7 @@ response_type_from_server(int rdset,
 	
 	/* Other response codes mean (so far) to throw the response away as
 	 * meaningless and move on to the next nameserver. */
-	if(FLAGS_GET_RCODE(msg->rep->flags) != LDNS_RCODE_NOERROR && FLAGS_GET_RCODE(msg->rep->flags) != LDNS_RCODE_NOTIMP)
+	if(FLAGS_GET_RCODE(msg->rep->flags) != LDNS_RCODE_NOERROR && FLAGS_GET_RCODE(msg->rep->flags) != LDNS_RCODE_NOTIMPL)
 		return RESPONSE_TYPE_THROWAWAY;
 
 	/* Note: TC bit has already been handled */

--- a/iterator/iter_resptype.c
+++ b/iterator/iter_resptype.c
@@ -134,7 +134,7 @@ response_type_from_server(int rdset,
 	
 	/* Other response codes mean (so far) to throw the response away as
 	 * meaningless and move on to the next nameserver. */
-	if(FLAGS_GET_RCODE(msg->rep->flags) != LDNS_RCODE_NOERROR)
+	if(FLAGS_GET_RCODE(msg->rep->flags) != LDNS_RCODE_NOERROR && FLAGS_GET_RCODE(msg->rep->flags) != LDNS_RCODE_NOTIMP)
 		return RESPONSE_TYPE_THROWAWAY;
 
 	/* Note: TC bit has already been handled */


### PR DESCRIPTION
If upstream responds with `NOTIMPL` we do not "throwaway" the request; meaning go to the next available resolver until nothing else is available, finally responding with a `SERVFAIL` if all servers fail to respond.  

This PR, checks that if the rcode from the resolvers is not `NOERROR` or `NOTIMPL` then we are a valid response, and to stop attempting to iterate to the next resolver.

## Issue

Local Resolver (Forwarding to upstream resolvers)

```bash
$ dig @localhost example.com ANY

; <<>> DiG 9.10.6 <<>> @localhost example.com ANY
; (2 servers found)
;; global options: +cmd
;; Got answer:
;; ->>HEADER<<- opcode: QUERY, status: SERVFAIL, id: 61786
;; flags: qr rd ra; QUERY: 1, ANSWER: 0, AUTHORITY: 0, ADDITIONAL: 1

;; OPT PSEUDOSECTION:
; EDNS: version: 0, flags:; udp: 4096
;; QUESTION SECTION:
;example.com.			IN	ANY
```

## Non-Issue Resolvers

OpenDNS responds with `NOTIMPL` when querying the resolver directly.

```bash
$ dig @208.67.220.220 example.com ANY

; <<>> DiG 9.10.6 <<>> @208.67.220.220 example.com ANY
; (1 server found)
;; global options: +cmd
;; Got answer:
;; ->>HEADER<<- opcode: QUERY, status: NOTIMP, id: 7892
;; flags: qr rd ra; QUERY: 1, ANSWER: 0, AUTHORITY: 0, ADDITIONAL: 1

;; OPT PSEUDOSECTION:
; EDNS: version: 0, flags:; udp: 4096
;; QUESTION SECTION:
;example.com.			IN	ANY

;; Query time: 233 msec
;; SERVER: 208.67.220.220#53(208.67.220.220)
;; WHEN: Tue Dec 15 13:54:44 PST 2020
;; MSG SIZE  rcvd: 40
```

Cloudflare responds with `NOTIMP` when querying the resolver directly.

```bash
$ dig @1.1.1.1 example.com ANY

; <<>> DiG 9.10.6 <<>> @1.1.1.1 example.com ANY
; (1 server found)
;; global options: +cmd
;; Got answer:
;; ->>HEADER<<- opcode: QUERY, status: NOTIMP, id: 54467
;; flags: qr rd ra; QUERY: 1, ANSWER: 0, AUTHORITY: 0, ADDITIONAL: 1

;; OPT PSEUDOSECTION:
; EDNS: version: 0, flags:; udp: 1232
;; QUESTION SECTION:
;example.com.			IN	ANY
```