### PR TITLE
Use OpenSSL 1.1 API to access DSA and RSA internals

### DIFF
--- a/sldns/keyraw.c
+++ b/sldns/keyraw.c
@@ -250,7 +250,7 @@ sldns_key_buf2dsa_raw(unsigned char* key, size_t len)
 	if(!(dsa = DSA_new())) {
 		return NULL;
 	}
-#if OPENSSL_VERSION_NUMBER < 0x10100000 || defined(HAVE_LIBRESSL)
+#if OPENSSL_VERSION_NUMBER < 0x10100000
 #ifndef S_SPLINT_S
 	dsa->p = P;
 	dsa->q = Q;
@@ -428,7 +428,7 @@ sldns_key_buf2rsa_raw(unsigned char* key, size_t len)
 		BN_free(modulus);
 		return NULL;
 	}
-#if OPENSSL_VERSION_NUMBER < 0x10100000 || defined(HAVE_LIBRESSL)
+#if OPENSSL_VERSION_NUMBER < 0x10100000
 #ifndef S_SPLINT_S
 	rsa->n = modulus;
 	rsa->e = exponent;

--- a/sldns/keyraw.c
+++ b/sldns/keyraw.c
@@ -250,7 +250,8 @@ sldns_key_buf2dsa_raw(unsigned char* key, size_t len)
 	if(!(dsa = DSA_new())) {
 		return NULL;
 	}
-#if OPENSSL_VERSION_NUMBER < 0x10100000
+#if OPENSSL_VERSION_NUMBER < 0x10100000 || \
+        (defined(HAVE_LIBRESSL) && LIBRESSL_VERSION_NUMBER < 0x02070000f)
 #ifndef S_SPLINT_S
 	dsa->p = P;
 	dsa->q = Q;
@@ -428,7 +429,8 @@ sldns_key_buf2rsa_raw(unsigned char* key, size_t len)
 		BN_free(modulus);
 		return NULL;
 	}
-#if OPENSSL_VERSION_NUMBER < 0x10100000
+#if OPENSSL_VERSION_NUMBER < 0x10100000 || \
+        (defined(HAVE_LIBRESSL) && LIBRESSL_VERSION_NUMBER < 0x02070000f)
 #ifndef S_SPLINT_S
 	rsa->n = modulus;
 	rsa->e = exponent;


### PR DESCRIPTION
In LibreSSL 3.5, DSA and RSA internals will become opaque, so they can
no longer be accessed directly and the libunbound build will break. The
required API, DSA_set0_pqg(), DSA_set0_key() as well as RSA_set0_key(),
has been available since LibreSSL 2.7, so this change should not affect
any users.

From Theo Buehler.