### PR TITLE
Windows: Fix startup failure due to unsupported socket option being applied

### DIFF
--- a/services/listen_dnsport.c
+++ b/services/listen_dnsport.c
@@ -496,12 +496,18 @@ create_udp_sock(int family, int socktype, struct sockaddr* addr,
 		 */
 		if (setsockopt(s, IPPROTO_IPV6, IPV6_MTU,
 			(void*)&mtu, (socklen_t)sizeof(mtu)) < 0) {
-			log_err("setsockopt(..., IPV6_MTU, ...) failed: %s", 
-				sock_strerror(errno));
-			sock_close(s);
-			*noproto = 0;
-			*inuse = 0;
-			return -1;
+#ifdef USE_WINSOCK
+			if (WSAGetLastError() != WSAENOPROTOOPT) {
+#endif
+				log_err("setsockopt(..., IPV6_MTU, ...) failed: %s", 
+					sock_strerror(errno));
+				sock_close(s);
+				*noproto = 0;
+				*inuse = 0;
+				return -1;
+#ifdef USE_WINSOCK
+			}
+#endif
 		}
 # endif /* IPv6 MTU */
 # if defined(IPV6_MTU_DISCOVER) && defined(IP_PMTUDISC_DONT)


### PR DESCRIPTION
Newer mingw-w64 (starting from 8.0.1) introduces support for `IPV6_MTU` socket option [1], which is not supported on Windows 8.1 and older. As there is no way to avoid this socket option from being picked at compile time when targeting older versions of Windows, check for `setsockopt(..., IPV6_MTU, ...)` failures at runtime in order to avoid startup failure on those versions of Windows where the `IPV6_MTU` socket option is not supported.

**Current behavior**
```
$ ./unbound.exe -d -v
[1628888738] unbound.exe[3604:0] notice: Start of unbound 1.13.2.
Aug 13 17:05:38 unbound[3604:0] error: setsockopt(..., IPV6_MTU, ...) failed: Bad protocol option.
Aug 13 17:05:38 unbound[3604:0] fatal error: could not open ports
```
**Expected behavior**
```
$ ./unbound.exe -d -v
[1628889077] unbound.exe[5404:0] notice: Start of unbound 1.13.2.
Aug 13 17:11:17 unbound[5404:0] notice: init module 0: validator
Aug 13 17:11:17 unbound[5404:0] notice: init module 1: iterator
Aug 13 17:11:17 unbound[5404:0] info: start of service (unbound 1.13.2).
```

[1] : mirror/mingw-w64@e30bff4

See also:
https://sourceforge.net/p/uftp-multicast/discussion/general/thread/257f3c21/
https://stackoverflow.com/questions/49982697/