### PR TITLE
Allow interface names as scope-id in IPv6 link-local addresses.

### DIFF
--- a/config.h.in
+++ b/config.h.in
@@ -318,6 +318,9 @@
 /* Define to 1 if you have the <ifaddrs.h> header file. */
 #undef HAVE_IFADDRS_H
 
+/* Define to 1 if you have the `if_nametoindex' function. */
+#undef HAVE_IF_NAMETOINDEX
+
 /* Define to 1 if you have the `inet_aton' function. */
 #undef HAVE_INET_ATON
 

--- a/configure
+++ b/configure
@@ -21731,6 +21731,12 @@ if test "${with_libunbound_only+set}" = set; then :
 	fi
 
 fi
+ac_fn_c_check_func "$LINENO" "if_nametoindex" "ac_cv_func_if_nametoindex"
+if test "x$ac_cv_func_if_nametoindex" = xyes
+then :
+  printf "%s\n" "#define HAVE_IF_NAMETOINDEX 1" >>confdefs.h
+
+fi
 
 if test $ALLTARGET = "alltargets"; then
 	if test $USE_NSS = "yes"; then

--- a/configure.ac
+++ b/configure.ac
@@ -1601,7 +1601,7 @@ AC_LINK_IFELSE([AC_LANG_PROGRAM([
   AC_MSG_RESULT(no))
 
 AC_SEARCH_LIBS([setusercontext], [util])
-AC_CHECK_FUNCS([tzset sigprocmask fcntl getpwnam endpwent getrlimit setrlimit setsid chroot kill chown sleep usleep random srandom recvmsg sendmsg writev socketpair glob initgroups strftime localtime_r setusercontext _beginthreadex endservent endprotoent fsync shmget accept4 getifaddrs])
+AC_CHECK_FUNCS([tzset sigprocmask fcntl getpwnam endpwent getrlimit setrlimit setsid chroot kill chown sleep usleep random srandom recvmsg sendmsg writev socketpair glob initgroups strftime localtime_r setusercontext _beginthreadex endservent endprotoent fsync shmget accept4 getifaddrs if_nametoindex])
 AC_CHECK_FUNCS([setresuid],,[AC_CHECK_FUNCS([setreuid])])
 AC_CHECK_FUNCS([setresgid],,[AC_CHECK_FUNCS([setregid])])
 

--- a/util/net_help.c
+++ b/util/net_help.c
@@ -38,6 +38,12 @@
  */
 
 #include "config.h"
+#ifdef HAVE_SYS_TYPES_H
+#  include <sys/types.h>
+#endif
+#ifdef HAVE_NET_IF_H
+#include <net/if.h>
+#endif
 #include "util/net_help.h"
 #include "util/log.h"
 #include "util/data/dname.h"
@@ -266,7 +272,10 @@ ipstrtoaddr(const char* ip, int port, struct sockaddr_storage* addr,
 				return 0;
 			(void)strlcpy(buf, ip, sizeof(buf));
 			buf[s-ip]=0;
-			sa->sin6_scope_id = (uint32_t)atoi(s+1);
+#ifdef HAVE_IF_NAMETOINDEX
+			if (!(sa->sin6_scope_id = if_nametoindex(s+1)))
+#endif /* HAVE_IF_NAMETOINDEX */
+				sa->sin6_scope_id = (uint32_t)atoi(s+1);
 			ip = buf;
 		}
 		if(inet_pton((int)sa->sin6_family, ip, &sa->sin6_addr) <= 0) {


### PR DESCRIPTION
For example, this makes
forward-zone:
    name: "."
    forward-addr: fe80::20d:b9ff:fe46:c7f4%vio0
    forward-first: yes

work instead of fe80::20d:b9ff:fe46:c7f4%1.