### PR TITLE
Reset keepalive per new tcp session

### DIFF
--- a/util/netevent.c
+++ b/util/netevent.c
@@ -818,6 +818,7 @@ setup_tcp_handler(struct comm_point* c, int fd, int cur, int max)
 #endif
 	c->tcp_is_reading = 1;
 	c->tcp_byte_count = 0;
+	c->tcp_keepalive = 0;
 	/* if more than half the tcp handlers are in use, use a shorter
 	 * timeout for this TCP connection, we need to make space for
 	 * other connections to be able to get attention */


### PR DESCRIPTION
Before, if edns-tcp-keepalive was configured, it was not sent along in responses unless **a** client on **a** TCP (or TLS) session signaled support for it, but then the options was sent along in responses to **all** clients using TCP (or TLS), also to the clients that did not signal support by sending a initial query with the option if they would reuse the internal comm_point for the TCP session.
Although according to [RFC7828 Section 3.3.2.](https://www.rfc-editor.org/rfc/rfc7828.html#section-3.3.2) a server does not need an initial query with keepalive option to sent along the option in responses, it is peculiar that **a** random client was needed to sent the option for unbound to start sending along the option on all responses (on TCP sessions that reused that comm_point). Clearly the intention was to sent along the option in responses only to those clients that signaled support by sending an initial query with the option. This PR makes it behave just like that.