### PR TITLE
Fix subnetcache statistics

### DIFF
--- a/daemon/remote.c
+++ b/daemon/remote.c
@@ -813,7 +813,7 @@ print_mem(RES* ssl, struct worker* worker, struct daemon* daemon,
 	iter = mod_get_mem(&worker->env, "iterator");
 	respip = mod_get_mem(&worker->env, "respip");
 #ifdef CLIENT_SUBNET
-	subnet = mod_get_mem(&worker->env, "subnet");
+	subnet = mod_get_mem(&worker->env, "subnetcache");
 #endif /* CLIENT_SUBNET */
 #ifdef USE_IPSECMOD
 	ipsecmod = mod_get_mem(&worker->env, "ipsecmod");

--- a/daemon/stats.c
+++ b/daemon/stats.c
@@ -137,7 +137,7 @@ static void
 set_subnet_stats(struct worker* worker, struct ub_server_stats* svr,
 	int reset)
 {
-	int m = modstack_find(&worker->env.mesh->mods, "subnet");
+	int m = modstack_find(&worker->env.mesh->mods, "subnetcache");
 	struct subnet_env* sne;
 	if(m == -1)
 		return;

--- a/daemon/worker.c
+++ b/daemon/worker.c
@@ -146,7 +146,7 @@ worker_mem_report(struct worker* ATTR_UNUSED(worker),
 				(&worker->env, i);
 #ifdef CLIENT_SUBNET
 		else if(strcmp(worker->env.mesh->mods.mod[i]->name,
-			"subnet")==0)
+			"subnetcache")==0)
 			subnet += (*worker->env.mesh->mods.mod[i]->get_mem)
 				(&worker->env, i);
 #endif /* CLIENT_SUBNET */
@@ -205,7 +205,7 @@ worker_mem_report(struct worker* ATTR_UNUSED(worker),
 				(&worker->env, i);
 #ifdef CLIENT_SUBNET
 		else if(strcmp(worker->env.mesh->mods.mod[i]->name,
-			"subnet")==0)
+			"subnetcache")==0)
 			subnet += (*worker->env.mesh->mods.mod[i]->get_mem)
 				(&worker->env, i);
 #endif /* CLIENT_SUBNET */

--- a/util/shm_side/shm_main.c
+++ b/util/shm_side/shm_main.c
@@ -281,7 +281,7 @@ void shm_main_run(struct worker *worker)
 		shm_stat->mem.subnet = 0;
 #ifdef CLIENT_SUBNET
 		shm_stat->mem.subnet = (long long)mod_get_mem(&worker->env,
-			"subnet");
+			"subnetcache");
 #endif
 		/* ipsecmod mem value is available in shm, also when not enabled,
 		 * to make the struct easier to memmap by other applications,


### PR DESCRIPTION
Hi all,
Following https://github.com/NLnetLabs/unbound/commit/d69132b9212f95c72fdfb8d0a652f6f58c069a9f
the subnet module was renamed to subnetcache to improve logging, but stats are not displayed correctly.

see https://github.com/NLnetLabs/unbound/blob/master/edns-subnet/subnetmod.c#L864

Tested on 1.13.2 on Debian Stretch. 

The subnet cache worked as expected, the issue was only on statistics (on unbonud-control stats)