### PR TITLE
fix: free() call more than once with the same pointer

### DIFF
--- a/util/data/msgreply.c
+++ b/util/data/msgreply.c
@@ -495,7 +495,6 @@ int reply_info_parse(sldns_buffer* pkt, struct alloc_cache* alloc,
 	/* this also performs dname decompression */
 	if(!parse_create_msg(pkt, msg, alloc, qinf, rep, NULL)) {
 		query_info_clear(qinf);
-		reply_info_parsedelete(*rep, alloc);
 		*rep = NULL;
 		return LDNS_RCODE_SERVFAIL;
 	}


### PR DESCRIPTION
If in the function 'parse_create_msg' failed calls 'reply_info_alloc_rrset_keys' or 'parse_copy_decompress' than in the same place will be called reply_info_parsedelete(*rep, alloc). After that 'reply_info_parsedelete(*rep, alloc)' will be called second time at "reply_info_parse()"