### PR TITLE
The lock of  lruhash table should unlocked after markdel entry

### DIFF
--- a/util/storage/lruhash.c
+++ b/util/storage/lruhash.c
@@ -398,13 +398,13 @@ lruhash_remove(struct lruhash* table, hashvalue_type hash, void* key)
 		return;
 	}
 	table->num--;
-	table->space_used -= (*table->sizefunc)(entry->key, entry->data);
-	lock_quick_unlock(&table->lock);
+	table->space_used -= (*table->sizefunc)(entry->key, entry->data);	
 	lock_rw_wrlock(&entry->lock);
 	if(table->markdelfunc)
 		(*table->markdelfunc)(entry->key);
 	lock_rw_unlock(&entry->lock);
 	lock_quick_unlock(&bin->lock);
+	lock_quick_unlock(&table->lock);
 	/* finish removal */
 	d = entry->data;
 	(*table->delkeyfunc)(entry->key, table->cb_arg);


### PR DESCRIPTION
…hen lru_remove the entry , then unlock the table, and then markdel entry , but in function rrset_cache_touch , the entry will be touched to lru again before markdelling entry in function lruhash_remove. This is a bug!