### PR TITLE
Add prefetch support for subnet cache entries

### DIFF
--- a/edns-subnet/subnetmod.h
+++ b/edns-subnet/subnetmod.h
@@ -143,4 +143,12 @@ int ecs_query_response(struct module_qstate* qstate, struct dns_msg* response,
 /** mark subnet msg to be deleted */
 void subnet_markdel(void* key);
 
+/** Add ecs struct to edns list, after parsing it to wire format. */
+void subnet_ecs_opt_list_append(struct ecs_data* ecs, struct edns_option** list,
+	struct module_qstate *qstate);
+
+/** Create ecs_data from the sockaddr_storage information. */
+void subnet_option_from_ss(struct sockaddr_storage *ss, struct ecs_data* ecs,
+	struct config_file* cfg);
+
 #endif /* SUBNETMOD_H */


### PR DESCRIPTION
Currently, only the entries in the global cache are being prefetched when prefetch is enable. However for queries with ECS option set, the results are being stored in subnet cache instead global cache which bypass the existing prefetch logic.

I think @gthess attempted to solve similar issue [previously](https://github.com/NLnetLabs/unbound/commit/abbc3305d49c93bfb3ac56a8eb474e7f41f6c1c3), but unfortunately the patch doesn't seem to work when we tested it. This PR follows a similar approach, but instead building the prefetch logic on top of the global cache, the prefetch is only applied to subnet cache queries.

Happy to chat more if people think there are better alternatives to implement this feature. Thanks. 

Signed-off-by: Tian Lan <tian.lan@twosigma.com>