### PR TITLE
build: Add missing linker flags.

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -464,7 +464,7 @@ libunbound/python/libunbound_wrap.c:	$(srcdir)/libunbound/python/libunbound.i un
 
 # Pyunbound python unbound wrapper
 _unbound.la:	libunbound_wrap.lo libunbound.la
-	$(LIBTOOL) --tag=CC --mode=link $(CC) $(RUNTIME_PATH) $(CPPFLAGS) $(CFLAGS) $(LDFLAGS) -module -avoid-version -no-undefined -shared -o $@ libunbound_wrap.lo -rpath $(PYTHON_SITE_PKG) -L. -L.libs -lunbound
+	$(LIBTOOL) --tag=CC --mode=link $(CC) $(RUNTIME_PATH) $(CPPFLAGS) $(CFLAGS) $(LDFLAGS) -module -avoid-version -no-undefined -shared -o $@ libunbound_wrap.lo -rpath $(PYTHON_SITE_PKG) -L. -L.libs -lunbound $(LIBS)
 
 util/config_file.c:	util/configparser.h
 util/configlexer.c:  $(srcdir)/util/configlexer.lex util/configparser.h


### PR DESCRIPTION
When building unbound with `--with-pyunbound` and slibtool (https://dev.midipix.org/cross/slibtool) it fails with many python undefined references.

This is because the `$(LIBTOOL)` linker command has `-no-undefined` and forgot `$(LIB)` which when added solves the problem. GNU libtool does not expose this issue because it silently ignores `-no-undefined`.

Full build log: [unbound.slibtool.log](https://github.com/NLnetLabs/unbound/files/6178609/unbound.slibtool.log)

Edit: Also see this downstream issue.

https://bugs.gentoo.org/777447
