### PR TITLE
Don't call a function which hasn't been defined

### DIFF
--- a/util/ub_event_pluggable.c
+++ b/util/ub_event_pluggable.c
@@ -666,7 +666,8 @@ ub_winsock_tcp_wouldblock(struct ub_event* ev, int eventbits)
 		fptr_ok(ev->vmt != &default_event_vmt ||
 			ev->vmt->winsock_tcp_wouldblock ==
 			my_winsock_tcp_wouldblock);
-		(*ev->vmt->winsock_tcp_wouldblock)(ev, eventbits);
+		if (ev->vmt->winsock_tcp_wouldblock)
+			(*ev->vmt->winsock_tcp_wouldblock)(ev, eventbits);
 	}
 }
 


### PR DESCRIPTION
This code path was causing segmentation faults by trying to call ev->vmt->winsock_tcp_wouldblock even though that was NULL