### PR TITLE
Fix: passed to proc after free

### DIFF
--- a/iterator/iter_hints.c
+++ b/iterator/iter_hints.c
@@ -397,10 +397,10 @@ read_root_hints(struct iter_hints* hints, char* fname)
 		delegpt_free_mlc(dp);
 		return 1;
 	}
+	delegpt_log(VERB_QUERY, dp);
 	if(!hints_insert(hints, c, dp, 0)) {
 		return 0;
 	}
-	delegpt_log(VERB_QUERY, dp);
 	return 1;
 
 stop_read:


### PR DESCRIPTION
Found by static analyzer svace
Static analyzer message: Pointer 'dp' is passed to a function at iter_hints.c:401 after the referenced memory was deallocated at iter_hints.c:174 by passing as 3rd parameter to function 'hints_insert' at iter_hints.c:398.

on-behalf-of: @ideco-team <github@ideco.ru>