### PR TITLE
Fix #426: Replace _Py_fopen() with fopen() in pythonmod.c

### DIFF
--- a/doc/Changelog
+++ b/doc/Changelog
@@ -2,6 +2,7 @@
 	- Fix #422: IPv6 fallback issues when IPv6 is not properly
 	  enabled/configured.
 	- Fix to make tests work with support indicators set for iterator.
+	- Fix build on Python 3.10.
 
 10 February 2021: Wouter
 	- Merge PR #420 from dyunwei: DOH not responsing with

--- a/pythonmod/pythonmod.c
+++ b/pythonmod/pythonmod.c
@@ -338,7 +338,7 @@ int pythonmod_init(struct module_env* env, int id)
    PyFileObject = PyFile_FromString((char*)pe->fname, "r");
    script_py = PyFile_AsFile(PyFileObject);
 #else
-   script_py = _Py_fopen(pe->fname, "r");
+   script_py = fopen(pe->fname, "r");
 #endif
    if (script_py == NULL)
    {


### PR DESCRIPTION
The private _Py_fopen() function has been removed in Python 3.10.

Fix build on Python 3.10.