### PR TITLE
Prevent a few more yacc clashes.

### DIFF
--- a/util/configyyrename.h
+++ b/util/configyyrename.h
@@ -84,5 +84,11 @@
 #define yyget_leng ub_c_get_leng
 #define yylineno ub_c_lineno
 #define yyget_text ub_c_get_text
+#define yyss    ub_c_ss
+#define yysslim ub_c_sslim
+#define yyssp   ub_c_ssp
+#define yystacksize ub_c_stacksize
+#define yyvs    ub_c_vs
+#define yyvsp   ub_c_vsp
 
 #endif /* UTIL_CONFIGYYRENAME_H */


### PR DESCRIPTION
I think these might cause problems when using libunbound in a program that itself uses yacc and compiling with -fno-common.
I spotted it in unwind(8) when trying to make it clang11 ready which has -fno-common on by default.
unwind link in libunbound statically and has its own peculiar make system so this might be self-inflicted or not
actually happing for other libunbound users.
In any case it would be appreciated if this could be merged, it will make my life easier and shouldn't cause harm for unbound.