### PR TITLE
Fix TTL of SOA record for negative answers

### DIFF
--- a/doc/Changelog
+++ b/doc/Changelog
@@ -1,3 +1,7 @@
+22 January 2021: George
+	- Fix TTL of SOA record for negative answers (localzone and
+	  authzone data) to be the minimum of the SOA TTL and the SOA.MINIMUM.
+
 18 January 2021: Wouter
 	- Fix #404: DNS query with small edns bufsize fail.
 	- Fix declaration before statement and signed comparison warning in

--- a/services/localzone.c
+++ b/services/localzone.c
@@ -494,12 +494,12 @@ lz_mark_soa_for_zone(struct local_zone* z, struct ub_packed_rrset_key* soa_rrset
 	if(!rrset_insert_rr(z->region, pd, rdata, rdata_len, ttl, rrstr))
 		return 0;
 	/* last 4 bytes are minimum ttl in network format */
-	if(pd->count == 0 || pd->rr_len[0] < 2+4) {
+	if(pd->count == 0 || pd->rr_len[0] < 2+4)
 		return 0;
-	}
 	minimum = (time_t)sldns_read_uint32(pd->rr_data[0]+(pd->rr_len[0]-4));
-	pd->ttl = ttl<minimum?ttl:minimum;
-	pd->rr_ttl[0] = pd->ttl;
+	minimum = ttl<minimum?ttl:minimum;
+	pd->ttl = minimum;
+	pd->rr_ttl[0] = minimum;
 
 	z->soa_negative = rrset_negative;
 	return 1;

--- a/services/localzone.h
+++ b/services/localzone.h
@@ -158,6 +158,10 @@ struct local_zone {
 	rbtree_type data;
 	/** if data contains zone apex SOA data, this is a ptr to it. */
 	struct ub_packed_rrset_key* soa;
+	/** if data contains zone apex SOA data, this is a prt to an
+	 * artificial negative SOA rrset (TTL is the minimum of the TTL and the
+	 * SOA.MINIMUM). */
+	struct ub_packed_rrset_key* soa_negative;
 };
 
 /**

--- a/testdata/auth_zonefile_down.rpl
+++ b/testdata/auth_zonefile_down.rpl
@@ -1,6 +1,12 @@
 ; config options
 server:
 	target-fetch-policy: "0 0 0 0 0"
+	; Options for singed zone. The zone is partially copied from val_negcache_nxdomain.rpl
+	trust-anchor: "testzone.nlnetlabs.nl.	IN	DS	2926 8 2 6f8512d1e82eecbd684fc4a76f39f8c5b411af385494873bdead663ddb78a88b"
+	val-override-date: "20180213111425"
+	qname-minimisation: "no"
+	trust-anchor-signaling: no
+	aggressive-nsec: yes
 
 auth-zone:
 	name: "example.com."
@@ -41,6 +47,50 @@ ns1	3600	IN	A	1.2.3.4
 ns2	3600	IN	AAAA	::2
 TEMPFILE_END
 
+auth-zone:
+	name: "soa.high.com."
+	for-downstream: yes
+	for-upstream: no
+	zonefile:
+TEMPFILE_NAME soa.high.com
+TEMPFILE_CONTENTS soa.high.com
+$ORIGIN high.com.
+soa	500	IN	SOA	dns.example.de. hostmaster.dns.example.de. (
+		1379078166 28800 7200 604800 200 )
+	3600	IN	NS	ns1.example.com.
+	3600	IN	NS	ns2.example.com.
+TEMPFILE_END
+
+auth-zone:
+	name: "soa.low.com."
+	for-downstream: yes
+	for-upstream: no
+	zonefile:
+TEMPFILE_NAME soa.low.com
+TEMPFILE_CONTENTS soa.low.com
+$ORIGIN low.com.
+soa	200	IN	SOA	dns.example.de. hostmaster.dns.example.de. (
+		1379078166 28800 7200 604800 500 )
+	3600	IN	NS	ns1.example.com.
+	3600	IN	NS	ns2.example.com.
+TEMPFILE_END
+
+auth-zone:
+	name: "testzone.nlnetlabs.nl."
+	for-downstream: yes
+	for-upstream: no
+	zonefile:
+TEMPFILE_NAME testzone.nlnetlabs.nl
+TEMPFILE_CONTENTS testzone.nlnetlabs.nl
+$ORIGIN testzone.nlnetlabs.nl.
+testzone.nlnetlabs.nl.  3600    IN      NSEC    alligator.testzone.nlnetlabs.nl. NS SOA RRSIG NSEC DNSKEY
+testzone.nlnetlabs.nl.  3600    IN      RRSIG   NSEC 8 3 3600 20180313102201 20180213102201 44940 testzone.nlnetlabs.nl. gTKn6U1nal9oA79IRxLa/7zexl6A0yJZzeEGBbZ5rh5feyAr2X4LTR9bPCgcHeMVggf4FP+kD1L/sxzj/YLwB1ZKGKlwnzsHtPFTlmvDClaqQ76DRZq5Vejr2ZfnclBUb2vtxaXywTRW8oueaaq9flcShEQ/cQ+KRU8sc344qd0=
+alligator.testzone.nlnetlabs.nl.        3600    IN      NSEC    cheetah.testzone.nlnetlabs.nl. TXT RRSIG NSEC
+alligator.testzone.nlnetlabs.nl.        3600    IN      RRSIG   NSEC 8 4 3600 20180313102201 20180213102201 44940 testzone.nlnetlabs.nl. QAgQ0AsMoYG02+VPfoOctSPlTHdQOkQt5fFkSkzIbVhUzNOqa+dB/Qkc81AwFeJosA+PvYjt6utcVkIWmK2Djy9eXC49gILtVF79vUe4G7ZrybO5NXjqNa5ANoUGM+yew4wkjeNOMVAsvs+1kvFY7S8RAa/0AIYlZHQ8vNBPNaI=
+testzone.nlnetlabs.nl.  4600    IN      SOA     ns.nlnetlabs.nl. ralph.nlnetlabs.nl. 1 14400 3600 604800 3600
+testzone.nlnetlabs.nl.  4600    IN      RRSIG   SOA 8 3 3600 20180313102201 20180213102201 44940 testzone.nlnetlabs.nl. GhmXNFQktZIgaBpGKwj9Q2mfq5+jcbRPK+PPgtRVicUPZga/d/iGEL8PV/8DzGwkaZbM14pamSUMgdJibW4zNhLz/ukjPilbjoj6giH1jtbdZLAQ6iK9pZ/4jKUEq4txviTczZNnDeolgPEEl4xo4NclQmi7zj1XBlQRbjvG0/0=
+TEMPFILE_END
+
 stub-zone:
 	name: "."
 	stub-addr: 193.0.14.129 	# K.ROOT-SERVERS.NET.
@@ -50,7 +100,7 @@ SCENARIO_BEGIN Test authority zone with zonefile for downstream responses
 
 ; K.ROOT-SERVERS.NET.
 RANGE_BEGIN 0 100
-	ADDRESS 193.0.14.129 
+	ADDRESS 193.0.14.129
 ENTRY_BEGIN
 MATCH opcode qtype qname
 ADJUST copy_id
@@ -180,6 +230,111 @@ SECTION QUESTION
 www.example.com. IN A
 SECTION ANSWER
 www.example.com. IN A	1.2.3.4
+ENTRY_END
+
+; check SOA TTL to be the minimum of the SOA.minimum and the SOA TTL
+STEP 30 QUERY
+ENTRY_BEGIN
+REPLY RD
+SECTION QUESTION
+nonexistent.soa.high.com. IN A
+ENTRY_END
+STEP 31 CHECK_ANSWER
+ENTRY_BEGIN
+MATCH all ttl
+REPLY QR RD RA AA NXDOMAIN
+SECTION QUESTION
+nonexistent.soa.high.com IN A
+SECTION AUTHORITY
+soa.high.com. 200 IN SOA dns.example.de. hostmaster.dns.example.de. 1379078166 28800 7200 604800 200
+ENTRY_END
+; check that the original SOA is also returned
+STEP 32 QUERY
+ENTRY_BEGIN
+REPLY RD
+SECTION QUESTION
+soa.high.com. IN SOA
+ENTRY_END
+STEP 33 CHECK_ANSWER
+ENTRY_BEGIN
+MATCH all ttl
+REPLY QR RD RA AA NOERROR
+SECTION QUESTION
+soa.high.com. IN SOA
+SECTION ANSWER
+soa.high.com. 500 IN SOA dns.example.de. hostmaster.dns.example.de. 1379078166 28800 7200 604800 200
+ENTRY_END
+
+; check SOA TTL to be the minimum of the SOA.minimum and the SOA TTL
+STEP 40 QUERY
+ENTRY_BEGIN
+REPLY RD
+SECTION QUESTION
+nonexistent.soa.low.com. IN A
+ENTRY_END
+STEP 41 CHECK_ANSWER
+ENTRY_BEGIN
+MATCH all ttl
+REPLY QR RD RA AA NXDOMAIN
+SECTION QUESTION
+nonexistent.soa.low.com. IN A
+SECTION AUTHORITY
+soa.low.com. 200 IN SOA dns.example.de. hostmaster.dns.example.de. 1379078166 28800 7200 604800 500
+ENTRY_END
+; check that the original SOA is also returned
+STEP 42 QUERY
+ENTRY_BEGIN
+REPLY RD
+SECTION QUESTION
+soa.low.com. IN SOA
+ENTRY_END
+STEP 43 CHECK_ANSWER
+ENTRY_BEGIN
+MATCH all ttl
+REPLY QR RD RA AA NOERROR
+SECTION QUESTION
+soa.low.com. IN SOA
+SECTION ANSWER
+soa.low.com. 200 IN SOA dns.example.de. hostmaster.dns.example.de. 1379078166 28800 7200 604800 500
+ENTRY_END
+
+; check SOA TTL to be minimum of the SOA.minimum and the SOA TTL for DNSSEC
+STEP 50 QUERY
+ENTRY_BEGIN
+REPLY RD DO
+SECTION QUESTION
+ant.testzone.nlnetlabs.nl. IN A
+ENTRY_END
+STEP 51 CHECK_ANSWER
+ENTRY_BEGIN
+MATCH all ttl
+REPLY QR RD DO RA AA NXDOMAIN
+SECTION QUESTION
+ant.testzone.nlnetlabs.nl. IN A
+SECTION AUTHORITY
+testzone.nlnetlabs.nl.  3600    IN      SOA     ns.nlnetlabs.nl. ralph.nlnetlabs.nl. 1 14400 3600 604800 3600
+testzone.nlnetlabs.nl.  3600    IN      RRSIG   SOA 8 3 3600 20180313102201 20180213102201 44940 testzone.nlnetlabs.nl. GhmXNFQktZIgaBpGKwj9Q2mfq5+jcbRPK+PPgtRVicUPZga/d/iGEL8PV/8DzGwkaZbM14pamSUMgdJibW4zNhLz/ukjPilbjoj6giH1jtbdZLAQ6iK9pZ/4jKUEq4txviTczZNnDeolgPEEl4xo4NclQmi7zj1XBlQRbjvG0/0=
+alligator.testzone.nlnetlabs.nl.        3600    IN      NSEC    cheetah.testzone.nlnetlabs.nl. TXT RRSIG NSEC
+alligator.testzone.nlnetlabs.nl.        3600    IN      RRSIG   NSEC 8 4 3600 20180313102201 20180213102201 44940 testzone.nlnetlabs.nl. QAgQ0AsMoYG02+VPfoOctSPlTHdQOkQt5fFkSkzIbVhUzNOqa+dB/Qkc81AwFeJosA+PvYjt6utcVkIWmK2Djy9eXC49gILtVF79vUe4G7ZrybO5NXjqNa5ANoUGM+yew4wkjeNOMVAsvs+1kvFY7S8RAa/0AIYlZHQ8vNBPNaI=
+testzone.nlnetlabs.nl.  3600    IN      NSEC    alligator.testzone.nlnetlabs.nl. NS SOA RRSIG NSEC DNSKEY
+testzone.nlnetlabs.nl.  3600    IN      RRSIG   NSEC 8 3 3600 20180313102201 20180213102201 44940 testzone.nlnetlabs.nl. gTKn6U1nal9oA79IRxLa/7zexl6A0yJZzeEGBbZ5rh5feyAr2X4LTR9bPCgcHeMVggf4FP+kD1L/sxzj/YLwB1ZKGKlwnzsHtPFTlmvDClaqQ76DRZq5Vejr2ZfnclBUb2vtxaXywTRW8oueaaq9flcShEQ/cQ+KRU8sc344qd0=
+ENTRY_END
+; check that the original SOA is also returned
+STEP 52 QUERY
+ENTRY_BEGIN
+REPLY RD DO
+SECTION QUESTION
+testzone.nlnetlabs.nl. IN SOA
+ENTRY_END
+STEP 53 CHECK_ANSWER
+ENTRY_BEGIN
+MATCH all ttl
+REPLY QR RD DO RA AA NOERROR
+SECTION QUESTION
+testzone.nlnetlabs.nl. IN SOA
+SECTION ANSWER
+testzone.nlnetlabs.nl.  4600    IN      SOA     ns.nlnetlabs.nl. ralph.nlnetlabs.nl. 1 14400 3600 604800 3600
+testzone.nlnetlabs.nl.  4600    IN      RRSIG   SOA 8 3 3600 20180313102201 20180213102201 44940 testzone.nlnetlabs.nl. GhmXNFQktZIgaBpGKwj9Q2mfq5+jcbRPK+PPgtRVicUPZga/d/iGEL8PV/8DzGwkaZbM14pamSUMgdJibW4zNhLz/ukjPilbjoj6giH1jtbdZLAQ6iK9pZ/4jKUEq4txviTczZNnDeolgPEEl4xo4NclQmi7zj1XBlQRbjvG0/0=
 ENTRY_END
 
 SCENARIO_END

--- a/testdata/auth_zonefile_down.rpl
+++ b/testdata/auth_zonefile_down.rpl
@@ -1,7 +1,7 @@
 ; config options
 server:
 	target-fetch-policy: "0 0 0 0 0"
-	; Options for singed zone. The zone is partially copied from val_negcache_nxdomain.rpl
+	; Options for signed zone. The zone is partially copied from val_negcache_nxdomain.rpl
 	trust-anchor: "testzone.nlnetlabs.nl.	IN	DS	2926 8 2 6f8512d1e82eecbd684fc4a76f39f8c5b411af385494873bdead663ddb78a88b"
 	val-override-date: "20180213111425"
 	qname-minimisation: "no"

--- a/testdata/localdata.rpl
+++ b/testdata/localdata.rpl
@@ -88,12 +88,12 @@ local. IN A
 ENTRY_END
 STEP 6 CHECK_ANSWER
 ENTRY_BEGIN
-MATCH all
+MATCH all ttl
 REPLY QR RA AA
 SECTION QUESTION
 local. IN A
 SECTION AUTHORITY
-local. 3600 IN SOA nobody nobody 1 2 3 4 5
+local. 5 IN SOA nobody nobody 1 2 3 4 5
 ENTRY_END
 
 ; positive SOA
@@ -104,7 +104,7 @@ local. IN SOA
 ENTRY_END
 STEP 8 CHECK_ANSWER
 ENTRY_BEGIN
-MATCH all
+MATCH all ttl
 REPLY QR RA AA
 SECTION QUESTION
 local. IN SOA
@@ -136,12 +136,12 @@ serv.local. IN MX
 ENTRY_END
 STEP 12 CHECK_ANSWER
 ENTRY_BEGIN
-MATCH all
+MATCH all ttl
 REPLY QR RA AA
 SECTION QUESTION
 serv.local. IN MX
 SECTION AUTHORITY
-local. 3600 IN SOA nobody nobody 1 2 3 4 5
+local. 5 IN SOA nobody nobody 1 2 3 4 5
 ENTRY_END
 
 ; no such type, empty nonterminal
@@ -152,12 +152,12 @@ bla.local. IN MX
 ENTRY_END
 STEP 14 CHECK_ANSWER
 ENTRY_BEGIN
-MATCH all
+MATCH all ttl
 REPLY QR RA AA
 SECTION QUESTION
 bla.local. IN MX
 SECTION AUTHORITY
-local. 3600 IN SOA nobody nobody 1 2 3 4 5
+local. 5 IN SOA nobody nobody 1 2 3 4 5
 ENTRY_END
 
 ; nxdomain with SOA
@@ -168,12 +168,12 @@ doing.local. IN MX
 ENTRY_END
 STEP 16 CHECK_ANSWER
 ENTRY_BEGIN
-MATCH all
+MATCH all ttl
 REPLY QR RA AA NXDOMAIN
 SECTION QUESTION
 doing.local. IN MX
 SECTION AUTHORITY
-local. 3600 IN SOA nobody nobody 1 2 3 4 5
+local. 5 IN SOA nobody nobody 1 2 3 4 5
 ENTRY_END
 
 ; nxdomain without SOA


### PR DESCRIPTION
This affects localzone and authzone data. The TTL is now the minimum of the SOA TTL and the SOA.MINIMUM.