### PR TITLE
Support OpenSSLs that lack SSL_get0_alpn_selected.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -859,7 +859,7 @@ AC_CHECK_FUNCS([OPENSSL_config EVP_sha1 EVP_sha256 EVP_sha512 FIPS_mode EVP_MD_C
 # these check_funcs need -lssl
 BAKLIBS="$LIBS"
 LIBS="-lssl $LIBS"
-AC_CHECK_FUNCS([OPENSSL_init_ssl SSL_CTX_set_security_level SSL_set1_host SSL_get0_peername X509_VERIFY_PARAM_set1_host SSL_CTX_set_ciphersuites SSL_CTX_set_tlsext_ticket_key_evp_cb SSL_CTX_set_alpn_select_cb])
+AC_CHECK_FUNCS([OPENSSL_init_ssl SSL_CTX_set_security_level SSL_set1_host SSL_get0_peername X509_VERIFY_PARAM_set1_host SSL_CTX_set_ciphersuites SSL_CTX_set_tlsext_ticket_key_evp_cb SSL_CTX_set_alpn_select_cb SSL_get0_alpn_selected])
 LIBS="$BAKLIBS"
 
 AC_CHECK_DECLS([SSL_COMP_get_compression_methods,sk_SSL_COMP_pop_free,SSL_CTX_set_ecdh_auto], [], [], [

--- a/util/netevent.c
+++ b/util/netevent.c
@@ -1314,6 +1314,7 @@ ssl_handshake(struct comm_point* c)
 			c->repinfo.addrlen);
 	}
 
+#ifdef HAVE_SSL_GET0_ALPN_SELECTED
 	/* check if http2 use is negotiated */
 	if(c->type == comm_http && c->h2_session) {
 		const unsigned char *alpn;
@@ -1325,6 +1326,7 @@ ssl_handshake(struct comm_point* c)
 			c->use_h2 = 1;
 		}
 	}
+#endif
 
 	/* setup listen rw correctly */
 	if(c->tcp_is_reading) {


### PR DESCRIPTION
Unbound currently doesn’t build on CloudLinux 6. This patch seems to fix the issue, though I’m still confirming.