### PR TITLE
Fix: buffer overflow bug

### DIFF
--- a/sldns/str2wire.c
+++ b/sldns/str2wire.c
@@ -601,7 +601,7 @@ sldns_affix_token(sldns_buffer* strbuf, char* token, size_t* token_len,
 	size_t addstrlen = 0;
 
 	/* add space */
-	if(addlen < 1) return 0;
+	if(addlen < 2) return 0;
 	token[*token_strlen] = ' ';
 	token[++(*token_strlen)] = 0;
 


### PR DESCRIPTION
Found by static analyzer svace
Static analyzer message: Array 'token' of size 65536 bytes passed to function 'rrinternal_parse_rdata' at str2wire.c:679 by passing as 2nd parameter to function 'rrinternal_parse_rdata' at str2wire.c:775, where it is accessed by unacceptable index. This may lead to buffer overflow.

on-behalf-of: @ideco-team <github@ideco.ru>