### PR TITLE
Better positioning of general EDNS option handling

### DIFF
--- a/daemon/worker.c
+++ b/daemon/worker.c
@@ -449,7 +449,6 @@ answer_norec_from_cache(struct worker* worker, struct query_info* qinfo,
 	 * Then check if it needs validation, if so, this routine fails,
 	 * so that iterator can prime and validator can verify rrsets.
 	 */
-	struct edns_data edns_bak;
 	uint16_t udpsize = edns->udp_size;
 	int secure = 0;
 	time_t timenow = *worker->env.now;
@@ -508,7 +507,6 @@ answer_norec_from_cache(struct worker* worker, struct query_info* qinfo,
 		}
 	}
 	/* return this delegation from the cache */
-	edns_bak = *edns;
 	edns->edns_version = EDNS_ADVERTISED_VERSION;
 	edns->udp_size = EDNS_ADVERTISED_SIZE;
 	edns->ext_rcode = 0;
@@ -518,9 +516,7 @@ answer_norec_from_cache(struct worker* worker, struct query_info* qinfo,
 		worker->env.now_tv))
 			return 0;
 	msg->rep->flags |= BIT_QR|BIT_RA;
-	if(!apply_edns_options(edns, &edns_bak, worker->env.cfg,
-		repinfo->c, worker->scratchpad) ||
-		!reply_info_answer_encode(&msg->qinfo, msg->rep, id, flags, 
+	if(!reply_info_answer_encode(&msg->qinfo, msg->rep, id, flags, 
 		repinfo->c->buffer, 0, 1, worker->scratchpad,
 		udpsize, edns, (int)(edns->bits & EDNS_DO), secure)) {
 		if(!inplace_cb_reply_servfail_call(&worker->env, qinfo, NULL, NULL,
@@ -604,7 +600,6 @@ answer_from_cache(struct worker* worker, struct query_info* qinfo,
 	struct reply_info* rep, uint16_t id, uint16_t flags,
 	struct comm_reply* repinfo, struct edns_data* edns)
 {
-	struct edns_data edns_bak;
 	time_t timenow = *worker->env.now;
 	uint16_t udpsize = edns->udp_size;
 	struct reply_info* encode_rep = rep;
@@ -685,7 +680,6 @@ answer_from_cache(struct worker* worker, struct query_info* qinfo,
 		}
 	} else *is_secure_answer = 0;
 
-	edns_bak = *edns;
 	edns->edns_version = EDNS_ADVERTISED_VERSION;
 	edns->udp_size = EDNS_ADVERTISED_SIZE;
 	edns->ext_rcode = 0;
@@ -722,9 +716,7 @@ answer_from_cache(struct worker* worker, struct query_info* qinfo,
 			if(!*partial_repp)
 				goto bail_out;
 		}
-	} else if(!apply_edns_options(edns, &edns_bak, worker->env.cfg,
-		repinfo->c, worker->scratchpad) ||
-		!reply_info_answer_encode(qinfo, encode_rep, id, flags,
+	} else if(!reply_info_answer_encode(qinfo, encode_rep, id, flags,
 		repinfo->c->buffer, timenow, 1, worker->scratchpad,
 		udpsize, edns, (int)(edns->bits & EDNS_DO), *is_secure_answer)) {
 		if(!inplace_cb_reply_servfail_call(&worker->env, qinfo, NULL, NULL,

--- a/services/mesh.c
+++ b/services/mesh.c
@@ -1307,9 +1307,6 @@ mesh_send_reply(struct mesh_state* m, int rcode, struct reply_info* rep,
 		m->s.qinfo.local_alias = r->local_alias;
 		if(!inplace_cb_reply_call(m->s.env, &m->s.qinfo, &m->s, rep,
 			LDNS_RCODE_NOERROR, &r->edns, &r->query_reply, m->s.region, &r->start_time) ||
-			!apply_edns_options(&r->edns, &edns_bak,
-				m->s.env->cfg, r->query_reply.c,
-				m->s.region) ||
 			!reply_info_answer_encode(&m->s.qinfo, rep, r->qid, 
 			r->qflags, r_buffer, 0, 1, m->s.env->scratch,
 			udp_size, &r->edns, (int)(r->edns.bits & EDNS_DO),

--- a/util/data/msgreply.c
+++ b/util/data/msgreply.c
@@ -1091,8 +1091,19 @@ static int inplace_cb_reply_call_generic(struct config_file* cfg,
 #if defined(EXPORT_ALL_SYMBOLS)
 	(void)type; /* param not used when fptr_ok disabled */
 #endif
-	if(qstate)
+	if(qstate) {
+		/* TODO (after discussion with Yorgos):
+		 * opt_list_out can change by the callbacks bellow,
+		 * but qstate->edns_opts_front_out changes too, but only
+		 * when there was an option already. Which might be a problem
+		 * if this function is called twice before an encoded answer is
+		 * returned.
+		 * To fix: Make opt_list_out a copy of qstate->edns_opts_front_out
+		 * Or to properly fix it: Have an opt_list_in
+		 * and and opt_list_out in the callbacks.
+		 */
 		opt_list_out = qstate->edns_opts_front_out;
+	}
 	for(cb=callback_list; cb; cb=cb->next) {
 		fptr_ok(fptr_whitelist_inplace_cb_reply_generic(
 			(inplace_cb_reply_func_type*)cb->cb, type));

--- a/util/edns.c
+++ b/util/edns.c
@@ -131,7 +131,7 @@ edns_string_addr_lookup(rbtree_type* tree, struct sockaddr_storage* addr,
 static int edns_keepalive(struct edns_data* edns_out, struct edns_data* edns_in,
 		struct comm_point* c, struct regional* region)
 {
-	if(c->type == comm_udp)
+	if(!c || c->type == comm_udp)
 		return 1;
 
 	/* To respond with a Keepalive option, the client connection
@@ -165,7 +165,7 @@ int apply_edns_options(struct edns_data* edns_out, struct edns_data* edns_in,
 			LDNS_EDNS_NSID, cfg->nsid_len, cfg->nsid, region))
 		return 0;
 
-	if(!cfg->pad_responses || c->type != comm_tcp || !c->ssl
+	if(!cfg->pad_responses || !c || c->type != comm_tcp || !c->ssl
 	|| !edns_opt_list_find(edns_in->opt_list, LDNS_EDNS_PADDING)) {
 	       ; /* pass */
 	}


### PR DESCRIPTION
General EDNS options like PADDING and NSID were only returned with answers from cache or from authoritative zones.
This commit repositions the handling of general EDNS options (from the apply_edns_options() function) so it is better cooperating with handling of EDNS options from modules, and as a result the options are handled for synthesized answers (like local data and id.server queries) too.

@gthess I have some questions about this. Can we discuss?
