### PR TITLE
Update mini_event.c

### DIFF
--- a/util/mini_event.c
+++ b/util/mini_event.c
@@ -337,6 +337,15 @@ int event_del(struct event* ev)
 		FD_CLR(FD_SET_T ev->ev_fd, &ev->ev_base->writes);
 		FD_CLR(FD_SET_T ev->ev_fd, &ev->ev_base->ready);
 		FD_CLR(FD_SET_T ev->ev_fd, &ev->ev_base->content);
+		if(ev->ev_fd == ev->ev_base->maxfd) {
+                        int i = ev->ev_base->maxfd - 1;
+                        for (; i > 3; i--) {
+                                if (NULL != ev->ev_base->fds[i]) {
+                                        break;
+                                }
+                        }
+                        ev->ev_base->maxfd = i;
+                }
 	}
 	ev->added = 0;
 	return 0;


### PR DESCRIPTION
When in heavy load, unbound opens many outside_network sockets for out going queries to delegation servers, which may result in a big fd(maxfd) value(for thread A 1200, for thread B 1201, for thread C ...). 
There are situations when thread A has a max fd num 1200 where maxfd is of course 1200, thread B has max fd num 20 for now but maxfd is still 1201. Though linux kernel checks whether maxfd+1  passed by select syscall  is really the process' maxfd+1. Linux kernel can not tell maxfd+1 passed by thread B select syscall is much bigger(1201+1 or 1200+1  after trimed by kerne) than it should be (20+1).
In this situation, when kernel do_select() for thread B, much work is wasted.