### PR TITLE
Fix: log_assert does nothing if UNBOUND_DEBUG is undefined

### DIFF
--- a/util/tube.c
+++ b/util/tube.c
@@ -363,7 +363,11 @@ int tube_read_msg(struct tube* tube, uint8_t** buf, uint32_t* len,
 		}
 		d += r;
 	}
-	log_assert(*len < 65536*2);
+	if (*len >= 65536*2) {
+	    log_err("tube msg length is too big", *len);
+        (void)fd_set_nonblock(fd);
+        return 0;
+	}
 	*buf = (uint8_t*)malloc(*len);
 	if(!*buf) {
 		log_err("tube read out of memory");


### PR DESCRIPTION
Found by static analyzer svace
Static analyzer message: Integer value 'len' obtained from untrusted source at tube.c:374 by passing as 2nd parameter to function 'read' at tube.c:340 without checking its higher bound is used as a loop bound at tube.c:374.


on-behalf-of: @ideco-team <github@ideco.ru>