### PR TITLE
Revert "- Fix the relationship between serve-expired and prefetch opt…

### DIFF
--- a/daemon/worker.c
+++ b/daemon/worker.c
@@ -1487,11 +1487,9 @@ lookup_cache:
 				 * Note that if there is more than one pass
 				 * its qname must be that used for cache
 				 * lookup. */
-				if((worker->env.cfg->prefetch && *worker->env.now >=
-							((struct reply_info*)e->data)->prefetch_ttl) ||
-						(worker->env.cfg->serve_expired &&
-						*worker->env.now >= ((struct reply_info*)e->data)->ttl)) {
-
+				if((worker->env.cfg->prefetch || worker->env.cfg->serve_expired)
+					&& *worker->env.now >=
+					((struct reply_info*)e->data)->prefetch_ttl) {
 					time_t leeway = ((struct reply_info*)e->
 						data)->ttl - *worker->env.now;
 					if(((struct reply_info*)e->data)->ttl


### PR DESCRIPTION
…ions,"

This reverts commit a8db52120b3d3ac078601ed875e8eac92bbbae65.

I am not quite sure of the rationale for the previous patch, but with it applied what I see is that when an expired entry is fetched from the cache the prefetch routine `reply_and_prefetch` is called. When this happens a response is returned to the client, however, the current cache entry is blacklisted. This makes the cache unusable until a response is fetched from the authoritative server.

Since the authoritative server can be down or slow, we would want to serve the stale response while this happens, and with this commit reverted that's exactly what I see.

Again, I don't know what this commit attempted to solve but the serve expired feature seems to work better without it.

Addresses #394 