### PR TITLE
Fix generation of libunbound.pc

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -824,7 +824,7 @@ ACX_WITH_SSL
 ACX_LIB_SSL
 SSLLIB="-lssl"
 
-PC_CRYPTO_DEPENDENCY="libcrypto libssl"
+PC_CRYPTO_DEPENDENCY=""
 AC_SUBST(PC_CRYPTO_DEPENDENCY)
 
 # check if -lcrypt32 is needed because CAPIENG needs that. (on windows)


### PR DESCRIPTION
According to a [PR at FreeBSD ports](https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=256064) a broken libunbound.pc file is installed.

This is the proposed patch for it.