### PR TITLE
Change file mode before changing file owner

### DIFF
--- a/daemon/remote.c
+++ b/daemon/remote.c
@@ -300,6 +300,7 @@ add_open(const char* ip, int nr, struct listen_port** list, int noproto_is_err,
 		 */
 		if(fd != -1) {
 #ifdef HAVE_CHOWN
+			chmod(ip, (mode_t)(S_IRUSR | S_IWUSR | S_IRGRP | S_IWGRP));
 			if (cfg->username && cfg->username[0] &&
 				cfg_uid != (uid_t)-1) {
 				if(chown(ip, cfg_uid, cfg_gid) == -1)
@@ -307,7 +308,6 @@ add_open(const char* ip, int nr, struct listen_port** list, int noproto_is_err,
 					  (unsigned)cfg_uid, (unsigned)cfg_gid,
 					  ip, strerror(errno));
 			}
-			chmod(ip, (mode_t)(S_IRUSR | S_IWUSR | S_IRGRP | S_IWGRP));
 #else
 			(void)cfg;
 #endif


### PR DESCRIPTION
Change mode first when configuring remote control unix socket. Some
security systems might strip capability of changing other user's system
even to process with effective uid 0. That is done on Fedora by SELinux
policy and systemd for example. SELinux audit then shows errors, because
unbound tries modifying permissions of not own file. Fix just by mode
change as first step, make it owned by unbound:unbound user as the last
step only.

Related: rhbz#1905441