### PR TITLE
Use /proc/sys/net/ipv4/ip_local_port_range to determine available outgoing ports

### DIFF
--- a/config.h.in
+++ b/config.h.in
@@ -856,6 +856,14 @@
 /* Define if you enable libevent */
 #undef USE_LIBEVENT
 
+/* Define this to enable use of /proc/sys/net/ipv4/ip_local_port_range as a
+   default outgoing port range. This is only for the libunbound on Linux and
+   does not affect unbound resolving daemon itself. This may severely limit
+   the number of available outgoing ports and thus decrease randomness. Define
+   this only when the target system restricts (e.g. some of SELinux enabled
+   distributions) the use of non-ephemeral ports. */
+#undef USE_LINUX_IP_LOCAL_PORT_RANGE
+
 /* Define if you want to use internal select based events */
 #undef USE_MINI_EVENT
 

--- a/configure
+++ b/configure
@@ -902,6 +902,7 @@ enable_ipsecmod
 enable_ipset
 with_libmnl
 enable_explicit_port_randomisation
+enable_linux_ip_local_port_range
 with_libunbound_only
 '
       ac_precious_vars='build_alias
@@ -1605,6 +1606,16 @@ Optional Features:
   --disable-explicit-port-randomisation
                           disable explicit source port randomisation and rely
                           on the kernel to provide random source ports
+  --enable-linux-ip-local-port-range
+                          Define this to enable use of
+                          /proc/sys/net/ipv4/ip_local_port_range as a default
+                          outgoing port range. This is only for the libunbound
+                          on Linux and does not affect unbound resolving
+                          daemon itself. This may severely limit the number of
+                          available outgoing ports and thus decrease
+                          randomness. Define this only when the target system
+                          restricts (e.g. some of SELinux enabled
+                          distributions) the use of non-ephemeral ports.
 
 Optional Packages:
   --with-PACKAGE[=ARG]    use PACKAGE [ARG=yes]
@@ -21631,6 +21642,23 @@ $as_echo "#define DISABLE_EXPLICIT_PORT_RANDOMISATION 1" >>confdefs.h
 	yes|*)
 		;;
 esac
+
+if echo "$host" | $GREP -i -e linux >/dev/null; then
+	# Check whether --enable-linux-ip-local-port-range was given.
+if test "${enable_linux_ip_local_port_range+set}" = set; then :
+  enableval=$enable_linux_ip_local_port_range;
+fi
+
+	case "$enable_linux_ip_local_port_range" in
+		yes)
+
+$as_echo "#define USE_LINUX_IP_LOCAL_PORT_RANGE 1" >>confdefs.h
+
+			;;
+		no|*)
+			;;
+	esac
+fi
 
 
 { $as_echo "$as_me:${as_lineno-$LINENO}: checking if ${MAKE:-make} supports $< with implicit rule in scope" >&5

--- a/configure.ac
+++ b/configure.ac
@@ -1862,6 +1862,17 @@ case "$enable_explicit_port_randomisation" in
 		;;
 esac
 
+if echo "$host" | $GREP -i -e linux >/dev/null; then
+	AC_ARG_ENABLE(linux-ip-local-port-range, AC_HELP_STRING([--enable-linux-ip-local-port-range], [Define this to enable use of /proc/sys/net/ipv4/ip_local_port_range as a default outgoing port range. This is only for the libunbound on Linux and does not affect unbound resolving daemon itself. This may severely limit the number of available outgoing ports and thus decrease randomness. Define this only when the target system restricts (e.g. some of SELinux enabled distributions) the use of non-ephemeral ports.]))
+	case "$enable_linux_ip_local_port_range" in
+		yes)
+			AC_DEFINE([USE_LINUX_IP_LOCAL_PORT_RANGE], [1], [Define this to enable use of /proc/sys/net/ipv4/ip_local_port_range as a default outgoing port range. This is only for the libunbound on Linux and does not affect unbound resolving daemon itself. This may severely limit the number of available outgoing ports and thus decrease randomness. Define this only when the target system restricts (e.g. some of SELinux enabled distributions) the use of non-ephemeral ports.])
+			;;
+		no|*)
+			;;
+	esac
+fi
+
 
 AC_MSG_CHECKING([if ${MAKE:-make} supports $< with implicit rule in scope])
 # on openBSD, the implicit rule make $< work.

--- a/libunbound/context.c
+++ b/libunbound/context.c
@@ -69,6 +69,7 @@ context_finalize(struct ub_ctx* ctx)
 	} else {
 		log_init(cfg->logfile, cfg->use_syslog, NULL);
 	}
+	cfg_apply_local_port_policy(cfg, 65536);
 	config_apply(cfg);
 	if(!modstack_setup(&ctx->mods, cfg->module_conf, ctx->env))
 		return UB_INITFAIL;

--- a/util/config_file.h
+++ b/util/config_file.h
@@ -1191,6 +1191,13 @@ int cfg_mark_ports(const char* str, int allow, int* avail, int num);
 int cfg_condense_ports(struct config_file* cfg, int** avail);
 
 /**
+ * Apply system specific port range policy.
+ * @param cfg: config file.
+ * @param num: size of the array (65536).
+ */
+void cfg_apply_local_port_policy(struct config_file* cfg, int num);
+
+/**
  * Scan ports available
  * @param avail: the array from cfg.
  * @param num: size of the array (65536).
@@ -1328,6 +1335,10 @@ int if_is_https(const char* ifname, const char* port, int https_port);
  * @return true if https ports are used for server.
  */
 int cfg_has_https(struct config_file* cfg);
+
+#ifdef USE_LINUX_IP_LOCAL_PORT_RANGE
+#define LINUX_IP_LOCAL_PORT_RANGE_PATH "/proc/sys/net/ipv4/ip_local_port_range"
+#endif
 
 #endif /* UTIL_CONFIG_FILE_H */
 


### PR DESCRIPTION
Use /proc/sys/net/ipv4/ip_local_port_range file to determine range of available ports.
```configure --enable-local-port-range``` is required to make this work.

Relates to #257