### PR TITLE
#420 breaks the mesh reply list function that need to reuse the dns answer.

### DIFF
--- a/services/listen_dnsport.c
+++ b/services/listen_dnsport.c
@@ -2477,6 +2477,10 @@ static int http2_query_read_done(struct http2_session* h2_session,
 			"buffer already assigned to stream");
 		return -1;
 	}
+    
+    /* the c->buffer might be used by mesh_send_reply and no be cleard
+	 * need to be cleared before use */
+	sldns_buffer_clear(h2_session->c->buffer);
 	if(sldns_buffer_remaining(h2_session->c->buffer) <
 		sldns_buffer_remaining(h2_stream->qbuffer)) {
 		/* qbuffer will be free'd in frame close cb */

--- a/util/netevent.c
+++ b/util/netevent.c
@@ -4063,7 +4063,6 @@ comm_point_send_reply(struct comm_reply *repinfo)
 			}
 			repinfo->c->h2_stream = NULL;
 			repinfo->c->tcp_is_reading = 0;
-			sldns_buffer_clear(repinfo->c->buffer);
 			comm_point_stop_listening(repinfo->c);
 			comm_point_start_listening(repinfo->c, -1,
 				adjusted_tcp_timeout(repinfo->c));


### PR DESCRIPTION
Sorry for my previous change causes another issue.

My previous change that clears the c->buffer in the comm_point_send_reply does resolve the "can't fit qbuffer in c->buffer" issue, but it breaks the mesh reply list function that need to reuse the answer. Since the c->buffer is cleared in the comm_point_send_reply, it cannot be resued again. it means that it is not inappropriate to clear c->buffer in the comm_point_send_reply.

After some investigation, i found it is appropriate to clear c->buffer before use in the http2_query_read_done.