### PR TITLE
add missing null check

### DIFF
--- a/util/netevent.c
+++ b/util/netevent.c
@@ -388,8 +388,9 @@ comm_point_send_udp_msg(struct comm_point *c, sldns_buffer* packet,
 		} else {
 			verbose(VERB_OPS, "send failed: %s", sock_strerror(errno));
 		}
-		log_addr(VERB_OPS, "remote address is",
-			(struct sockaddr_storage*)addr, addrlen);
+		if(addr)
+			log_addr(VERB_OPS, "remote address is",
+				(struct sockaddr_storage*)addr, addrlen);
 		return 0;
 	} else if((size_t)sent != sldns_buffer_remaining(packet)) {
 		log_err("sent %d in place of %d bytes", 


### PR DESCRIPTION
I have a unbound forward zone configured on my router for my $DAYJOB.
The address associated with the zone is only accessible when the router
is connected to a VPN. If the VPN connection is absent, trying to
resolve any domain that must be handled by the zone crashes unbound.
Turns out there's a missing NULL check in `comm_point_send_udp_msg()`.
The same routine already has `if (addr) {} else {}` branches so I guess
protecting the call to `log_addr()` using the same conditional is
reasonable

I have also committed the same fix to unbound shipped with OpenBSD[1].

[1] https://marc.info/?l=openbsd-cvs&m=160993335615698&w=2