### PR TITLE
Make event_add() complementary to event_del().

### DIFF
--- a/util/mini_event.c
+++ b/util/mini_event.c
@@ -319,7 +319,8 @@ int event_add(struct event* ev, struct timeval* tv)
 		}
 #endif
 		(void)rbtree_insert(ev->ev_base->times, &ev->node);
-	}
+	} else
+		ev->ev_events &= ~EV_TIMEOUT;
 	ev->added = 1;
 	return 0;
 }


### PR DESCRIPTION
If the former inserts an event into the timeout rbtree, then the
latter would remove it. If the former didn't insert, the latter
won't try to remove.

Fixes #558

Note: this is change we are testing right now. As #558 says we don't have a reproduce recipe for the crash. It just happens sometimes at a huge fleet of machines. I will keep updated on the results.