### PR TITLE
- Reduce unnecessary linking                                                                                                                                             

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -61,6 +61,7 @@ PYTHON_CPPFLAGS=-I. @PYTHON_CPPFLAGS@
 CFLAGS=-DSRCDIR=$(srcdir) @CFLAGS@
 LDFLAGS=@LDFLAGS@
 LIBS=@LIBS@
+PYTHON_LIBS=@PYTHON_LIBS@
 LIBOBJS=@LIBOBJS@
 # filter out ctime_r from compat obj.
 LIBOBJ_WITHOUT_CTIME=@LIBOBJ_WITHOUT_CTIME@
@@ -476,7 +477,7 @@ libunbound/python/libunbound_wrap.c:	$(srcdir)/libunbound/python/libunbound.i un
 
 # Pyunbound python unbound wrapper
 _unbound.la:	libunbound_wrap.lo libunbound.la
-	$(LIBTOOL) --tag=CC --mode=link $(CC) $(RUNTIME_PATH) $(CPPFLAGS) $(CFLAGS) $(LDFLAGS) -module -avoid-version -no-undefined -shared -o $@ libunbound_wrap.lo -rpath $(PYTHON_SITE_PKG) -L. -L.libs libunbound.la $(LIBS)
+	$(LIBTOOL) --tag=CC --mode=link $(CC) $(RUNTIME_PATH) $(CPPFLAGS) $(CFLAGS) $(LDFLAGS) -module -avoid-version -no-undefined -shared -o $@ libunbound_wrap.lo -rpath $(PYTHON_SITE_PKG) -L. -L.libs libunbound.la $(PYTHON_LIBS)
 
 util/config_file.c:	util/configparser.h
 util/configlexer.c:  $(srcdir)/util/configlexer.lex util/configparser.h

--- a/configure.ac
+++ b/configure.ac
@@ -699,11 +699,15 @@ if test x_$ub_test_python != x_no; then
       AC_SUBST(PY_MAJOR_VERSION)
       # Have Python
       AC_DEFINE(HAVE_PYTHON,1,[Define if you have Python libraries and header files.])
-      if test -n "$LIBS"; then
-        LIBS="$PYTHON_LDFLAGS $LIBS"
-      else
-        LIBS="$PYTHON_LDFLAGS"
+      if test x_$ub_with_pythonmod != x_no; then
+        if test -n "$LIBS"; then
+          LIBS="$PYTHON_LDFLAGS $LIBS"
+        else
+          LIBS="$PYTHON_LDFLAGS"
+        fi
       fi
+      PYTHON_LIBS="$PYTHON_LDFLAGS"
+      AC_SUBST(PYTHON_LIBS)
       if test -n "$CPPFLAGS"; then
         CPPFLAGS="$CPPFLAGS $PYTHON_CPPFLAGS"
       else


### PR DESCRIPTION
When pyunbound is enabled while pythonmodule is not (i.e., `./configure --without-pythonmodule --with-pyunbound`), only the Python library `_unbound.so` uses Python functions, and main programs (`unbound`, `unbound-anchor`, ...) and `libunbound.so` do not. This patch removes unneeded linking.

Note that I didn't commit re-generated autoconf files as that brings too many unrelated changes to `./configure`. If you wish, I will push updated autoconf files.