### PR TITLE
unbound.service.in: Disable ProtectKernelTunables again

### DIFF
--- a/contrib/unbound.service.in
+++ b/contrib/unbound.service.in
@@ -64,7 +64,8 @@ ProtectClock=true
 ProtectControlGroups=true
 ProtectKernelLogs=true
 ProtectKernelModules=true
-ProtectKernelTunables=true
+# This breaks using socket options like 'so-rcvbuf'. Explicitly disable for visibility.
+ProtectKernelTunables=false
 ProtectProc=invisible
 ProtectSystem=strict
 RuntimeDirectory=unbound


### PR DESCRIPTION
This option was removed in https://github.com/NLnetLabs/unbound/commit/ff8fd0be5c529e7a1b84e8c74426e9c531c0a8f8 but reintroduced in https://github.com/NLnetLabs/unbound/commit/c32b9e4ba95983146eac805719db720f02a64358

Disable it with commentary in hope to prevent slipping it in again.

cc: @ArchangeGabriel