### PR TITLE
Fix: dereferencing a null pointer

### DIFF
--- a/dns64/dns64.c
+++ b/dns64/dns64.c
@@ -913,8 +913,9 @@ dns64_adjust_ptr(struct module_qstate* qstate, struct module_qstate* super)
                     sizeof(struct dns_msg))))
         return;
     super->return_msg->qinfo = super->qinfo;
-    super->return_msg->rep = reply_info_copy(qstate->return_msg->rep, NULL,
-            super->region);
+    if (!(super->return_msg->rep = reply_info_copy(qstate->return_msg->rep,
+                    NULL, super->region)))
+        return;
 
     /*
      * Adjust the domain name of the answer RR set so that it matches the


### PR DESCRIPTION
Found by static analyzer svace
Static analyzer message: Return value of a function 'reply_info_copy' is dereferenced at dns64.c:923 without checking, but it is usually checked for this function (4/5).

on-behalf-of: @ideco-team <github@ideco.ru>