### PR TITLE
Use /proc/sys/net/ipv4/ip_local_port_range to determine available outgoing ports

### DIFF
--- a/util/config_file.c
+++ b/util/config_file.c
@@ -1568,6 +1568,31 @@ init_outgoing_availports(int* a, int num)
 		if(iana_assigned[i] < num)
 			a[iana_assigned[i]] = 0;
 	}
+
+#ifndef UB_ON_WINDOWS
+	/* exclude ports not in ip_local_port_range */
+	FILE* range_fd;
+	if ((range_fd = fopen(IP_LOCAL_PORT_RANGE_PATH, "r")) != NULL) {
+		int min_port = 0;
+		int max_port = num - 1;
+		if (fscanf(range_fd, "%d %d", &min_port, &max_port) == 2) {
+			for(i=0; i<min_port; i++) {
+				a[i] = 0;
+			}
+			for(i=max_port+1; i<num; i++) {
+				a[i] = 0;
+			}
+		} else {
+			log_err("unexpected port range in %s",
+					IP_LOCAL_PORT_RANGE_PATH);
+		}
+		fclose(range_fd);
+	} else {
+		log_warn("failed to read from file: %s ",
+				IP_LOCAL_PORT_RANGE_PATH);
+		perror("fopen");
+	}
+#endif
 }
 
 int 

--- a/util/config_file.h
+++ b/util/config_file.h
@@ -1276,3 +1276,7 @@ extern int fake_dsa, fake_sha1;
 
 #endif /* UTIL_CONFIG_FILE_H */
 
+#ifndef UB_ON_WINDOWS
+#define IP_LOCAL_PORT_RANGE_PATH "/proc/sys/net/ipv4/ip_local_port_range"
+#endif
+


### PR DESCRIPTION
Use /proc/sys/net/ipv4/ip_local_port_range file to determine range of available ports.
Relates to #257