### PR TITLE
Disable ED25519 and ED448 in FIPS mode on openssl3

### DIFF
--- a/config.h.in
+++ b/config.h.in
@@ -222,6 +222,10 @@
 /* Define to 1 if you have the `EVP_cleanup' function. */
 #undef HAVE_EVP_CLEANUP
 
+/* Define to 1 if you have the `EVP_default_properties_is_fips_enabled'
+   function. */
+#undef HAVE_EVP_DEFAULT_PROPERTIES_IS_FIPS_ENABLED
+
 /* Define to 1 if you have the `EVP_DigestVerify' function. */
 #undef HAVE_EVP_DIGESTVERIFY
 

--- a/configure
+++ b/configure
@@ -5,8 +5,7 @@
 # Report bugs to <unbound-bugs@nlnetlabs.nl or https://github.com/NLnetLabs/unbound/issues>.
 #
 #
-# Copyright (C) 1992-1996, 1998-2017, 2020-2021 Free Software Foundation,
-# Inc.
+# Copyright (C) 1992-1996, 1998-2012 Free Software Foundation, Inc.
 #
 #
 # This configure script is free software; the Free Software Foundation
@@ -17,16 +16,14 @@
 
 # Be more Bourne compatible
 DUALCASE=1; export DUALCASE # for MKS sh
-as_nop=:
-if test ${ZSH_VERSION+y} && (emulate sh) >/dev/null 2>&1
-then :
+if test -n "${ZSH_VERSION+set}" && (emulate sh) >/dev/null 2>&1; then :
   emulate sh
   NULLCMD=:
   # Pre-4.2 versions of Zsh do word splitting on ${1+"$@"}, which
   # is contrary to our usage.  Disable this feature.
   alias -g '${1+"$@"}'='"$@"'
   setopt NO_GLOB_SUBST
-else $as_nop
+else
   case `(set -o) 2>/dev/null` in #(
   *posix*) :
     set -o posix ;; #(
@@ -36,46 +33,46 @@ esac
 fi
 
 
-
-# Reset variables that may have inherited troublesome values from
-# the environment.
-
-# IFS needs to be set, to space, tab, and newline, in precisely that order.
-# (If _AS_PATH_WALK were called with IFS unset, it would have the
-# side effect of setting IFS to empty, thus disabling word splitting.)
-# Quoting is to prevent editors from complaining about space-tab.
 as_nl='
 '
 export as_nl
-IFS=" ""	$as_nl"
-
-PS1='$ '
-PS2='> '
-PS4='+ '
-
-# Ensure predictable behavior from utilities with locale-dependent output.
-LC_ALL=C
-export LC_ALL
-LANGUAGE=C
-export LANGUAGE
-
-# We cannot yet rely on "unset" to work, but we need these variables
-# to be unset--not just set to an empty or harmless value--now, to
-# avoid bugs in old shells (e.g. pre-3.0 UWIN ksh).  This construct
-# also avoids known problems related to "unset" and subshell syntax
-# in other old shells (e.g. bash 2.01 and pdksh 5.2.14).
-for as_var in BASH_ENV ENV MAIL MAILPATH CDPATH
-do eval test \${$as_var+y} \
-  && ( (unset $as_var) || exit 1) >/dev/null 2>&1 && unset $as_var || :
-done
-
-# Ensure that fds 0, 1, and 2 are open.
-if (exec 3>&0) 2>/dev/null; then :; else exec 0</dev/null; fi
-if (exec 3>&1) 2>/dev/null; then :; else exec 1>/dev/null; fi
-if (exec 3>&2)            ; then :; else exec 2>/dev/null; fi
+# Printing a long string crashes Solaris 7 /usr/bin/printf.
+as_echo='\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\'
+as_echo=$as_echo$as_echo$as_echo$as_echo$as_echo
+as_echo=$as_echo$as_echo$as_echo$as_echo$as_echo$as_echo
+# Prefer a ksh shell builtin over an external printf program on Solaris,
+# but without wasting forks for bash or zsh.
+if test -z "$BASH_VERSION$ZSH_VERSION" \
+    && (test "X`print -r -- $as_echo`" = "X$as_echo") 2>/dev/null; then
+  as_echo='print -r --'
+  as_echo_n='print -rn --'
+elif (test "X`printf %s $as_echo`" = "X$as_echo") 2>/dev/null; then
+  as_echo='printf %s\n'
+  as_echo_n='printf %s'
+else
+  if test "X`(/usr/ucb/echo -n -n $as_echo) 2>/dev/null`" = "X-n $as_echo"; then
+    as_echo_body='eval /usr/ucb/echo -n "$1$as_nl"'
+    as_echo_n='/usr/ucb/echo -n'
+  else
+    as_echo_body='eval expr "X$1" : "X\\(.*\\)"'
+    as_echo_n_body='eval
+      arg=$1;
+      case $arg in #(
+      *"$as_nl"*)
+	expr "X$arg" : "X\\(.*\\)$as_nl";
+	arg=`expr "X$arg" : ".*$as_nl\\(.*\\)"`;;
+      esac;
+      expr "X$arg" : "X\\(.*\\)" | tr -d "$as_nl"
+    '
+    export as_echo_n_body
+    as_echo_n='sh -c $as_echo_n_body as_echo'
+  fi
+  export as_echo_body
+  as_echo='sh -c $as_echo_body as_echo'
+fi
 
 # The user is always right.
-if ${PATH_SEPARATOR+false} :; then
+if test "${PATH_SEPARATOR+set}" != set; then
   PATH_SEPARATOR=:
   (PATH='/bin;/bin'; FPATH=$PATH; sh -c :) >/dev/null 2>&1 && {
     (PATH='/bin:/bin'; FPATH=$PATH; sh -c :) >/dev/null 2>&1 ||
@@ -83,6 +80,13 @@ if ${PATH_SEPARATOR+false} :; then
   }
 fi
 
+
+# IFS
+# We need space, tab and new line, in precisely that order.  Quoting is
+# there to prevent editors from complaining about space-tab.
+# (If _AS_PATH_WALK were called with IFS unset, it would disable word
+# splitting by setting IFS to empty value.)
+IFS=" ""	$as_nl"
 
 # Find who we are.  Look in the path if we contain no directory separator.
 as_myself=
@@ -92,12 +96,8 @@ case $0 in #((
 for as_dir in $PATH
 do
   IFS=$as_save_IFS
-  case $as_dir in #(((
-    '') as_dir=./ ;;
-    */) ;;
-    *) as_dir=$as_dir/ ;;
-  esac
-    test -r "$as_dir$0" && as_myself=$as_dir$0 && break
+  test -z "$as_dir" && as_dir=.
+    test -r "$as_dir/$0" && as_myself=$as_dir/$0 && break
   done
 IFS=$as_save_IFS
 
@@ -109,10 +109,30 @@ if test "x$as_myself" = x; then
   as_myself=$0
 fi
 if test ! -f "$as_myself"; then
-  printf "%s\n" "$as_myself: error: cannot find myself; rerun with an absolute file name" >&2
+  $as_echo "$as_myself: error: cannot find myself; rerun with an absolute file name" >&2
   exit 1
 fi
 
+# Unset variables that we do not need and which cause bugs (e.g. in
+# pre-3.0 UWIN ksh).  But do not cause bugs in bash 2.01; the "|| exit 1"
+# suppresses any "Segmentation fault" message there.  '((' could
+# trigger a bug in pdksh 5.2.14.
+for as_var in BASH_ENV ENV MAIL MAILPATH
+do eval test x\${$as_var+set} = xset \
+  && ( (unset $as_var) || exit 1) >/dev/null 2>&1 && unset $as_var || :
+done
+PS1='$ '
+PS2='> '
+PS4='+ '
+
+# NLS nuisances.
+LC_ALL=C
+export LC_ALL
+LANGUAGE=C
+export LANGUAGE
+
+# CDPATH.
+(unset CDPATH) >/dev/null 2>&1 && unset CDPATH
 
 # Use a proper internal environment variable to ensure we don't fall
   # into an infinite loop, continuously re-executing ourselves.
@@ -134,22 +154,20 @@ esac
 exec $CONFIG_SHELL $as_opts "$as_myself" ${1+"$@"}
 # Admittedly, this is quite paranoid, since all the known shells bail
 # out after a failed `exec'.
-printf "%s\n" "$0: could not re-execute with $CONFIG_SHELL" >&2
-exit 255
+$as_echo "$0: could not re-execute with $CONFIG_SHELL" >&2
+as_fn_exit 255
   fi
   # We don't want this to propagate to other subprocesses.
           { _as_can_reexec=; unset _as_can_reexec;}
 if test "x$CONFIG_SHELL" = x; then
-  as_bourne_compatible="as_nop=:
-if test \${ZSH_VERSION+y} && (emulate sh) >/dev/null 2>&1
-then :
+  as_bourne_compatible="if test -n \"\${ZSH_VERSION+set}\" && (emulate sh) >/dev/null 2>&1; then :
   emulate sh
   NULLCMD=:
   # Pre-4.2 versions of Zsh do word splitting on \${1+\"\$@\"}, which
   # is contrary to our usage.  Disable this feature.
   alias -g '\${1+\"\$@\"}'='\"\$@\"'
   setopt NO_GLOB_SUBST
-else \$as_nop
+else
   case \`(set -o) 2>/dev/null\` in #(
   *posix*) :
     set -o posix ;; #(
@@ -169,20 +187,18 @@ as_fn_success || { exitcode=1; echo as_fn_success failed.; }
 as_fn_failure && { exitcode=1; echo as_fn_failure succeeded.; }
 as_fn_ret_success || { exitcode=1; echo as_fn_ret_success failed.; }
 as_fn_ret_failure && { exitcode=1; echo as_fn_ret_failure succeeded.; }
-if ( set x; as_fn_ret_success y && test x = \"\$1\" )
-then :
+if ( set x; as_fn_ret_success y && test x = \"\$1\" ); then :
 
-else \$as_nop
+else
   exitcode=1; echo positional parameters were not saved.
 fi
 test x\$exitcode = x0 || exit 1
-blah=\$(echo \$(echo blah))
-test x\"\$blah\" = xblah || exit 1
 test -x / || exit 1"
   as_suggested="  as_lineno_1=";as_suggested=$as_suggested$LINENO;as_suggested=$as_suggested" as_lineno_1a=\$LINENO
   as_lineno_2=";as_suggested=$as_suggested$LINENO;as_suggested=$as_suggested" as_lineno_2a=\$LINENO
   eval 'test \"x\$as_lineno_1'\$as_run'\" != \"x\$as_lineno_2'\$as_run'\" &&
   test \"x\`expr \$as_lineno_1'\$as_run' + 1\`\" = \"x\$as_lineno_2'\$as_run'\"' || exit 1
+test \$(( 1 + 1 )) = 2 || exit 1
 
   test -n \"\${ZSH_VERSION+set}\${BASH_VERSION+set}\" || (
     ECHO='\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\'
@@ -190,40 +206,31 @@ test -x / || exit 1"
     ECHO=\$ECHO\$ECHO\$ECHO\$ECHO\$ECHO\$ECHO
     PATH=/empty FPATH=/empty; export PATH FPATH
     test \"X\`printf %s \$ECHO\`\" = \"X\$ECHO\" \\
-      || test \"X\`print -r -- \$ECHO\`\" = \"X\$ECHO\" ) || exit 1
-test \$(( 1 + 1 )) = 2 || exit 1"
-  if (eval "$as_required") 2>/dev/null
-then :
+      || test \"X\`print -r -- \$ECHO\`\" = \"X\$ECHO\" ) || exit 1"
+  if (eval "$as_required") 2>/dev/null; then :
   as_have_required=yes
-else $as_nop
+else
   as_have_required=no
 fi
-  if test x$as_have_required = xyes && (eval "$as_suggested") 2>/dev/null
-then :
+  if test x$as_have_required = xyes && (eval "$as_suggested") 2>/dev/null; then :
 
-else $as_nop
+else
   as_save_IFS=$IFS; IFS=$PATH_SEPARATOR
 as_found=false
 for as_dir in /bin$PATH_SEPARATOR/usr/bin$PATH_SEPARATOR$PATH
 do
   IFS=$as_save_IFS
-  case $as_dir in #(((
-    '') as_dir=./ ;;
-    */) ;;
-    *) as_dir=$as_dir/ ;;
-  esac
+  test -z "$as_dir" && as_dir=.
   as_found=:
   case $as_dir in #(
 	 /*)
 	   for as_base in sh bash ksh sh5; do
 	     # Try only shells that exist, to save several forks.
-	     as_shell=$as_dir$as_base
+	     as_shell=$as_dir/$as_base
 	     if { test -f "$as_shell" || test -f "$as_shell.exe"; } &&
-		    as_run=a "$as_shell" -c "$as_bourne_compatible""$as_required" 2>/dev/null
-then :
+		    { $as_echo "$as_bourne_compatible""$as_required" | as_run=a "$as_shell"; } 2>/dev/null; then :
   CONFIG_SHELL=$as_shell as_have_required=yes
-		   if as_run=a "$as_shell" -c "$as_bourne_compatible""$as_suggested" 2>/dev/null
-then :
+		   if { $as_echo "$as_bourne_compatible""$as_suggested" | as_run=a "$as_shell"; } 2>/dev/null; then :
   break 2
 fi
 fi
@@ -231,21 +238,14 @@ fi
        esac
   as_found=false
 done
-IFS=$as_save_IFS
-if $as_found
-then :
-
-else $as_nop
-  if { test -f "$SHELL" || test -f "$SHELL.exe"; } &&
-	      as_run=a "$SHELL" -c "$as_bourne_compatible""$as_required" 2>/dev/null
-then :
+$as_found || { if { test -f "$SHELL" || test -f "$SHELL.exe"; } &&
+	      { $as_echo "$as_bourne_compatible""$as_required" | as_run=a "$SHELL"; } 2>/dev/null; then :
   CONFIG_SHELL=$SHELL as_have_required=yes
-fi
-fi
+fi; }
+IFS=$as_save_IFS
 
 
-      if test "x$CONFIG_SHELL" != x
-then :
+      if test "x$CONFIG_SHELL" != x; then :
   export CONFIG_SHELL
              # We cannot yet assume a decent shell, so we have to provide a
 # neutralization value for shells without unset; and this also
@@ -263,19 +263,18 @@ esac
 exec $CONFIG_SHELL $as_opts "$as_myself" ${1+"$@"}
 # Admittedly, this is quite paranoid, since all the known shells bail
 # out after a failed `exec'.
-printf "%s\n" "$0: could not re-execute with $CONFIG_SHELL" >&2
+$as_echo "$0: could not re-execute with $CONFIG_SHELL" >&2
 exit 255
 fi
 
-    if test x$as_have_required = xno
-then :
-  printf "%s\n" "$0: This script requires a shell more modern than all"
-  printf "%s\n" "$0: the shells that I found on your system."
-  if test ${ZSH_VERSION+y} ; then
-    printf "%s\n" "$0: In particular, zsh $ZSH_VERSION has bugs and should"
-    printf "%s\n" "$0: be upgraded to zsh 4.3.4 or later."
+    if test x$as_have_required = xno; then :
+  $as_echo "$0: This script requires a shell more modern than all"
+  $as_echo "$0: the shells that I found on your system."
+  if test x${ZSH_VERSION+set} = xset ; then
+    $as_echo "$0: In particular, zsh $ZSH_VERSION has bugs and should"
+    $as_echo "$0: be upgraded to zsh 4.3.4 or later."
   else
-    printf "%s\n" "$0: Please tell bug-autoconf@gnu.org and
+    $as_echo "$0: Please tell bug-autoconf@gnu.org and
 $0: unbound-bugs@nlnetlabs.nl or
 $0: https://github.com/NLnetLabs/unbound/issues about your
 $0: system, including any error possibly output before this
@@ -304,7 +303,6 @@ as_fn_unset ()
 }
 as_unset=as_fn_unset
 
-
 # as_fn_set_status STATUS
 # -----------------------
 # Set $? to STATUS, without forking.
@@ -322,14 +320,6 @@ as_fn_exit ()
   as_fn_set_status $1
   exit $1
 } # as_fn_exit
-# as_fn_nop
-# ---------
-# Do nothing but, unlike ":", preserve the value of $?.
-as_fn_nop ()
-{
-  return $?
-}
-as_nop=as_fn_nop
 
 # as_fn_mkdir_p
 # -------------
@@ -344,7 +334,7 @@ as_fn_mkdir_p ()
     as_dirs=
     while :; do
       case $as_dir in #(
-      *\'*) as_qdir=`printf "%s\n" "$as_dir" | sed "s/'/'\\\\\\\\''/g"`;; #'(
+      *\'*) as_qdir=`$as_echo "$as_dir" | sed "s/'/'\\\\\\\\''/g"`;; #'(
       *) as_qdir=$as_dir;;
       esac
       as_dirs="'$as_qdir' $as_dirs"
@@ -353,7 +343,7 @@ $as_expr X"$as_dir" : 'X\(.*[^/]\)//*[^/][^/]*/*$' \| \
 	 X"$as_dir" : 'X\(//\)[^/]' \| \
 	 X"$as_dir" : 'X\(//\)$' \| \
 	 X"$as_dir" : 'X\(/\)' \| . 2>/dev/null ||
-printf "%s\n" X"$as_dir" |
+$as_echo X"$as_dir" |
     sed '/^X\(.*[^/]\)\/\/*[^/][^/]*\/*$/{
 	    s//\1/
 	    q
@@ -392,13 +382,12 @@ as_fn_executable_p ()
 # advantage of any shell optimizations that allow amortized linear growth over
 # repeated appends, instead of the typical quadratic growth present in naive
 # implementations.
-if (eval "as_var=1; as_var+=2; test x\$as_var = x12") 2>/dev/null
-then :
+if (eval "as_var=1; as_var+=2; test x\$as_var = x12") 2>/dev/null; then :
   eval 'as_fn_append ()
   {
     eval $1+=\$2
   }'
-else $as_nop
+else
   as_fn_append ()
   {
     eval $1=\$$1\$2
@@ -410,27 +399,18 @@ fi # as_fn_append
 # Perform arithmetic evaluation on the ARGs, and store the result in the
 # global $as_val. Take advantage of shells that can avoid forks. The arguments
 # must be portable across $(()) and expr.
-if (eval "test \$(( 1 + 1 )) = 2") 2>/dev/null
-then :
+if (eval "test \$(( 1 + 1 )) = 2") 2>/dev/null; then :
   eval 'as_fn_arith ()
   {
     as_val=$(( $* ))
   }'
-else $as_nop
+else
   as_fn_arith ()
   {
     as_val=`expr "$@" || test $? -eq 1`
   }
 fi # as_fn_arith
 
-# as_fn_nop
-# ---------
-# Do nothing but, unlike ":", preserve the value of $?.
-as_fn_nop ()
-{
-  return $?
-}
-as_nop=as_fn_nop
 
 # as_fn_error STATUS ERROR [LINENO LOG_FD]
 # ----------------------------------------
@@ -442,9 +422,9 @@ as_fn_error ()
   as_status=$1; test $as_status -eq 0 && as_status=1
   if test "$4"; then
     as_lineno=${as_lineno-"$3"} as_lineno_stack=as_lineno_stack=$as_lineno_stack
-    printf "%s\n" "$as_me:${as_lineno-$LINENO}: error: $2" >&$4
+    $as_echo "$as_me:${as_lineno-$LINENO}: error: $2" >&$4
   fi
-  printf "%s\n" "$as_me: error: $2" >&2
+  $as_echo "$as_me: error: $2" >&2
   as_fn_exit $as_status
 } # as_fn_error
 
@@ -471,7 +451,7 @@ as_me=`$as_basename -- "$0" ||
 $as_expr X/"$0" : '.*/\([^/][^/]*\)/*$' \| \
 	 X"$0" : 'X\(//\)$' \| \
 	 X"$0" : 'X\(/\)' \| . 2>/dev/null ||
-printf "%s\n" X/"$0" |
+$as_echo X/"$0" |
     sed '/^.*\/\([^/][^/]*\)\/*$/{
 	    s//\1/
 	    q
@@ -515,7 +495,7 @@ as_cr_alnum=$as_cr_Letters$as_cr_digits
       s/-\n.*//
     ' >$as_me.lineno &&
   chmod +x "$as_me.lineno" ||
-    { printf "%s\n" "$as_me: error: cannot create $as_me.lineno; rerun with a POSIX shell" >&2; as_fn_exit 1; }
+    { $as_echo "$as_me: error: cannot create $as_me.lineno; rerun with a POSIX shell" >&2; as_fn_exit 1; }
 
   # If we had to re-execute with $CONFIG_SHELL, we're ensured to have
   # already done that, so ensure we don't try to do so again and fall
@@ -529,10 +509,6 @@ as_cr_alnum=$as_cr_Letters$as_cr_digits
   exit
 }
 
-
-# Determine whether it's possible to make 'echo' print without a newline.
-# These variables are no longer used directly by Autoconf, but are AC_SUBSTed
-# for compatibility with existing Makefiles.
 ECHO_C= ECHO_N= ECHO_T=
 case `echo -n x` in #(((((
 -n*)
@@ -545,13 +521,6 @@ case `echo -n x` in #(((((
 *)
   ECHO_N='-n';;
 esac
-
-# For backward compatibility with old third-party macros, we provide
-# the shell variables $as_echo and $as_echo_n.  New code should use
-# AS_ECHO(["message"]) and AS_ECHO_N(["message"]), respectively.
-as_echo='printf %s\n'
-as_echo_n='printf %s'
-
 
 rm -f conf$$ conf$$.exe conf$$.file
 if test -d conf$$.dir; then
@@ -629,15 +598,29 @@ PACKAGE_URL=''
 
 # Factoring default headers for most tests.
 ac_includes_default="\
-#include <stddef.h>
-#ifdef HAVE_STDIO_H
-# include <stdio.h>
+#include <stdio.h>
+#ifdef HAVE_SYS_TYPES_H
+# include <sys/types.h>
 #endif
-#ifdef HAVE_STDLIB_H
+#ifdef HAVE_SYS_STAT_H
+# include <sys/stat.h>
+#endif
+#ifdef STDC_HEADERS
 # include <stdlib.h>
+# include <stddef.h>
+#else
+# ifdef HAVE_STDLIB_H
+#  include <stdlib.h>
+# endif
 #endif
 #ifdef HAVE_STRING_H
+# if !defined STDC_HEADERS && defined HAVE_MEMORY_H
+#  include <memory.h>
+# endif
 # include <string.h>
+#endif
+#ifdef HAVE_STRINGS_H
+# include <strings.h>
 #endif
 #ifdef HAVE_INTTYPES_H
 # include <inttypes.h>
@@ -645,21 +628,10 @@ ac_includes_default="\
 #ifdef HAVE_STDINT_H
 # include <stdint.h>
 #endif
-#ifdef HAVE_STRINGS_H
-# include <strings.h>
-#endif
-#ifdef HAVE_SYS_TYPES_H
-# include <sys/types.h>
-#endif
-#ifdef HAVE_SYS_STAT_H
-# include <sys/stat.h>
-#endif
 #ifdef HAVE_UNISTD_H
 # include <unistd.h>
 #endif"
 
-ac_header_c_list=
-ac_func_c_list=
 ac_subst_vars='LTLIBOBJS
 date
 version
@@ -752,7 +724,6 @@ SYSTEMD_LIBS
 SYSTEMD_CFLAGS
 RUNTIME_PATH
 LIBOBJS
-CPP
 PKG_CONFIG_LIBDIR
 PKG_CONFIG_PATH
 PKG_CONFIG
@@ -774,8 +745,6 @@ ac_ct_DUMPBIN
 DUMPBIN
 LD
 FGREP
-EGREP
-GREP
 SED
 LIBTOOL
 AR
@@ -809,6 +778,9 @@ ub_conf_file
 UNBOUND_LOCALSTATE_DIR
 UNBOUND_SYSCONF_DIR
 UNBOUND_SBIN_DIR
+EGREP
+GREP
+CPP
 OBJEXT
 EXEEXT
 ac_ct_CC
@@ -943,13 +915,13 @@ CFLAGS
 LDFLAGS
 LIBS
 CPPFLAGS
+CPP
 YACC
 YFLAGS
 LT_SYS_LIBRARY_PATH
 PKG_CONFIG
 PKG_CONFIG_PATH
 PKG_CONFIG_LIBDIR
-CPP
 SYSTEMD_CFLAGS
 SYSTEMD_LIBS
 SYSTEMD_DAEMON_CFLAGS
@@ -1023,6 +995,8 @@ do
   *)    ac_optarg=yes ;;
   esac
 
+  # Accept the important Cygnus configure options, so we can diagnose typos.
+
   case $ac_dashdash$ac_option in
   --)
     ac_dashdash=yes ;;
@@ -1063,9 +1037,9 @@ do
     ac_useropt=`expr "x$ac_option" : 'x-*disable-\(.*\)'`
     # Reject names that are not valid shell variable names.
     expr "x$ac_useropt" : ".*[^-+._$as_cr_alnum]" >/dev/null &&
-      as_fn_error $? "invalid feature name: \`$ac_useropt'"
+      as_fn_error $? "invalid feature name: $ac_useropt"
     ac_useropt_orig=$ac_useropt
-    ac_useropt=`printf "%s\n" "$ac_useropt" | sed 's/[-+.]/_/g'`
+    ac_useropt=`$as_echo "$ac_useropt" | sed 's/[-+.]/_/g'`
     case $ac_user_opts in
       *"
 "enable_$ac_useropt"
@@ -1089,9 +1063,9 @@ do
     ac_useropt=`expr "x$ac_option" : 'x-*enable-\([^=]*\)'`
     # Reject names that are not valid shell variable names.
     expr "x$ac_useropt" : ".*[^-+._$as_cr_alnum]" >/dev/null &&
-      as_fn_error $? "invalid feature name: \`$ac_useropt'"
+      as_fn_error $? "invalid feature name: $ac_useropt"
     ac_useropt_orig=$ac_useropt
-    ac_useropt=`printf "%s\n" "$ac_useropt" | sed 's/[-+.]/_/g'`
+    ac_useropt=`$as_echo "$ac_useropt" | sed 's/[-+.]/_/g'`
     case $ac_user_opts in
       *"
 "enable_$ac_useropt"
@@ -1302,9 +1276,9 @@ do
     ac_useropt=`expr "x$ac_option" : 'x-*with-\([^=]*\)'`
     # Reject names that are not valid shell variable names.
     expr "x$ac_useropt" : ".*[^-+._$as_cr_alnum]" >/dev/null &&
-      as_fn_error $? "invalid package name: \`$ac_useropt'"
+      as_fn_error $? "invalid package name: $ac_useropt"
     ac_useropt_orig=$ac_useropt
-    ac_useropt=`printf "%s\n" "$ac_useropt" | sed 's/[-+.]/_/g'`
+    ac_useropt=`$as_echo "$ac_useropt" | sed 's/[-+.]/_/g'`
     case $ac_user_opts in
       *"
 "with_$ac_useropt"
@@ -1318,9 +1292,9 @@ do
     ac_useropt=`expr "x$ac_option" : 'x-*without-\(.*\)'`
     # Reject names that are not valid shell variable names.
     expr "x$ac_useropt" : ".*[^-+._$as_cr_alnum]" >/dev/null &&
-      as_fn_error $? "invalid package name: \`$ac_useropt'"
+      as_fn_error $? "invalid package name: $ac_useropt"
     ac_useropt_orig=$ac_useropt
-    ac_useropt=`printf "%s\n" "$ac_useropt" | sed 's/[-+.]/_/g'`
+    ac_useropt=`$as_echo "$ac_useropt" | sed 's/[-+.]/_/g'`
     case $ac_user_opts in
       *"
 "with_$ac_useropt"
@@ -1364,9 +1338,9 @@ Try \`$0 --help' for more information"
 
   *)
     # FIXME: should be removed in autoconf 3.0.
-    printf "%s\n" "$as_me: WARNING: you should use --build, --host, --target" >&2
+    $as_echo "$as_me: WARNING: you should use --build, --host, --target" >&2
     expr "x$ac_option" : ".*[^-._$as_cr_alnum]" >/dev/null &&
-      printf "%s\n" "$as_me: WARNING: invalid host type: $ac_option" >&2
+      $as_echo "$as_me: WARNING: invalid host type: $ac_option" >&2
     : "${build_alias=$ac_option} ${host_alias=$ac_option} ${target_alias=$ac_option}"
     ;;
 
@@ -1382,7 +1356,7 @@ if test -n "$ac_unrecognized_opts"; then
   case $enable_option_checking in
     no) ;;
     fatal) as_fn_error $? "unrecognized options: $ac_unrecognized_opts" ;;
-    *)     printf "%s\n" "$as_me: WARNING: unrecognized options: $ac_unrecognized_opts" >&2 ;;
+    *)     $as_echo "$as_me: WARNING: unrecognized options: $ac_unrecognized_opts" >&2 ;;
   esac
 fi
 
@@ -1446,7 +1420,7 @@ $as_expr X"$as_myself" : 'X\(.*[^/]\)//*[^/][^/]*/*$' \| \
 	 X"$as_myself" : 'X\(//\)[^/]' \| \
 	 X"$as_myself" : 'X\(//\)$' \| \
 	 X"$as_myself" : 'X\(/\)' \| . 2>/dev/null ||
-printf "%s\n" X"$as_myself" |
+$as_echo X"$as_myself" |
     sed '/^X\(.*[^/]\)\/\/*[^/][^/]*\/*$/{
 	    s//\1/
 	    q
@@ -1718,6 +1692,7 @@ Some influential environment variables:
   LIBS        libraries to pass to the linker, e.g. -l<library>
   CPPFLAGS    (Objective) C/C++ preprocessor flags, e.g. -I<include dir> if
               you have headers in a nonstandard directory <include dir>
+  CPP         C preprocessor
   YACC        The `Yet Another Compiler Compiler' implementation to use.
               Defaults to the first program found out of: `bison -y', `byacc',
               `yacc'.
@@ -1731,7 +1706,6 @@ Some influential environment variables:
               directories to add to pkg-config's search path
   PKG_CONFIG_LIBDIR
               path overriding pkg-config's built-in search path
-  CPP         C preprocessor
   SYSTEMD_CFLAGS
               C compiler flags for SYSTEMD, overriding pkg-config
   SYSTEMD_LIBS
@@ -1764,9 +1738,9 @@ if test "$ac_init_help" = "recursive"; then
 case "$ac_dir" in
 .) ac_dir_suffix= ac_top_builddir_sub=. ac_top_build_prefix= ;;
 *)
-  ac_dir_suffix=/`printf "%s\n" "$ac_dir" | sed 's|^\.[\\/]||'`
+  ac_dir_suffix=/`$as_echo "$ac_dir" | sed 's|^\.[\\/]||'`
   # A ".." for each directory in $ac_dir_suffix.
-  ac_top_builddir_sub=`printf "%s\n" "$ac_dir_suffix" | sed 's|/[^\\/]*|/..|g;s|/||'`
+  ac_top_builddir_sub=`$as_echo "$ac_dir_suffix" | sed 's|/[^\\/]*|/..|g;s|/||'`
   case $ac_top_builddir_sub in
   "") ac_top_builddir_sub=. ac_top_build_prefix= ;;
   *)  ac_top_build_prefix=$ac_top_builddir_sub/ ;;
@@ -1794,8 +1768,7 @@ esac
 ac_abs_srcdir=$ac_abs_top_srcdir$ac_dir_suffix
 
     cd "$ac_dir" || { ac_status=$?; continue; }
-    # Check for configure.gnu first; this name is used for a wrapper for
-    # Metaconfig's "Configure" on case-insensitive file systems.
+    # Check for guested configure.
     if test -f "$ac_srcdir/configure.gnu"; then
       echo &&
       $SHELL "$ac_srcdir/configure.gnu" --help=recursive
@@ -1803,7 +1776,7 @@ ac_abs_srcdir=$ac_abs_top_srcdir$ac_dir_suffix
       echo &&
       $SHELL "$ac_srcdir/configure" --help=recursive
     else
-      printf "%s\n" "$as_me: WARNING: no configuration information is in $ac_dir" >&2
+      $as_echo "$as_me: WARNING: no configuration information is in $ac_dir" >&2
     fi || ac_status=$?
     cd "$ac_pwd" || { ac_status=$?; break; }
   done
@@ -1815,7 +1788,7 @@ if $ac_init_version; then
 unbound configure 1.15.1
 generated by GNU Autoconf 2.69
 
-Copyright (C) 2021 Free Software Foundation, Inc.
+Copyright (C) 2012 Free Software Foundation, Inc.
 This configure script is free software; the Free Software Foundation
 gives unlimited permission to copy, distribute and modify it.
 _ACEOF
@@ -1832,14 +1805,14 @@ fi
 ac_fn_c_try_compile ()
 {
   as_lineno=${as_lineno-"$1"} as_lineno_stack=as_lineno_stack=$as_lineno_stack
-  rm -f conftest.$ac_objext conftest.beam
+  rm -f conftest.$ac_objext
   if { { ac_try="$ac_compile"
 case "(($ac_try" in
   *\"* | *\`* | *\\*) ac_try_echo=\$ac_try;;
   *) ac_try_echo=$ac_try;;
 esac
 eval ac_try_echo="\"\$as_me:${as_lineno-$LINENO}: $ac_try_echo\""
-printf "%s\n" "$ac_try_echo"; } >&5
+$as_echo "$ac_try_echo"; } >&5
   (eval "$ac_compile") 2>conftest.err
   ac_status=$?
   if test -s conftest.err; then
@@ -1847,15 +1820,14 @@ printf "%s\n" "$ac_try_echo"; } >&5
     cat conftest.er1 >&5
     mv -f conftest.er1 conftest.err
   fi
-  printf "%s\n" "$as_me:${as_lineno-$LINENO}: \$? = $ac_status" >&5
+  $as_echo "$as_me:${as_lineno-$LINENO}: \$? = $ac_status" >&5
   test $ac_status = 0; } && {
 	 test -z "$ac_c_werror_flag" ||
 	 test ! -s conftest.err
-       } && test -s conftest.$ac_objext
-then :
+       } && test -s conftest.$ac_objext; then :
   ac_retval=0
-else $as_nop
-  printf "%s\n" "$as_me: failed program was:" >&5
+else
+  $as_echo "$as_me: failed program was:" >&5
 sed 's/^/| /' conftest.$ac_ext >&5
 
 	ac_retval=1
@@ -1865,6 +1837,176 @@ fi
 
 } # ac_fn_c_try_compile
 
+# ac_fn_c_try_cpp LINENO
+# ----------------------
+# Try to preprocess conftest.$ac_ext, and return whether this succeeded.
+ac_fn_c_try_cpp ()
+{
+  as_lineno=${as_lineno-"$1"} as_lineno_stack=as_lineno_stack=$as_lineno_stack
+  if { { ac_try="$ac_cpp conftest.$ac_ext"
+case "(($ac_try" in
+  *\"* | *\`* | *\\*) ac_try_echo=\$ac_try;;
+  *) ac_try_echo=$ac_try;;
+esac
+eval ac_try_echo="\"\$as_me:${as_lineno-$LINENO}: $ac_try_echo\""
+$as_echo "$ac_try_echo"; } >&5
+  (eval "$ac_cpp conftest.$ac_ext") 2>conftest.err
+  ac_status=$?
+  if test -s conftest.err; then
+    grep -v '^ *+' conftest.err >conftest.er1
+    cat conftest.er1 >&5
+    mv -f conftest.er1 conftest.err
+  fi
+  $as_echo "$as_me:${as_lineno-$LINENO}: \$? = $ac_status" >&5
+  test $ac_status = 0; } > conftest.i && {
+	 test -z "$ac_c_preproc_warn_flag$ac_c_werror_flag" ||
+	 test ! -s conftest.err
+       }; then :
+  ac_retval=0
+else
+  $as_echo "$as_me: failed program was:" >&5
+sed 's/^/| /' conftest.$ac_ext >&5
+
+    ac_retval=1
+fi
+  eval $as_lineno_stack; ${as_lineno_stack:+:} unset as_lineno
+  as_fn_set_status $ac_retval
+
+} # ac_fn_c_try_cpp
+
+# ac_fn_c_check_header_mongrel LINENO HEADER VAR INCLUDES
+# -------------------------------------------------------
+# Tests whether HEADER exists, giving a warning if it cannot be compiled using
+# the include files in INCLUDES and setting the cache variable VAR
+# accordingly.
+ac_fn_c_check_header_mongrel ()
+{
+  as_lineno=${as_lineno-"$1"} as_lineno_stack=as_lineno_stack=$as_lineno_stack
+  if eval \${$3+:} false; then :
+  { $as_echo "$as_me:${as_lineno-$LINENO}: checking for $2" >&5
+$as_echo_n "checking for $2... " >&6; }
+if eval \${$3+:} false; then :
+  $as_echo_n "(cached) " >&6
+fi
+eval ac_res=\$$3
+	       { $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_res" >&5
+$as_echo "$ac_res" >&6; }
+else
+  # Is the header compilable?
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking $2 usability" >&5
+$as_echo_n "checking $2 usability... " >&6; }
+cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+/* end confdefs.h.  */
+$4
+#include <$2>
+_ACEOF
+if ac_fn_c_try_compile "$LINENO"; then :
+  ac_header_compiler=yes
+else
+  ac_header_compiler=no
+fi
+rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
+{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_header_compiler" >&5
+$as_echo "$ac_header_compiler" >&6; }
+
+# Is the header present?
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking $2 presence" >&5
+$as_echo_n "checking $2 presence... " >&6; }
+cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+/* end confdefs.h.  */
+#include <$2>
+_ACEOF
+if ac_fn_c_try_cpp "$LINENO"; then :
+  ac_header_preproc=yes
+else
+  ac_header_preproc=no
+fi
+rm -f conftest.err conftest.i conftest.$ac_ext
+{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_header_preproc" >&5
+$as_echo "$ac_header_preproc" >&6; }
+
+# So?  What about this header?
+case $ac_header_compiler:$ac_header_preproc:$ac_c_preproc_warn_flag in #((
+  yes:no: )
+    { $as_echo "$as_me:${as_lineno-$LINENO}: WARNING: $2: accepted by the compiler, rejected by the preprocessor!" >&5
+$as_echo "$as_me: WARNING: $2: accepted by the compiler, rejected by the preprocessor!" >&2;}
+    { $as_echo "$as_me:${as_lineno-$LINENO}: WARNING: $2: proceeding with the compiler's result" >&5
+$as_echo "$as_me: WARNING: $2: proceeding with the compiler's result" >&2;}
+    ;;
+  no:yes:* )
+    { $as_echo "$as_me:${as_lineno-$LINENO}: WARNING: $2: present but cannot be compiled" >&5
+$as_echo "$as_me: WARNING: $2: present but cannot be compiled" >&2;}
+    { $as_echo "$as_me:${as_lineno-$LINENO}: WARNING: $2:     check for missing prerequisite headers?" >&5
+$as_echo "$as_me: WARNING: $2:     check for missing prerequisite headers?" >&2;}
+    { $as_echo "$as_me:${as_lineno-$LINENO}: WARNING: $2: see the Autoconf documentation" >&5
+$as_echo "$as_me: WARNING: $2: see the Autoconf documentation" >&2;}
+    { $as_echo "$as_me:${as_lineno-$LINENO}: WARNING: $2:     section \"Present But Cannot Be Compiled\"" >&5
+$as_echo "$as_me: WARNING: $2:     section \"Present But Cannot Be Compiled\"" >&2;}
+    { $as_echo "$as_me:${as_lineno-$LINENO}: WARNING: $2: proceeding with the compiler's result" >&5
+$as_echo "$as_me: WARNING: $2: proceeding with the compiler's result" >&2;}
+( $as_echo "## --------------------------------------------------------------------------------------- ##
+## Report this to unbound-bugs@nlnetlabs.nl or https://github.com/NLnetLabs/unbound/issues ##
+## --------------------------------------------------------------------------------------- ##"
+     ) | sed "s/^/$as_me: WARNING:     /" >&2
+    ;;
+esac
+  { $as_echo "$as_me:${as_lineno-$LINENO}: checking for $2" >&5
+$as_echo_n "checking for $2... " >&6; }
+if eval \${$3+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
+  eval "$3=\$ac_header_compiler"
+fi
+eval ac_res=\$$3
+	       { $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_res" >&5
+$as_echo "$ac_res" >&6; }
+fi
+  eval $as_lineno_stack; ${as_lineno_stack:+:} unset as_lineno
+
+} # ac_fn_c_check_header_mongrel
+
+# ac_fn_c_try_run LINENO
+# ----------------------
+# Try to link conftest.$ac_ext, and return whether this succeeded. Assumes
+# that executables *can* be run.
+ac_fn_c_try_run ()
+{
+  as_lineno=${as_lineno-"$1"} as_lineno_stack=as_lineno_stack=$as_lineno_stack
+  if { { ac_try="$ac_link"
+case "(($ac_try" in
+  *\"* | *\`* | *\\*) ac_try_echo=\$ac_try;;
+  *) ac_try_echo=$ac_try;;
+esac
+eval ac_try_echo="\"\$as_me:${as_lineno-$LINENO}: $ac_try_echo\""
+$as_echo "$ac_try_echo"; } >&5
+  (eval "$ac_link") 2>&5
+  ac_status=$?
+  $as_echo "$as_me:${as_lineno-$LINENO}: \$? = $ac_status" >&5
+  test $ac_status = 0; } && { ac_try='./conftest$ac_exeext'
+  { { case "(($ac_try" in
+  *\"* | *\`* | *\\*) ac_try_echo=\$ac_try;;
+  *) ac_try_echo=$ac_try;;
+esac
+eval ac_try_echo="\"\$as_me:${as_lineno-$LINENO}: $ac_try_echo\""
+$as_echo "$ac_try_echo"; } >&5
+  (eval "$ac_try") 2>&5
+  ac_status=$?
+  $as_echo "$as_me:${as_lineno-$LINENO}: \$? = $ac_status" >&5
+  test $ac_status = 0; }; }; then :
+  ac_retval=0
+else
+  $as_echo "$as_me: program exited with status $ac_status" >&5
+       $as_echo "$as_me: failed program was:" >&5
+sed 's/^/| /' conftest.$ac_ext >&5
+
+       ac_retval=$ac_status
+fi
+  rm -rf conftest.dSYM conftest_ipa8_conftest.oo
+  eval $as_lineno_stack; ${as_lineno_stack:+:} unset as_lineno
+  as_fn_set_status $ac_retval
+
+} # ac_fn_c_try_run
+
 # ac_fn_c_check_header_compile LINENO HEADER VAR INCLUDES
 # -------------------------------------------------------
 # Tests whether HEADER exists and can be compiled using the include files in
@@ -1872,28 +2014,26 @@ fi
 ac_fn_c_check_header_compile ()
 {
   as_lineno=${as_lineno-"$1"} as_lineno_stack=as_lineno_stack=$as_lineno_stack
-  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for $2" >&5
-printf %s "checking for $2... " >&6; }
-if eval test \${$3+y}
-then :
-  printf %s "(cached) " >&6
-else $as_nop
+  { $as_echo "$as_me:${as_lineno-$LINENO}: checking for $2" >&5
+$as_echo_n "checking for $2... " >&6; }
+if eval \${$3+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
   cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 /* end confdefs.h.  */
 $4
 #include <$2>
 _ACEOF
-if ac_fn_c_try_compile "$LINENO"
-then :
+if ac_fn_c_try_compile "$LINENO"; then :
   eval "$3=yes"
-else $as_nop
+else
   eval "$3=no"
 fi
-rm -f core conftest.err conftest.$ac_objext conftest.beam conftest.$ac_ext
+rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
 fi
 eval ac_res=\$$3
-	       { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $ac_res" >&5
-printf "%s\n" "$ac_res" >&6; }
+	       { $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_res" >&5
+$as_echo "$ac_res" >&6; }
   eval $as_lineno_stack; ${as_lineno_stack:+:} unset as_lineno
 
 } # ac_fn_c_check_header_compile
@@ -1904,14 +2044,14 @@ printf "%s\n" "$ac_res" >&6; }
 ac_fn_c_try_link ()
 {
   as_lineno=${as_lineno-"$1"} as_lineno_stack=as_lineno_stack=$as_lineno_stack
-  rm -f conftest.$ac_objext conftest.beam conftest$ac_exeext
+  rm -f conftest.$ac_objext conftest$ac_exeext
   if { { ac_try="$ac_link"
 case "(($ac_try" in
   *\"* | *\`* | *\\*) ac_try_echo=\$ac_try;;
   *) ac_try_echo=$ac_try;;
 esac
 eval ac_try_echo="\"\$as_me:${as_lineno-$LINENO}: $ac_try_echo\""
-printf "%s\n" "$ac_try_echo"; } >&5
+$as_echo "$ac_try_echo"; } >&5
   (eval "$ac_link") 2>conftest.err
   ac_status=$?
   if test -s conftest.err; then
@@ -1919,18 +2059,17 @@ printf "%s\n" "$ac_try_echo"; } >&5
     cat conftest.er1 >&5
     mv -f conftest.er1 conftest.err
   fi
-  printf "%s\n" "$as_me:${as_lineno-$LINENO}: \$? = $ac_status" >&5
+  $as_echo "$as_me:${as_lineno-$LINENO}: \$? = $ac_status" >&5
   test $ac_status = 0; } && {
 	 test -z "$ac_c_werror_flag" ||
 	 test ! -s conftest.err
        } && test -s conftest$ac_exeext && {
 	 test "$cross_compiling" = yes ||
 	 test -x conftest$ac_exeext
-       }
-then :
+       }; then :
   ac_retval=0
-else $as_nop
-  printf "%s\n" "$as_me: failed program was:" >&5
+else
+  $as_echo "$as_me: failed program was:" >&5
 sed 's/^/| /' conftest.$ac_ext >&5
 
 	ac_retval=1
@@ -1951,12 +2090,11 @@ fi
 ac_fn_c_check_func ()
 {
   as_lineno=${as_lineno-"$1"} as_lineno_stack=as_lineno_stack=$as_lineno_stack
-  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for $2" >&5
-printf %s "checking for $2... " >&6; }
-if eval test \${$3+y}
-then :
-  printf %s "(cached) " >&6
-else $as_nop
+  { $as_echo "$as_me:${as_lineno-$LINENO}: checking for $2" >&5
+$as_echo_n "checking for $2... " >&6; }
+if eval \${$3+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
   cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 /* end confdefs.h.  */
 /* Define $2 to an innocuous variant, in case <limits.h> declares $2.
@@ -1964,9 +2102,16 @@ else $as_nop
 #define $2 innocuous_$2
 
 /* System header to define __stub macros and hopefully few prototypes,
-   which can conflict with char $2 (); below.  */
+    which can conflict with char $2 (); below.
+    Prefer <limits.h> to <assert.h> if __STDC__ is defined, since
+    <limits.h> exists even on freestanding compilers.  */
 
-#include <limits.h>
+#ifdef __STDC__
+# include <limits.h>
+#else
+# include <assert.h>
+#endif
+
 #undef $2
 
 /* Override any GCC internal prototype to avoid an error.
@@ -1984,25 +2129,24 @@ choke me
 #endif
 
 int
-main (void)
+main ()
 {
 return $2 ();
   ;
   return 0;
 }
 _ACEOF
-if ac_fn_c_try_link "$LINENO"
-then :
+if ac_fn_c_try_link "$LINENO"; then :
   eval "$3=yes"
-else $as_nop
+else
   eval "$3=no"
 fi
-rm -f core conftest.err conftest.$ac_objext conftest.beam \
+rm -f core conftest.err conftest.$ac_objext \
     conftest$ac_exeext conftest.$ac_ext
 fi
 eval ac_res=\$$3
-	       { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $ac_res" >&5
-printf "%s\n" "$ac_res" >&6; }
+	       { $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_res" >&5
+$as_echo "$ac_res" >&6; }
   eval $as_lineno_stack; ${as_lineno_stack:+:} unset as_lineno
 
 } # ac_fn_c_check_func
@@ -2014,18 +2158,17 @@ printf "%s\n" "$ac_res" >&6; }
 ac_fn_c_check_type ()
 {
   as_lineno=${as_lineno-"$1"} as_lineno_stack=as_lineno_stack=$as_lineno_stack
-  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for $2" >&5
-printf %s "checking for $2... " >&6; }
-if eval test \${$3+y}
-then :
-  printf %s "(cached) " >&6
-else $as_nop
+  { $as_echo "$as_me:${as_lineno-$LINENO}: checking for $2" >&5
+$as_echo_n "checking for $2... " >&6; }
+if eval \${$3+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
   eval "$3=no"
   cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 /* end confdefs.h.  */
 $4
 int
-main (void)
+main ()
 {
 if (sizeof ($2))
 	 return 0;
@@ -2033,13 +2176,12 @@ if (sizeof ($2))
   return 0;
 }
 _ACEOF
-if ac_fn_c_try_compile "$LINENO"
-then :
+if ac_fn_c_try_compile "$LINENO"; then :
   cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 /* end confdefs.h.  */
 $4
 int
-main (void)
+main ()
 {
 if (sizeof (($2)))
 	    return 0;
@@ -2047,103 +2189,21 @@ if (sizeof (($2)))
   return 0;
 }
 _ACEOF
-if ac_fn_c_try_compile "$LINENO"
-then :
+if ac_fn_c_try_compile "$LINENO"; then :
 
-else $as_nop
+else
   eval "$3=yes"
 fi
-rm -f core conftest.err conftest.$ac_objext conftest.beam conftest.$ac_ext
+rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
 fi
-rm -f core conftest.err conftest.$ac_objext conftest.beam conftest.$ac_ext
+rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
 fi
 eval ac_res=\$$3
-	       { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $ac_res" >&5
-printf "%s\n" "$ac_res" >&6; }
+	       { $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_res" >&5
+$as_echo "$ac_res" >&6; }
   eval $as_lineno_stack; ${as_lineno_stack:+:} unset as_lineno
 
 } # ac_fn_c_check_type
-
-# ac_fn_c_try_cpp LINENO
-# ----------------------
-# Try to preprocess conftest.$ac_ext, and return whether this succeeded.
-ac_fn_c_try_cpp ()
-{
-  as_lineno=${as_lineno-"$1"} as_lineno_stack=as_lineno_stack=$as_lineno_stack
-  if { { ac_try="$ac_cpp conftest.$ac_ext"
-case "(($ac_try" in
-  *\"* | *\`* | *\\*) ac_try_echo=\$ac_try;;
-  *) ac_try_echo=$ac_try;;
-esac
-eval ac_try_echo="\"\$as_me:${as_lineno-$LINENO}: $ac_try_echo\""
-printf "%s\n" "$ac_try_echo"; } >&5
-  (eval "$ac_cpp conftest.$ac_ext") 2>conftest.err
-  ac_status=$?
-  if test -s conftest.err; then
-    grep -v '^ *+' conftest.err >conftest.er1
-    cat conftest.er1 >&5
-    mv -f conftest.er1 conftest.err
-  fi
-  printf "%s\n" "$as_me:${as_lineno-$LINENO}: \$? = $ac_status" >&5
-  test $ac_status = 0; } > conftest.i && {
-	 test -z "$ac_c_preproc_warn_flag$ac_c_werror_flag" ||
-	 test ! -s conftest.err
-       }
-then :
-  ac_retval=0
-else $as_nop
-  printf "%s\n" "$as_me: failed program was:" >&5
-sed 's/^/| /' conftest.$ac_ext >&5
-
-    ac_retval=1
-fi
-  eval $as_lineno_stack; ${as_lineno_stack:+:} unset as_lineno
-  as_fn_set_status $ac_retval
-
-} # ac_fn_c_try_cpp
-
-# ac_fn_c_try_run LINENO
-# ----------------------
-# Try to run conftest.$ac_ext, and return whether this succeeded. Assumes that
-# executables *can* be run.
-ac_fn_c_try_run ()
-{
-  as_lineno=${as_lineno-"$1"} as_lineno_stack=as_lineno_stack=$as_lineno_stack
-  if { { ac_try="$ac_link"
-case "(($ac_try" in
-  *\"* | *\`* | *\\*) ac_try_echo=\$ac_try;;
-  *) ac_try_echo=$ac_try;;
-esac
-eval ac_try_echo="\"\$as_me:${as_lineno-$LINENO}: $ac_try_echo\""
-printf "%s\n" "$ac_try_echo"; } >&5
-  (eval "$ac_link") 2>&5
-  ac_status=$?
-  printf "%s\n" "$as_me:${as_lineno-$LINENO}: \$? = $ac_status" >&5
-  test $ac_status = 0; } && { ac_try='./conftest$ac_exeext'
-  { { case "(($ac_try" in
-  *\"* | *\`* | *\\*) ac_try_echo=\$ac_try;;
-  *) ac_try_echo=$ac_try;;
-esac
-eval ac_try_echo="\"\$as_me:${as_lineno-$LINENO}: $ac_try_echo\""
-printf "%s\n" "$ac_try_echo"; } >&5
-  (eval "$ac_try") 2>&5
-  ac_status=$?
-  printf "%s\n" "$as_me:${as_lineno-$LINENO}: \$? = $ac_status" >&5
-  test $ac_status = 0; }; }
-then :
-  ac_retval=0
-else $as_nop
-  printf "%s\n" "$as_me: program exited with status $ac_status" >&5
-       printf "%s\n" "$as_me: failed program was:" >&5
-sed 's/^/| /' conftest.$ac_ext >&5
-
-       ac_retval=$ac_status
-fi
-  rm -rf conftest.dSYM conftest_ipa8_conftest.oo
-  eval $as_lineno_stack; ${as_lineno_stack:+:} unset as_lineno
-  as_fn_set_status $ac_retval
-
-} # ac_fn_c_try_run
 
 # ac_fn_c_compute_int LINENO EXPR VAR INCLUDES
 # --------------------------------------------
@@ -2159,7 +2219,7 @@ cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 /* end confdefs.h.  */
 $4
 int
-main (void)
+main ()
 {
 static int test_array [1 - 2 * !(($2) >= 0)];
 test_array [0] = 0;
@@ -2169,15 +2229,14 @@ return test_array [0];
   return 0;
 }
 _ACEOF
-if ac_fn_c_try_compile "$LINENO"
-then :
+if ac_fn_c_try_compile "$LINENO"; then :
   ac_lo=0 ac_mid=0
   while :; do
     cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 /* end confdefs.h.  */
 $4
 int
-main (void)
+main ()
 {
 static int test_array [1 - 2 * !(($2) <= $ac_mid)];
 test_array [0] = 0;
@@ -2187,10 +2246,9 @@ return test_array [0];
   return 0;
 }
 _ACEOF
-if ac_fn_c_try_compile "$LINENO"
-then :
+if ac_fn_c_try_compile "$LINENO"; then :
   ac_hi=$ac_mid; break
-else $as_nop
+else
   as_fn_arith $ac_mid + 1 && ac_lo=$as_val
 			if test $ac_lo -le $ac_mid; then
 			  ac_lo= ac_hi=
@@ -2198,14 +2256,14 @@ else $as_nop
 			fi
 			as_fn_arith 2 '*' $ac_mid + 1 && ac_mid=$as_val
 fi
-rm -f core conftest.err conftest.$ac_objext conftest.beam conftest.$ac_ext
+rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
   done
-else $as_nop
+else
   cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 /* end confdefs.h.  */
 $4
 int
-main (void)
+main ()
 {
 static int test_array [1 - 2 * !(($2) < 0)];
 test_array [0] = 0;
@@ -2215,15 +2273,14 @@ return test_array [0];
   return 0;
 }
 _ACEOF
-if ac_fn_c_try_compile "$LINENO"
-then :
+if ac_fn_c_try_compile "$LINENO"; then :
   ac_hi=-1 ac_mid=-1
   while :; do
     cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 /* end confdefs.h.  */
 $4
 int
-main (void)
+main ()
 {
 static int test_array [1 - 2 * !(($2) >= $ac_mid)];
 test_array [0] = 0;
@@ -2233,10 +2290,9 @@ return test_array [0];
   return 0;
 }
 _ACEOF
-if ac_fn_c_try_compile "$LINENO"
-then :
+if ac_fn_c_try_compile "$LINENO"; then :
   ac_lo=$ac_mid; break
-else $as_nop
+else
   as_fn_arith '(' $ac_mid ')' - 1 && ac_hi=$as_val
 			if test $ac_mid -le $ac_hi; then
 			  ac_lo= ac_hi=
@@ -2244,14 +2300,14 @@ else $as_nop
 			fi
 			as_fn_arith 2 '*' $ac_mid && ac_mid=$as_val
 fi
-rm -f core conftest.err conftest.$ac_objext conftest.beam conftest.$ac_ext
+rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
   done
-else $as_nop
+else
   ac_lo= ac_hi=
 fi
-rm -f core conftest.err conftest.$ac_objext conftest.beam conftest.$ac_ext
+rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
 fi
-rm -f core conftest.err conftest.$ac_objext conftest.beam conftest.$ac_ext
+rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
 # Binary search between lo and hi bounds.
 while test "x$ac_lo" != "x$ac_hi"; do
   as_fn_arith '(' $ac_hi - $ac_lo ')' / 2 + $ac_lo && ac_mid=$as_val
@@ -2259,7 +2315,7 @@ while test "x$ac_lo" != "x$ac_hi"; do
 /* end confdefs.h.  */
 $4
 int
-main (void)
+main ()
 {
 static int test_array [1 - 2 * !(($2) <= $ac_mid)];
 test_array [0] = 0;
@@ -2269,13 +2325,12 @@ return test_array [0];
   return 0;
 }
 _ACEOF
-if ac_fn_c_try_compile "$LINENO"
-then :
+if ac_fn_c_try_compile "$LINENO"; then :
   ac_hi=$ac_mid
-else $as_nop
+else
   as_fn_arith '(' $ac_mid ')' + 1 && ac_lo=$as_val
 fi
-rm -f core conftest.err conftest.$ac_objext conftest.beam conftest.$ac_ext
+rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
 done
 case $ac_lo in #((
 ?*) eval "$3=\$ac_lo"; ac_retval=0 ;;
@@ -2285,12 +2340,12 @@ esac
     cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 /* end confdefs.h.  */
 $4
-static long int longval (void) { return $2; }
-static unsigned long int ulongval (void) { return $2; }
+static long int longval () { return $2; }
+static unsigned long int ulongval () { return $2; }
 #include <stdio.h>
 #include <stdlib.h>
 int
-main (void)
+main ()
 {
 
   FILE *f = fopen ("conftest.val", "w");
@@ -2318,10 +2373,9 @@ main (void)
   return 0;
 }
 _ACEOF
-if ac_fn_c_try_run "$LINENO"
-then :
+if ac_fn_c_try_run "$LINENO"; then :
   echo >>conftest.val; read $3 <conftest.val; ac_retval=0
-else $as_nop
+else
   ac_retval=1
 fi
 rm -f core *.core core.conftest.* gmon.out bb.out conftest$ac_exeext \
@@ -2334,28 +2388,25 @@ rm -f conftest.val
 
 } # ac_fn_c_compute_int
 
-# ac_fn_check_decl LINENO SYMBOL VAR INCLUDES EXTRA-OPTIONS FLAG-VAR
-# ------------------------------------------------------------------
+# ac_fn_c_check_decl LINENO SYMBOL VAR INCLUDES
+# ---------------------------------------------
 # Tests whether SYMBOL is declared in INCLUDES, setting cache variable VAR
-# accordingly. Pass EXTRA-OPTIONS to the compiler, using FLAG-VAR.
-ac_fn_check_decl ()
+# accordingly.
+ac_fn_c_check_decl ()
 {
   as_lineno=${as_lineno-"$1"} as_lineno_stack=as_lineno_stack=$as_lineno_stack
   as_decl_name=`echo $2|sed 's/ *(.*//'`
-  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking whether $as_decl_name is declared" >&5
-printf %s "checking whether $as_decl_name is declared... " >&6; }
-if eval test \${$3+y}
-then :
-  printf %s "(cached) " >&6
-else $as_nop
   as_decl_use=`echo $2|sed -e 's/(/((/' -e 's/)/) 0&/' -e 's/,/) 0& (/g'`
-  eval ac_save_FLAGS=\$$6
-  as_fn_append $6 " $5"
+  { $as_echo "$as_me:${as_lineno-$LINENO}: checking whether $as_decl_name is declared" >&5
+$as_echo_n "checking whether $as_decl_name is declared... " >&6; }
+if eval \${$3+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
   cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 /* end confdefs.h.  */
 $4
 int
-main (void)
+main ()
 {
 #ifndef $as_decl_name
 #ifdef __cplusplus
@@ -2369,22 +2420,19 @@ main (void)
   return 0;
 }
 _ACEOF
-if ac_fn_c_try_compile "$LINENO"
-then :
+if ac_fn_c_try_compile "$LINENO"; then :
   eval "$3=yes"
-else $as_nop
+else
   eval "$3=no"
 fi
-rm -f core conftest.err conftest.$ac_objext conftest.beam conftest.$ac_ext
-  eval $6=\$ac_save_FLAGS
-
+rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
 fi
 eval ac_res=\$$3
-	       { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $ac_res" >&5
-printf "%s\n" "$ac_res" >&6; }
+	       { $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_res" >&5
+$as_echo "$ac_res" >&6; }
   eval $as_lineno_stack; ${as_lineno_stack:+:} unset as_lineno
 
-} # ac_fn_check_decl
+} # ac_fn_c_check_decl
 
 # ac_fn_c_check_member LINENO AGGR MEMBER VAR INCLUDES
 # ----------------------------------------------------
@@ -2393,17 +2441,16 @@ printf "%s\n" "$ac_res" >&6; }
 ac_fn_c_check_member ()
 {
   as_lineno=${as_lineno-"$1"} as_lineno_stack=as_lineno_stack=$as_lineno_stack
-  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for $2.$3" >&5
-printf %s "checking for $2.$3... " >&6; }
-if eval test \${$4+y}
-then :
-  printf %s "(cached) " >&6
-else $as_nop
+  { $as_echo "$as_me:${as_lineno-$LINENO}: checking for $2.$3" >&5
+$as_echo_n "checking for $2.$3... " >&6; }
+if eval \${$4+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
   cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 /* end confdefs.h.  */
 $5
 int
-main (void)
+main ()
 {
 static $2 ac_aggr;
 if (ac_aggr.$3)
@@ -2412,15 +2459,14 @@ return 0;
   return 0;
 }
 _ACEOF
-if ac_fn_c_try_compile "$LINENO"
-then :
+if ac_fn_c_try_compile "$LINENO"; then :
   eval "$4=yes"
-else $as_nop
+else
   cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 /* end confdefs.h.  */
 $5
 int
-main (void)
+main ()
 {
 static $2 ac_aggr;
 if (sizeof ac_aggr.$3)
@@ -2429,42 +2475,21 @@ return 0;
   return 0;
 }
 _ACEOF
-if ac_fn_c_try_compile "$LINENO"
-then :
+if ac_fn_c_try_compile "$LINENO"; then :
   eval "$4=yes"
-else $as_nop
+else
   eval "$4=no"
 fi
-rm -f core conftest.err conftest.$ac_objext conftest.beam conftest.$ac_ext
+rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
 fi
-rm -f core conftest.err conftest.$ac_objext conftest.beam conftest.$ac_ext
+rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
 fi
 eval ac_res=\$$4
-	       { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $ac_res" >&5
-printf "%s\n" "$ac_res" >&6; }
+	       { $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_res" >&5
+$as_echo "$ac_res" >&6; }
   eval $as_lineno_stack; ${as_lineno_stack:+:} unset as_lineno
 
 } # ac_fn_c_check_member
-ac_configure_args_raw=
-for ac_arg
-do
-  case $ac_arg in
-  *\'*)
-    ac_arg=`printf "%s\n" "$ac_arg" | sed "s/'/'\\\\\\\\''/g"` ;;
-  esac
-  as_fn_append ac_configure_args_raw " '$ac_arg'"
-done
-
-case $ac_configure_args_raw in
-  *$as_nl*)
-    ac_safe_unquote= ;;
-  *)
-    ac_unsafe_z='|&;<>()$`\\"*?[ ''	' # This string ends in space, tab.
-    ac_unsafe_a="$ac_unsafe_z#~"
-    ac_safe_unquote="s/ '\\([^$ac_unsafe_a][^$ac_unsafe_z]*\\)'/ \\1/g"
-    ac_configure_args_raw=`      printf "%s\n" "$ac_configure_args_raw" | sed "$ac_safe_unquote"`;;
-esac
-
 cat >config.log <<_ACEOF
 This file contains any messages produced by compilers while
 running configure, to aid debugging if configure makes a mistake.
@@ -2472,7 +2497,7 @@ running configure, to aid debugging if configure makes a mistake.
 It was created by unbound $as_me 1.15.1, which was
 generated by GNU Autoconf 2.69.  Invocation command line was
 
-  $ $0$ac_configure_args_raw
+  $ $0 $@
 
 _ACEOF
 exec 5>>config.log
@@ -2505,12 +2530,8 @@ as_save_IFS=$IFS; IFS=$PATH_SEPARATOR
 for as_dir in $PATH
 do
   IFS=$as_save_IFS
-  case $as_dir in #(((
-    '') as_dir=./ ;;
-    */) ;;
-    *) as_dir=$as_dir/ ;;
-  esac
-    printf "%s\n" "PATH: $as_dir"
+  test -z "$as_dir" && as_dir=.
+    $as_echo "PATH: $as_dir"
   done
 IFS=$as_save_IFS
 
@@ -2545,7 +2566,7 @@ do
     | -silent | --silent | --silen | --sile | --sil)
       continue ;;
     *\'*)
-      ac_arg=`printf "%s\n" "$ac_arg" | sed "s/'/'\\\\\\\\''/g"` ;;
+      ac_arg=`$as_echo "$ac_arg" | sed "s/'/'\\\\\\\\''/g"` ;;
     esac
     case $ac_pass in
     1) as_fn_append ac_configure_args0 " '$ac_arg'" ;;
@@ -2580,13 +2601,11 @@ done
 # WARNING: Use '\'' to represent an apostrophe within the trap.
 # WARNING: Do not start the trap code with a newline, due to a FreeBSD 4.0 bug.
 trap 'exit_status=$?
-  # Sanitize IFS.
-  IFS=" ""	$as_nl"
   # Save into config.log some information that might help in debugging.
   {
     echo
 
-    printf "%s\n" "## ---------------- ##
+    $as_echo "## ---------------- ##
 ## Cache variables. ##
 ## ---------------- ##"
     echo
@@ -2597,8 +2616,8 @@ trap 'exit_status=$?
     case $ac_val in #(
     *${as_nl}*)
       case $ac_var in #(
-      *_cv_*) { printf "%s\n" "$as_me:${as_lineno-$LINENO}: WARNING: cache variable $ac_var contains a newline" >&5
-printf "%s\n" "$as_me: WARNING: cache variable $ac_var contains a newline" >&2;} ;;
+      *_cv_*) { $as_echo "$as_me:${as_lineno-$LINENO}: WARNING: cache variable $ac_var contains a newline" >&5
+$as_echo "$as_me: WARNING: cache variable $ac_var contains a newline" >&2;} ;;
       esac
       case $ac_var in #(
       _ | IFS | as_nl) ;; #(
@@ -2622,7 +2641,7 @@ printf "%s\n" "$as_me: WARNING: cache variable $ac_var contains a newline" >&2;}
 )
     echo
 
-    printf "%s\n" "## ----------------- ##
+    $as_echo "## ----------------- ##
 ## Output variables. ##
 ## ----------------- ##"
     echo
@@ -2630,14 +2649,14 @@ printf "%s\n" "$as_me: WARNING: cache variable $ac_var contains a newline" >&2;}
     do
       eval ac_val=\$$ac_var
       case $ac_val in
-      *\'\''*) ac_val=`printf "%s\n" "$ac_val" | sed "s/'\''/'\''\\\\\\\\'\'''\''/g"`;;
+      *\'\''*) ac_val=`$as_echo "$ac_val" | sed "s/'\''/'\''\\\\\\\\'\'''\''/g"`;;
       esac
-      printf "%s\n" "$ac_var='\''$ac_val'\''"
+      $as_echo "$ac_var='\''$ac_val'\''"
     done | sort
     echo
 
     if test -n "$ac_subst_files"; then
-      printf "%s\n" "## ------------------- ##
+      $as_echo "## ------------------- ##
 ## File substitutions. ##
 ## ------------------- ##"
       echo
@@ -2645,15 +2664,15 @@ printf "%s\n" "$as_me: WARNING: cache variable $ac_var contains a newline" >&2;}
       do
 	eval ac_val=\$$ac_var
 	case $ac_val in
-	*\'\''*) ac_val=`printf "%s\n" "$ac_val" | sed "s/'\''/'\''\\\\\\\\'\'''\''/g"`;;
+	*\'\''*) ac_val=`$as_echo "$ac_val" | sed "s/'\''/'\''\\\\\\\\'\'''\''/g"`;;
 	esac
-	printf "%s\n" "$ac_var='\''$ac_val'\''"
+	$as_echo "$ac_var='\''$ac_val'\''"
       done | sort
       echo
     fi
 
     if test -s confdefs.h; then
-      printf "%s\n" "## ----------- ##
+      $as_echo "## ----------- ##
 ## confdefs.h. ##
 ## ----------- ##"
       echo
@@ -2661,8 +2680,8 @@ printf "%s\n" "$as_me: WARNING: cache variable $ac_var contains a newline" >&2;}
       echo
     fi
     test "$ac_signal" != 0 &&
-      printf "%s\n" "$as_me: caught signal $ac_signal"
-    printf "%s\n" "$as_me: exit $exit_status"
+      $as_echo "$as_me: caught signal $ac_signal"
+    $as_echo "$as_me: exit $exit_status"
   } >&5
   rm -f core *.core core.conftest.* &&
     rm -f -r conftest* confdefs* conf$$* $ac_clean_files &&
@@ -2676,48 +2695,63 @@ ac_signal=0
 # confdefs.h avoids OS command line length limits that DEFS can exceed.
 rm -f -r conftest* confdefs.h
 
-printf "%s\n" "/* confdefs.h */" > confdefs.h
+$as_echo "/* confdefs.h */" > confdefs.h
 
 # Predefined preprocessor variables.
 
-printf "%s\n" "#define PACKAGE_NAME \"$PACKAGE_NAME\"" >>confdefs.h
+cat >>confdefs.h <<_ACEOF
+#define PACKAGE_NAME "$PACKAGE_NAME"
+_ACEOF
 
-printf "%s\n" "#define PACKAGE_TARNAME \"$PACKAGE_TARNAME\"" >>confdefs.h
+cat >>confdefs.h <<_ACEOF
+#define PACKAGE_TARNAME "$PACKAGE_TARNAME"
+_ACEOF
 
-printf "%s\n" "#define PACKAGE_VERSION \"$PACKAGE_VERSION\"" >>confdefs.h
+cat >>confdefs.h <<_ACEOF
+#define PACKAGE_VERSION "$PACKAGE_VERSION"
+_ACEOF
 
-printf "%s\n" "#define PACKAGE_STRING \"$PACKAGE_STRING\"" >>confdefs.h
+cat >>confdefs.h <<_ACEOF
+#define PACKAGE_STRING "$PACKAGE_STRING"
+_ACEOF
 
-printf "%s\n" "#define PACKAGE_BUGREPORT \"$PACKAGE_BUGREPORT\"" >>confdefs.h
+cat >>confdefs.h <<_ACEOF
+#define PACKAGE_BUGREPORT "$PACKAGE_BUGREPORT"
+_ACEOF
 
-printf "%s\n" "#define PACKAGE_URL \"$PACKAGE_URL\"" >>confdefs.h
+cat >>confdefs.h <<_ACEOF
+#define PACKAGE_URL "$PACKAGE_URL"
+_ACEOF
 
 
 # Let the site file select an alternate cache file if it wants to.
 # Prefer an explicitly selected file to automatically selected ones.
+ac_site_file1=NONE
+ac_site_file2=NONE
 if test -n "$CONFIG_SITE"; then
-  ac_site_files="$CONFIG_SITE"
+  # We do not want a PATH search for config.site.
+  case $CONFIG_SITE in #((
+    -*)  ac_site_file1=./$CONFIG_SITE;;
+    */*) ac_site_file1=$CONFIG_SITE;;
+    *)   ac_site_file1=./$CONFIG_SITE;;
+  esac
 elif test "x$prefix" != xNONE; then
-  ac_site_files="$prefix/share/config.site $prefix/etc/config.site"
+  ac_site_file1=$prefix/share/config.site
+  ac_site_file2=$prefix/etc/config.site
 else
-  ac_site_files="$ac_default_prefix/share/config.site $ac_default_prefix/etc/config.site"
+  ac_site_file1=$ac_default_prefix/share/config.site
+  ac_site_file2=$ac_default_prefix/etc/config.site
 fi
-
-for ac_site_file in $ac_site_files
+for ac_site_file in "$ac_site_file1" "$ac_site_file2"
 do
-  case $ac_site_file in #(
-  */*) :
-     ;; #(
-  *) :
-    ac_site_file=./$ac_site_file ;;
-esac
-  if test -f "$ac_site_file" && test -r "$ac_site_file"; then
-    { printf "%s\n" "$as_me:${as_lineno-$LINENO}: loading site script $ac_site_file" >&5
-printf "%s\n" "$as_me: loading site script $ac_site_file" >&6;}
+  test "x$ac_site_file" = xNONE && continue
+  if test /dev/null != "$ac_site_file" && test -r "$ac_site_file"; then
+    { $as_echo "$as_me:${as_lineno-$LINENO}: loading site script $ac_site_file" >&5
+$as_echo "$as_me: loading site script $ac_site_file" >&6;}
     sed 's/^/| /' "$ac_site_file" >&5
     . "$ac_site_file" \
-      || { { printf "%s\n" "$as_me:${as_lineno-$LINENO}: error: in \`$ac_pwd':" >&5
-printf "%s\n" "$as_me: error: in \`$ac_pwd':" >&2;}
+      || { { $as_echo "$as_me:${as_lineno-$LINENO}: error: in \`$ac_pwd':" >&5
+$as_echo "$as_me: error: in \`$ac_pwd':" >&2;}
 as_fn_error $? "failed to load site script $ac_site_file
 See \`config.log' for more details" "$LINENO" 5; }
   fi
@@ -2727,437 +2761,17 @@ if test -r "$cache_file"; then
   # Some versions of bash will fail to source /dev/null (special files
   # actually), so we avoid doing that.  DJGPP emulates it as a regular file.
   if test /dev/null != "$cache_file" && test -f "$cache_file"; then
-    { printf "%s\n" "$as_me:${as_lineno-$LINENO}: loading cache $cache_file" >&5
-printf "%s\n" "$as_me: loading cache $cache_file" >&6;}
+    { $as_echo "$as_me:${as_lineno-$LINENO}: loading cache $cache_file" >&5
+$as_echo "$as_me: loading cache $cache_file" >&6;}
     case $cache_file in
       [\\/]* | ?:[\\/]* ) . "$cache_file";;
       *)                      . "./$cache_file";;
     esac
   fi
 else
-  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: creating cache $cache_file" >&5
-printf "%s\n" "$as_me: creating cache $cache_file" >&6;}
+  { $as_echo "$as_me:${as_lineno-$LINENO}: creating cache $cache_file" >&5
+$as_echo "$as_me: creating cache $cache_file" >&6;}
   >$cache_file
-fi
-
-as_fn_append ac_header_c_list " stdio.h stdio_h HAVE_STDIO_H"
-# Test code for whether the C compiler supports C89 (global declarations)
-ac_c_conftest_c89_globals='
-/* Does the compiler advertise C89 conformance?
-   Do not test the value of __STDC__, because some compilers set it to 0
-   while being otherwise adequately conformant. */
-#if !defined __STDC__
-# error "Compiler does not advertise C89 conformance"
-#endif
-
-#include <stddef.h>
-#include <stdarg.h>
-struct stat;
-/* Most of the following tests are stolen from RCS 5.7 src/conf.sh.  */
-struct buf { int x; };
-struct buf * (*rcsopen) (struct buf *, struct stat *, int);
-static char *e (p, i)
-     char **p;
-     int i;
-{
-  return p[i];
-}
-static char *f (char * (*g) (char **, int), char **p, ...)
-{
-  char *s;
-  va_list v;
-  va_start (v,p);
-  s = g (p, va_arg (v,int));
-  va_end (v);
-  return s;
-}
-
-/* OSF 4.0 Compaq cc is some sort of almost-ANSI by default.  It has
-   function prototypes and stuff, but not \xHH hex character constants.
-   These do not provoke an error unfortunately, instead are silently treated
-   as an "x".  The following induces an error, until -std is added to get
-   proper ANSI mode.  Curiously \x00 != x always comes out true, for an
-   array size at least.  It is necessary to write \x00 == 0 to get something
-   that is true only with -std.  */
-int osf4_cc_array ['\''\x00'\'' == 0 ? 1 : -1];
-
-/* IBM C 6 for AIX is almost-ANSI by default, but it replaces macro parameters
-   inside strings and character constants.  */
-#define FOO(x) '\''x'\''
-int xlc6_cc_array[FOO(a) == '\''x'\'' ? 1 : -1];
-
-int test (int i, double x);
-struct s1 {int (*f) (int a);};
-struct s2 {int (*f) (double a);};
-int pairnames (int, char **, int *(*)(struct buf *, struct stat *, int),
-               int, int);'
-
-# Test code for whether the C compiler supports C89 (body of main).
-ac_c_conftest_c89_main='
-ok |= (argc == 0 || f (e, argv, 0) != argv[0] || f (e, argv, 1) != argv[1]);
-'
-
-# Test code for whether the C compiler supports C99 (global declarations)
-ac_c_conftest_c99_globals='
-// Does the compiler advertise C99 conformance?
-#if !defined __STDC_VERSION__ || __STDC_VERSION__ < 199901L
-# error "Compiler does not advertise C99 conformance"
-#endif
-
-#include <stdbool.h>
-extern int puts (const char *);
-extern int printf (const char *, ...);
-extern int dprintf (int, const char *, ...);
-extern void *malloc (size_t);
-
-// Check varargs macros.  These examples are taken from C99 6.10.3.5.
-// dprintf is used instead of fprintf to avoid needing to declare
-// FILE and stderr.
-#define debug(...) dprintf (2, __VA_ARGS__)
-#define showlist(...) puts (#__VA_ARGS__)
-#define report(test,...) ((test) ? puts (#test) : printf (__VA_ARGS__))
-static void
-test_varargs_macros (void)
-{
-  int x = 1234;
-  int y = 5678;
-  debug ("Flag");
-  debug ("X = %d\n", x);
-  showlist (The first, second, and third items.);
-  report (x>y, "x is %d but y is %d", x, y);
-}
-
-// Check long long types.
-#define BIG64 18446744073709551615ull
-#define BIG32 4294967295ul
-#define BIG_OK (BIG64 / BIG32 == 4294967297ull && BIG64 % BIG32 == 0)
-#if !BIG_OK
-  #error "your preprocessor is broken"
-#endif
-#if BIG_OK
-#else
-  #error "your preprocessor is broken"
-#endif
-static long long int bignum = -9223372036854775807LL;
-static unsigned long long int ubignum = BIG64;
-
-struct incomplete_array
-{
-  int datasize;
-  double data[];
-};
-
-struct named_init {
-  int number;
-  const wchar_t *name;
-  double average;
-};
-
-typedef const char *ccp;
-
-static inline int
-test_restrict (ccp restrict text)
-{
-  // See if C++-style comments work.
-  // Iterate through items via the restricted pointer.
-  // Also check for declarations in for loops.
-  for (unsigned int i = 0; *(text+i) != '\''\0'\''; ++i)
-    continue;
-  return 0;
-}
-
-// Check varargs and va_copy.
-static bool
-test_varargs (const char *format, ...)
-{
-  va_list args;
-  va_start (args, format);
-  va_list args_copy;
-  va_copy (args_copy, args);
-
-  const char *str = "";
-  int number = 0;
-  float fnumber = 0;
-
-  while (*format)
-    {
-      switch (*format++)
-	{
-	case '\''s'\'': // string
-	  str = va_arg (args_copy, const char *);
-	  break;
-	case '\''d'\'': // int
-	  number = va_arg (args_copy, int);
-	  break;
-	case '\''f'\'': // float
-	  fnumber = va_arg (args_copy, double);
-	  break;
-	default:
-	  break;
-	}
-    }
-  va_end (args_copy);
-  va_end (args);
-
-  return *str && number && fnumber;
-}
-'
-
-# Test code for whether the C compiler supports C99 (body of main).
-ac_c_conftest_c99_main='
-  // Check bool.
-  _Bool success = false;
-  success |= (argc != 0);
-
-  // Check restrict.
-  if (test_restrict ("String literal") == 0)
-    success = true;
-  char *restrict newvar = "Another string";
-
-  // Check varargs.
-  success &= test_varargs ("s, d'\'' f .", "string", 65, 34.234);
-  test_varargs_macros ();
-
-  // Check flexible array members.
-  struct incomplete_array *ia =
-    malloc (sizeof (struct incomplete_array) + (sizeof (double) * 10));
-  ia->datasize = 10;
-  for (int i = 0; i < ia->datasize; ++i)
-    ia->data[i] = i * 1.234;
-
-  // Check named initializers.
-  struct named_init ni = {
-    .number = 34,
-    .name = L"Test wide string",
-    .average = 543.34343,
-  };
-
-  ni.number = 58;
-
-  int dynamic_array[ni.number];
-  dynamic_array[0] = argv[0][0];
-  dynamic_array[ni.number - 1] = 543;
-
-  // work around unused variable warnings
-  ok |= (!success || bignum == 0LL || ubignum == 0uLL || newvar[0] == '\''x'\''
-	 || dynamic_array[ni.number - 1] != 543);
-'
-
-# Test code for whether the C compiler supports C11 (global declarations)
-ac_c_conftest_c11_globals='
-// Does the compiler advertise C11 conformance?
-#if !defined __STDC_VERSION__ || __STDC_VERSION__ < 201112L
-# error "Compiler does not advertise C11 conformance"
-#endif
-
-// Check _Alignas.
-char _Alignas (double) aligned_as_double;
-char _Alignas (0) no_special_alignment;
-extern char aligned_as_int;
-char _Alignas (0) _Alignas (int) aligned_as_int;
-
-// Check _Alignof.
-enum
-{
-  int_alignment = _Alignof (int),
-  int_array_alignment = _Alignof (int[100]),
-  char_alignment = _Alignof (char)
-};
-_Static_assert (0 < -_Alignof (int), "_Alignof is signed");
-
-// Check _Noreturn.
-int _Noreturn does_not_return (void) { for (;;) continue; }
-
-// Check _Static_assert.
-struct test_static_assert
-{
-  int x;
-  _Static_assert (sizeof (int) <= sizeof (long int),
-                  "_Static_assert does not work in struct");
-  long int y;
-};
-
-// Check UTF-8 literals.
-#define u8 syntax error!
-char const utf8_literal[] = u8"happens to be ASCII" "another string";
-
-// Check duplicate typedefs.
-typedef long *long_ptr;
-typedef long int *long_ptr;
-typedef long_ptr long_ptr;
-
-// Anonymous structures and unions -- taken from C11 6.7.2.1 Example 1.
-struct anonymous
-{
-  union {
-    struct { int i; int j; };
-    struct { int k; long int l; } w;
-  };
-  int m;
-} v1;
-'
-
-# Test code for whether the C compiler supports C11 (body of main).
-ac_c_conftest_c11_main='
-  _Static_assert ((offsetof (struct anonymous, i)
-		   == offsetof (struct anonymous, w.k)),
-		  "Anonymous union alignment botch");
-  v1.i = 2;
-  v1.w.k = 5;
-  ok |= v1.i != 5;
-'
-
-# Test code for whether the C compiler supports C11 (complete).
-ac_c_conftest_c11_program="${ac_c_conftest_c89_globals}
-${ac_c_conftest_c99_globals}
-${ac_c_conftest_c11_globals}
-
-int
-main (int argc, char **argv)
-{
-  int ok = 0;
-  ${ac_c_conftest_c89_main}
-  ${ac_c_conftest_c99_main}
-  ${ac_c_conftest_c11_main}
-  return ok;
-}
-"
-
-# Test code for whether the C compiler supports C99 (complete).
-ac_c_conftest_c99_program="${ac_c_conftest_c89_globals}
-${ac_c_conftest_c99_globals}
-
-int
-main (int argc, char **argv)
-{
-  int ok = 0;
-  ${ac_c_conftest_c89_main}
-  ${ac_c_conftest_c99_main}
-  return ok;
-}
-"
-
-# Test code for whether the C compiler supports C89 (complete).
-ac_c_conftest_c89_program="${ac_c_conftest_c89_globals}
-
-int
-main (int argc, char **argv)
-{
-  int ok = 0;
-  ${ac_c_conftest_c89_main}
-  return ok;
-}
-"
-
-as_fn_append ac_header_c_list " stdlib.h stdlib_h HAVE_STDLIB_H"
-as_fn_append ac_header_c_list " string.h string_h HAVE_STRING_H"
-as_fn_append ac_header_c_list " inttypes.h inttypes_h HAVE_INTTYPES_H"
-as_fn_append ac_header_c_list " stdint.h stdint_h HAVE_STDINT_H"
-as_fn_append ac_header_c_list " strings.h strings_h HAVE_STRINGS_H"
-as_fn_append ac_header_c_list " sys/stat.h sys_stat_h HAVE_SYS_STAT_H"
-as_fn_append ac_header_c_list " sys/types.h sys_types_h HAVE_SYS_TYPES_H"
-as_fn_append ac_header_c_list " unistd.h unistd_h HAVE_UNISTD_H"
-as_fn_append ac_header_c_list " wchar.h wchar_h HAVE_WCHAR_H"
-as_fn_append ac_header_c_list " minix/config.h minix_config_h HAVE_MINIX_CONFIG_H"
-as_fn_append ac_header_c_list " vfork.h vfork_h HAVE_VFORK_H"
-as_fn_append ac_func_c_list " fork HAVE_FORK"
-as_fn_append ac_func_c_list " vfork HAVE_VFORK"
-
-# Auxiliary files required by this configure script.
-ac_aux_files="ltmain.sh config.guess config.sub"
-
-# Locations in which to look for auxiliary files.
-ac_aux_dir_candidates="${srcdir}${PATH_SEPARATOR}${srcdir}/..${PATH_SEPARATOR}${srcdir}/../.."
-
-# Search for a directory containing all of the required auxiliary files,
-# $ac_aux_files, from the $PATH-style list $ac_aux_dir_candidates.
-# If we don't find one directory that contains all the files we need,
-# we report the set of missing files from the *first* directory in
-# $ac_aux_dir_candidates and give up.
-ac_missing_aux_files=""
-ac_first_candidate=:
-printf "%s\n" "$as_me:${as_lineno-$LINENO}: looking for aux files: $ac_aux_files" >&5
-as_save_IFS=$IFS; IFS=$PATH_SEPARATOR
-as_found=false
-for as_dir in $ac_aux_dir_candidates
-do
-  IFS=$as_save_IFS
-  case $as_dir in #(((
-    '') as_dir=./ ;;
-    */) ;;
-    *) as_dir=$as_dir/ ;;
-  esac
-  as_found=:
-
-  printf "%s\n" "$as_me:${as_lineno-$LINENO}:  trying $as_dir" >&5
-  ac_aux_dir_found=yes
-  ac_install_sh=
-  for ac_aux in $ac_aux_files
-  do
-    # As a special case, if "install-sh" is required, that requirement
-    # can be satisfied by any of "install-sh", "install.sh", or "shtool",
-    # and $ac_install_sh is set appropriately for whichever one is found.
-    if test x"$ac_aux" = x"install-sh"
-    then
-      if test -f "${as_dir}install-sh"; then
-        printf "%s\n" "$as_me:${as_lineno-$LINENO}:   ${as_dir}install-sh found" >&5
-        ac_install_sh="${as_dir}install-sh -c"
-      elif test -f "${as_dir}install.sh"; then
-        printf "%s\n" "$as_me:${as_lineno-$LINENO}:   ${as_dir}install.sh found" >&5
-        ac_install_sh="${as_dir}install.sh -c"
-      elif test -f "${as_dir}shtool"; then
-        printf "%s\n" "$as_me:${as_lineno-$LINENO}:   ${as_dir}shtool found" >&5
-        ac_install_sh="${as_dir}shtool install -c"
-      else
-        ac_aux_dir_found=no
-        if $ac_first_candidate; then
-          ac_missing_aux_files="${ac_missing_aux_files} install-sh"
-        else
-          break
-        fi
-      fi
-    else
-      if test -f "${as_dir}${ac_aux}"; then
-        printf "%s\n" "$as_me:${as_lineno-$LINENO}:   ${as_dir}${ac_aux} found" >&5
-      else
-        ac_aux_dir_found=no
-        if $ac_first_candidate; then
-          ac_missing_aux_files="${ac_missing_aux_files} ${ac_aux}"
-        else
-          break
-        fi
-      fi
-    fi
-  done
-  if test "$ac_aux_dir_found" = yes; then
-    ac_aux_dir="$as_dir"
-    break
-  fi
-  ac_first_candidate=false
-
-  as_found=false
-done
-IFS=$as_save_IFS
-if $as_found
-then :
-
-else $as_nop
-  as_fn_error $? "cannot find required auxiliary files:$ac_missing_aux_files" "$LINENO" 5
-fi
-
-
-# These three variables are undocumented and unsupported,
-# and are intended to be withdrawn in a future Autoconf release.
-# They can cause serious problems if a builder's source tree is in a directory
-# whose full name contains unusual characters.
-if test -f "${ac_aux_dir}config.guess"; then
-  ac_config_guess="$SHELL ${ac_aux_dir}config.guess"
-fi
-if test -f "${ac_aux_dir}config.sub"; then
-  ac_config_sub="$SHELL ${ac_aux_dir}config.sub"
-fi
-if test -f "$ac_aux_dir/configure"; then
-  ac_configure="$SHELL ${ac_aux_dir}configure"
 fi
 
 # Check that the precious variables saved in the cache have kept the same
@@ -3170,12 +2784,12 @@ for ac_var in $ac_precious_vars; do
   eval ac_new_val=\$ac_env_${ac_var}_value
   case $ac_old_set,$ac_new_set in
     set,)
-      { printf "%s\n" "$as_me:${as_lineno-$LINENO}: error: \`$ac_var' was set to \`$ac_old_val' in the previous run" >&5
-printf "%s\n" "$as_me: error: \`$ac_var' was set to \`$ac_old_val' in the previous run" >&2;}
+      { $as_echo "$as_me:${as_lineno-$LINENO}: error: \`$ac_var' was set to \`$ac_old_val' in the previous run" >&5
+$as_echo "$as_me: error: \`$ac_var' was set to \`$ac_old_val' in the previous run" >&2;}
       ac_cache_corrupted=: ;;
     ,set)
-      { printf "%s\n" "$as_me:${as_lineno-$LINENO}: error: \`$ac_var' was not set in the previous run" >&5
-printf "%s\n" "$as_me: error: \`$ac_var' was not set in the previous run" >&2;}
+      { $as_echo "$as_me:${as_lineno-$LINENO}: error: \`$ac_var' was not set in the previous run" >&5
+$as_echo "$as_me: error: \`$ac_var' was not set in the previous run" >&2;}
       ac_cache_corrupted=: ;;
     ,);;
     *)
@@ -3184,24 +2798,24 @@ printf "%s\n" "$as_me: error: \`$ac_var' was not set in the previous run" >&2;}
 	ac_old_val_w=`echo x $ac_old_val`
 	ac_new_val_w=`echo x $ac_new_val`
 	if test "$ac_old_val_w" != "$ac_new_val_w"; then
-	  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: error: \`$ac_var' has changed since the previous run:" >&5
-printf "%s\n" "$as_me: error: \`$ac_var' has changed since the previous run:" >&2;}
+	  { $as_echo "$as_me:${as_lineno-$LINENO}: error: \`$ac_var' has changed since the previous run:" >&5
+$as_echo "$as_me: error: \`$ac_var' has changed since the previous run:" >&2;}
 	  ac_cache_corrupted=:
 	else
-	  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: warning: ignoring whitespace changes in \`$ac_var' since the previous run:" >&5
-printf "%s\n" "$as_me: warning: ignoring whitespace changes in \`$ac_var' since the previous run:" >&2;}
+	  { $as_echo "$as_me:${as_lineno-$LINENO}: warning: ignoring whitespace changes in \`$ac_var' since the previous run:" >&5
+$as_echo "$as_me: warning: ignoring whitespace changes in \`$ac_var' since the previous run:" >&2;}
 	  eval $ac_var=\$ac_old_val
 	fi
-	{ printf "%s\n" "$as_me:${as_lineno-$LINENO}:   former value:  \`$ac_old_val'" >&5
-printf "%s\n" "$as_me:   former value:  \`$ac_old_val'" >&2;}
-	{ printf "%s\n" "$as_me:${as_lineno-$LINENO}:   current value: \`$ac_new_val'" >&5
-printf "%s\n" "$as_me:   current value: \`$ac_new_val'" >&2;}
+	{ $as_echo "$as_me:${as_lineno-$LINENO}:   former value:  \`$ac_old_val'" >&5
+$as_echo "$as_me:   former value:  \`$ac_old_val'" >&2;}
+	{ $as_echo "$as_me:${as_lineno-$LINENO}:   current value: \`$ac_new_val'" >&5
+$as_echo "$as_me:   current value: \`$ac_new_val'" >&2;}
       fi;;
   esac
   # Pass precious variables to config.status.
   if test "$ac_new_set" = set; then
     case $ac_new_val in
-    *\'*) ac_arg=$ac_var=`printf "%s\n" "$ac_new_val" | sed "s/'/'\\\\\\\\''/g"` ;;
+    *\'*) ac_arg=$ac_var=`$as_echo "$ac_new_val" | sed "s/'/'\\\\\\\\''/g"` ;;
     *) ac_arg=$ac_var=$ac_new_val ;;
     esac
     case " $ac_configure_args " in
@@ -3211,12 +2825,11 @@ printf "%s\n" "$as_me:   current value: \`$ac_new_val'" >&2;}
   fi
 done
 if $ac_cache_corrupted; then
-  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: error: in \`$ac_pwd':" >&5
-printf "%s\n" "$as_me: error: in \`$ac_pwd':" >&2;}
-  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: error: changes in the environment can compromise the build" >&5
-printf "%s\n" "$as_me: error: changes in the environment can compromise the build" >&2;}
-  as_fn_error $? "run \`${MAKE-make} distclean' and/or \`rm $cache_file'
-	    and start over" "$LINENO" 5
+  { $as_echo "$as_me:${as_lineno-$LINENO}: error: in \`$ac_pwd':" >&5
+$as_echo "$as_me: error: in \`$ac_pwd':" >&2;}
+  { $as_echo "$as_me:${as_lineno-$LINENO}: error: changes in the environment can compromise the build" >&5
+$as_echo "$as_me: error: changes in the environment can compromise the build" >&2;}
+  as_fn_error $? "run \`make distclean' and/or \`rm $cache_file' and start over" "$LINENO" 5
 fi
 ## -------------------- ##
 ## Main body of script. ##
@@ -3347,19 +2960,12 @@ LIBUNBOUND_AGE=1
 
 cmdln="`echo $@ | sed -e 's/\\\\/\\\\\\\\/g' | sed -e 's/"/\\\\"/'g`"
 
-printf "%s\n" "#define CONFCMDLINE \"$cmdln\"" >>confdefs.h
+cat >>confdefs.h <<_ACEOF
+#define CONFCMDLINE "$cmdln"
+_ACEOF
 
 
 CFLAGS="$CFLAGS"
-
-
-
-
-
-
-
-
-
 ac_ext=c
 ac_cpp='$CPP $CPPFLAGS'
 ac_compile='$CC -c $CFLAGS $CPPFLAGS conftest.$ac_ext >&5'
@@ -3368,12 +2974,11 @@ ac_compiler_gnu=$ac_cv_c_compiler_gnu
 if test -n "$ac_tool_prefix"; then
   # Extract the first word of "${ac_tool_prefix}gcc", so it can be a program name with args.
 set dummy ${ac_tool_prefix}gcc; ac_word=$2
-{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for $ac_word" >&5
-printf %s "checking for $ac_word... " >&6; }
-if test ${ac_cv_prog_CC+y}
-then :
-  printf %s "(cached) " >&6
-else $as_nop
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for $ac_word" >&5
+$as_echo_n "checking for $ac_word... " >&6; }
+if ${ac_cv_prog_CC+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
   if test -n "$CC"; then
   ac_cv_prog_CC="$CC" # Let the user override the test.
 else
@@ -3381,15 +2986,11 @@ as_save_IFS=$IFS; IFS=$PATH_SEPARATOR
 for as_dir in $PATH
 do
   IFS=$as_save_IFS
-  case $as_dir in #(((
-    '') as_dir=./ ;;
-    */) ;;
-    *) as_dir=$as_dir/ ;;
-  esac
+  test -z "$as_dir" && as_dir=.
     for ac_exec_ext in '' $ac_executable_extensions; do
-  if as_fn_executable_p "$as_dir$ac_word$ac_exec_ext"; then
+  if as_fn_executable_p "$as_dir/$ac_word$ac_exec_ext"; then
     ac_cv_prog_CC="${ac_tool_prefix}gcc"
-    printf "%s\n" "$as_me:${as_lineno-$LINENO}: found $as_dir$ac_word$ac_exec_ext" >&5
+    $as_echo "$as_me:${as_lineno-$LINENO}: found $as_dir/$ac_word$ac_exec_ext" >&5
     break 2
   fi
 done
@@ -3400,11 +3001,11 @@ fi
 fi
 CC=$ac_cv_prog_CC
 if test -n "$CC"; then
-  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $CC" >&5
-printf "%s\n" "$CC" >&6; }
+  { $as_echo "$as_me:${as_lineno-$LINENO}: result: $CC" >&5
+$as_echo "$CC" >&6; }
 else
-  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: no" >&5
-printf "%s\n" "no" >&6; }
+  { $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
+$as_echo "no" >&6; }
 fi
 
 
@@ -3413,12 +3014,11 @@ if test -z "$ac_cv_prog_CC"; then
   ac_ct_CC=$CC
   # Extract the first word of "gcc", so it can be a program name with args.
 set dummy gcc; ac_word=$2
-{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for $ac_word" >&5
-printf %s "checking for $ac_word... " >&6; }
-if test ${ac_cv_prog_ac_ct_CC+y}
-then :
-  printf %s "(cached) " >&6
-else $as_nop
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for $ac_word" >&5
+$as_echo_n "checking for $ac_word... " >&6; }
+if ${ac_cv_prog_ac_ct_CC+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
   if test -n "$ac_ct_CC"; then
   ac_cv_prog_ac_ct_CC="$ac_ct_CC" # Let the user override the test.
 else
@@ -3426,15 +3026,11 @@ as_save_IFS=$IFS; IFS=$PATH_SEPARATOR
 for as_dir in $PATH
 do
   IFS=$as_save_IFS
-  case $as_dir in #(((
-    '') as_dir=./ ;;
-    */) ;;
-    *) as_dir=$as_dir/ ;;
-  esac
+  test -z "$as_dir" && as_dir=.
     for ac_exec_ext in '' $ac_executable_extensions; do
-  if as_fn_executable_p "$as_dir$ac_word$ac_exec_ext"; then
+  if as_fn_executable_p "$as_dir/$ac_word$ac_exec_ext"; then
     ac_cv_prog_ac_ct_CC="gcc"
-    printf "%s\n" "$as_me:${as_lineno-$LINENO}: found $as_dir$ac_word$ac_exec_ext" >&5
+    $as_echo "$as_me:${as_lineno-$LINENO}: found $as_dir/$ac_word$ac_exec_ext" >&5
     break 2
   fi
 done
@@ -3445,11 +3041,11 @@ fi
 fi
 ac_ct_CC=$ac_cv_prog_ac_ct_CC
 if test -n "$ac_ct_CC"; then
-  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $ac_ct_CC" >&5
-printf "%s\n" "$ac_ct_CC" >&6; }
+  { $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_ct_CC" >&5
+$as_echo "$ac_ct_CC" >&6; }
 else
-  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: no" >&5
-printf "%s\n" "no" >&6; }
+  { $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
+$as_echo "no" >&6; }
 fi
 
   if test "x$ac_ct_CC" = x; then
@@ -3457,8 +3053,8 @@ fi
   else
     case $cross_compiling:$ac_tool_warned in
 yes:)
-{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: WARNING: using cross tools not prefixed with host triplet" >&5
-printf "%s\n" "$as_me: WARNING: using cross tools not prefixed with host triplet" >&2;}
+{ $as_echo "$as_me:${as_lineno-$LINENO}: WARNING: using cross tools not prefixed with host triplet" >&5
+$as_echo "$as_me: WARNING: using cross tools not prefixed with host triplet" >&2;}
 ac_tool_warned=yes ;;
 esac
     CC=$ac_ct_CC
@@ -3471,12 +3067,11 @@ if test -z "$CC"; then
           if test -n "$ac_tool_prefix"; then
     # Extract the first word of "${ac_tool_prefix}cc", so it can be a program name with args.
 set dummy ${ac_tool_prefix}cc; ac_word=$2
-{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for $ac_word" >&5
-printf %s "checking for $ac_word... " >&6; }
-if test ${ac_cv_prog_CC+y}
-then :
-  printf %s "(cached) " >&6
-else $as_nop
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for $ac_word" >&5
+$as_echo_n "checking for $ac_word... " >&6; }
+if ${ac_cv_prog_CC+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
   if test -n "$CC"; then
   ac_cv_prog_CC="$CC" # Let the user override the test.
 else
@@ -3484,15 +3079,11 @@ as_save_IFS=$IFS; IFS=$PATH_SEPARATOR
 for as_dir in $PATH
 do
   IFS=$as_save_IFS
-  case $as_dir in #(((
-    '') as_dir=./ ;;
-    */) ;;
-    *) as_dir=$as_dir/ ;;
-  esac
+  test -z "$as_dir" && as_dir=.
     for ac_exec_ext in '' $ac_executable_extensions; do
-  if as_fn_executable_p "$as_dir$ac_word$ac_exec_ext"; then
+  if as_fn_executable_p "$as_dir/$ac_word$ac_exec_ext"; then
     ac_cv_prog_CC="${ac_tool_prefix}cc"
-    printf "%s\n" "$as_me:${as_lineno-$LINENO}: found $as_dir$ac_word$ac_exec_ext" >&5
+    $as_echo "$as_me:${as_lineno-$LINENO}: found $as_dir/$ac_word$ac_exec_ext" >&5
     break 2
   fi
 done
@@ -3503,11 +3094,11 @@ fi
 fi
 CC=$ac_cv_prog_CC
 if test -n "$CC"; then
-  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $CC" >&5
-printf "%s\n" "$CC" >&6; }
+  { $as_echo "$as_me:${as_lineno-$LINENO}: result: $CC" >&5
+$as_echo "$CC" >&6; }
 else
-  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: no" >&5
-printf "%s\n" "no" >&6; }
+  { $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
+$as_echo "no" >&6; }
 fi
 
 
@@ -3516,12 +3107,11 @@ fi
 if test -z "$CC"; then
   # Extract the first word of "cc", so it can be a program name with args.
 set dummy cc; ac_word=$2
-{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for $ac_word" >&5
-printf %s "checking for $ac_word... " >&6; }
-if test ${ac_cv_prog_CC+y}
-then :
-  printf %s "(cached) " >&6
-else $as_nop
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for $ac_word" >&5
+$as_echo_n "checking for $ac_word... " >&6; }
+if ${ac_cv_prog_CC+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
   if test -n "$CC"; then
   ac_cv_prog_CC="$CC" # Let the user override the test.
 else
@@ -3530,19 +3120,15 @@ as_save_IFS=$IFS; IFS=$PATH_SEPARATOR
 for as_dir in $PATH
 do
   IFS=$as_save_IFS
-  case $as_dir in #(((
-    '') as_dir=./ ;;
-    */) ;;
-    *) as_dir=$as_dir/ ;;
-  esac
+  test -z "$as_dir" && as_dir=.
     for ac_exec_ext in '' $ac_executable_extensions; do
-  if as_fn_executable_p "$as_dir$ac_word$ac_exec_ext"; then
-    if test "$as_dir$ac_word$ac_exec_ext" = "/usr/ucb/cc"; then
+  if as_fn_executable_p "$as_dir/$ac_word$ac_exec_ext"; then
+    if test "$as_dir/$ac_word$ac_exec_ext" = "/usr/ucb/cc"; then
        ac_prog_rejected=yes
        continue
      fi
     ac_cv_prog_CC="cc"
-    printf "%s\n" "$as_me:${as_lineno-$LINENO}: found $as_dir$ac_word$ac_exec_ext" >&5
+    $as_echo "$as_me:${as_lineno-$LINENO}: found $as_dir/$ac_word$ac_exec_ext" >&5
     break 2
   fi
 done
@@ -3558,18 +3144,18 @@ if test $ac_prog_rejected = yes; then
     # However, it has the same basename, so the bogon will be chosen
     # first if we set CC to just the basename; use the full file name.
     shift
-    ac_cv_prog_CC="$as_dir$ac_word${1+' '}$@"
+    ac_cv_prog_CC="$as_dir/$ac_word${1+' '}$@"
   fi
 fi
 fi
 fi
 CC=$ac_cv_prog_CC
 if test -n "$CC"; then
-  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $CC" >&5
-printf "%s\n" "$CC" >&6; }
+  { $as_echo "$as_me:${as_lineno-$LINENO}: result: $CC" >&5
+$as_echo "$CC" >&6; }
 else
-  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: no" >&5
-printf "%s\n" "no" >&6; }
+  { $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
+$as_echo "no" >&6; }
 fi
 
 
@@ -3580,12 +3166,11 @@ if test -z "$CC"; then
   do
     # Extract the first word of "$ac_tool_prefix$ac_prog", so it can be a program name with args.
 set dummy $ac_tool_prefix$ac_prog; ac_word=$2
-{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for $ac_word" >&5
-printf %s "checking for $ac_word... " >&6; }
-if test ${ac_cv_prog_CC+y}
-then :
-  printf %s "(cached) " >&6
-else $as_nop
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for $ac_word" >&5
+$as_echo_n "checking for $ac_word... " >&6; }
+if ${ac_cv_prog_CC+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
   if test -n "$CC"; then
   ac_cv_prog_CC="$CC" # Let the user override the test.
 else
@@ -3593,15 +3178,11 @@ as_save_IFS=$IFS; IFS=$PATH_SEPARATOR
 for as_dir in $PATH
 do
   IFS=$as_save_IFS
-  case $as_dir in #(((
-    '') as_dir=./ ;;
-    */) ;;
-    *) as_dir=$as_dir/ ;;
-  esac
+  test -z "$as_dir" && as_dir=.
     for ac_exec_ext in '' $ac_executable_extensions; do
-  if as_fn_executable_p "$as_dir$ac_word$ac_exec_ext"; then
+  if as_fn_executable_p "$as_dir/$ac_word$ac_exec_ext"; then
     ac_cv_prog_CC="$ac_tool_prefix$ac_prog"
-    printf "%s\n" "$as_me:${as_lineno-$LINENO}: found $as_dir$ac_word$ac_exec_ext" >&5
+    $as_echo "$as_me:${as_lineno-$LINENO}: found $as_dir/$ac_word$ac_exec_ext" >&5
     break 2
   fi
 done
@@ -3612,11 +3193,11 @@ fi
 fi
 CC=$ac_cv_prog_CC
 if test -n "$CC"; then
-  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $CC" >&5
-printf "%s\n" "$CC" >&6; }
+  { $as_echo "$as_me:${as_lineno-$LINENO}: result: $CC" >&5
+$as_echo "$CC" >&6; }
 else
-  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: no" >&5
-printf "%s\n" "no" >&6; }
+  { $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
+$as_echo "no" >&6; }
 fi
 
 
@@ -3629,12 +3210,11 @@ if test -z "$CC"; then
 do
   # Extract the first word of "$ac_prog", so it can be a program name with args.
 set dummy $ac_prog; ac_word=$2
-{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for $ac_word" >&5
-printf %s "checking for $ac_word... " >&6; }
-if test ${ac_cv_prog_ac_ct_CC+y}
-then :
-  printf %s "(cached) " >&6
-else $as_nop
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for $ac_word" >&5
+$as_echo_n "checking for $ac_word... " >&6; }
+if ${ac_cv_prog_ac_ct_CC+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
   if test -n "$ac_ct_CC"; then
   ac_cv_prog_ac_ct_CC="$ac_ct_CC" # Let the user override the test.
 else
@@ -3642,15 +3222,11 @@ as_save_IFS=$IFS; IFS=$PATH_SEPARATOR
 for as_dir in $PATH
 do
   IFS=$as_save_IFS
-  case $as_dir in #(((
-    '') as_dir=./ ;;
-    */) ;;
-    *) as_dir=$as_dir/ ;;
-  esac
+  test -z "$as_dir" && as_dir=.
     for ac_exec_ext in '' $ac_executable_extensions; do
-  if as_fn_executable_p "$as_dir$ac_word$ac_exec_ext"; then
+  if as_fn_executable_p "$as_dir/$ac_word$ac_exec_ext"; then
     ac_cv_prog_ac_ct_CC="$ac_prog"
-    printf "%s\n" "$as_me:${as_lineno-$LINENO}: found $as_dir$ac_word$ac_exec_ext" >&5
+    $as_echo "$as_me:${as_lineno-$LINENO}: found $as_dir/$ac_word$ac_exec_ext" >&5
     break 2
   fi
 done
@@ -3661,11 +3237,11 @@ fi
 fi
 ac_ct_CC=$ac_cv_prog_ac_ct_CC
 if test -n "$ac_ct_CC"; then
-  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $ac_ct_CC" >&5
-printf "%s\n" "$ac_ct_CC" >&6; }
+  { $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_ct_CC" >&5
+$as_echo "$ac_ct_CC" >&6; }
 else
-  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: no" >&5
-printf "%s\n" "no" >&6; }
+  { $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
+$as_echo "no" >&6; }
 fi
 
 
@@ -3677,8 +3253,8 @@ done
   else
     case $cross_compiling:$ac_tool_warned in
 yes:)
-{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: WARNING: using cross tools not prefixed with host triplet" >&5
-printf "%s\n" "$as_me: WARNING: using cross tools not prefixed with host triplet" >&2;}
+{ $as_echo "$as_me:${as_lineno-$LINENO}: WARNING: using cross tools not prefixed with host triplet" >&5
+$as_echo "$as_me: WARNING: using cross tools not prefixed with host triplet" >&2;}
 ac_tool_warned=yes ;;
 esac
     CC=$ac_ct_CC
@@ -3686,129 +3262,25 @@ esac
 fi
 
 fi
-if test -z "$CC"; then
-  if test -n "$ac_tool_prefix"; then
-  # Extract the first word of "${ac_tool_prefix}clang", so it can be a program name with args.
-set dummy ${ac_tool_prefix}clang; ac_word=$2
-{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for $ac_word" >&5
-printf %s "checking for $ac_word... " >&6; }
-if test ${ac_cv_prog_CC+y}
-then :
-  printf %s "(cached) " >&6
-else $as_nop
-  if test -n "$CC"; then
-  ac_cv_prog_CC="$CC" # Let the user override the test.
-else
-as_save_IFS=$IFS; IFS=$PATH_SEPARATOR
-for as_dir in $PATH
-do
-  IFS=$as_save_IFS
-  case $as_dir in #(((
-    '') as_dir=./ ;;
-    */) ;;
-    *) as_dir=$as_dir/ ;;
-  esac
-    for ac_exec_ext in '' $ac_executable_extensions; do
-  if as_fn_executable_p "$as_dir$ac_word$ac_exec_ext"; then
-    ac_cv_prog_CC="${ac_tool_prefix}clang"
-    printf "%s\n" "$as_me:${as_lineno-$LINENO}: found $as_dir$ac_word$ac_exec_ext" >&5
-    break 2
-  fi
-done
-  done
-IFS=$as_save_IFS
-
-fi
-fi
-CC=$ac_cv_prog_CC
-if test -n "$CC"; then
-  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $CC" >&5
-printf "%s\n" "$CC" >&6; }
-else
-  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: no" >&5
-printf "%s\n" "no" >&6; }
-fi
 
 
-fi
-if test -z "$ac_cv_prog_CC"; then
-  ac_ct_CC=$CC
-  # Extract the first word of "clang", so it can be a program name with args.
-set dummy clang; ac_word=$2
-{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for $ac_word" >&5
-printf %s "checking for $ac_word... " >&6; }
-if test ${ac_cv_prog_ac_ct_CC+y}
-then :
-  printf %s "(cached) " >&6
-else $as_nop
-  if test -n "$ac_ct_CC"; then
-  ac_cv_prog_ac_ct_CC="$ac_ct_CC" # Let the user override the test.
-else
-as_save_IFS=$IFS; IFS=$PATH_SEPARATOR
-for as_dir in $PATH
-do
-  IFS=$as_save_IFS
-  case $as_dir in #(((
-    '') as_dir=./ ;;
-    */) ;;
-    *) as_dir=$as_dir/ ;;
-  esac
-    for ac_exec_ext in '' $ac_executable_extensions; do
-  if as_fn_executable_p "$as_dir$ac_word$ac_exec_ext"; then
-    ac_cv_prog_ac_ct_CC="clang"
-    printf "%s\n" "$as_me:${as_lineno-$LINENO}: found $as_dir$ac_word$ac_exec_ext" >&5
-    break 2
-  fi
-done
-  done
-IFS=$as_save_IFS
-
-fi
-fi
-ac_ct_CC=$ac_cv_prog_ac_ct_CC
-if test -n "$ac_ct_CC"; then
-  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $ac_ct_CC" >&5
-printf "%s\n" "$ac_ct_CC" >&6; }
-else
-  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: no" >&5
-printf "%s\n" "no" >&6; }
-fi
-
-  if test "x$ac_ct_CC" = x; then
-    CC=""
-  else
-    case $cross_compiling:$ac_tool_warned in
-yes:)
-{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: WARNING: using cross tools not prefixed with host triplet" >&5
-printf "%s\n" "$as_me: WARNING: using cross tools not prefixed with host triplet" >&2;}
-ac_tool_warned=yes ;;
-esac
-    CC=$ac_ct_CC
-  fi
-else
-  CC="$ac_cv_prog_CC"
-fi
-
-fi
-
-
-test -z "$CC" && { { printf "%s\n" "$as_me:${as_lineno-$LINENO}: error: in \`$ac_pwd':" >&5
-printf "%s\n" "$as_me: error: in \`$ac_pwd':" >&2;}
+test -z "$CC" && { { $as_echo "$as_me:${as_lineno-$LINENO}: error: in \`$ac_pwd':" >&5
+$as_echo "$as_me: error: in \`$ac_pwd':" >&2;}
 as_fn_error $? "no acceptable C compiler found in \$PATH
 See \`config.log' for more details" "$LINENO" 5; }
 
 # Provide some information about the compiler.
-printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for C compiler version" >&5
+$as_echo "$as_me:${as_lineno-$LINENO}: checking for C compiler version" >&5
 set X $ac_compile
 ac_compiler=$2
-for ac_option in --version -v -V -qversion -version; do
+for ac_option in --version -v -V -qversion; do
   { { ac_try="$ac_compiler $ac_option >&5"
 case "(($ac_try" in
   *\"* | *\`* | *\\*) ac_try_echo=\$ac_try;;
   *) ac_try_echo=$ac_try;;
 esac
 eval ac_try_echo="\"\$as_me:${as_lineno-$LINENO}: $ac_try_echo\""
-printf "%s\n" "$ac_try_echo"; } >&5
+$as_echo "$ac_try_echo"; } >&5
   (eval "$ac_compiler $ac_option >&5") 2>conftest.err
   ac_status=$?
   if test -s conftest.err; then
@@ -3818,7 +3290,7 @@ printf "%s\n" "$ac_try_echo"; } >&5
     cat conftest.er1 >&5
   fi
   rm -f conftest.er1 conftest.err
-  printf "%s\n" "$as_me:${as_lineno-$LINENO}: \$? = $ac_status" >&5
+  $as_echo "$as_me:${as_lineno-$LINENO}: \$? = $ac_status" >&5
   test $ac_status = 0; }
 done
 
@@ -3826,7 +3298,7 @@ cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 /* end confdefs.h.  */
 
 int
-main (void)
+main ()
 {
 
   ;
@@ -3838,9 +3310,9 @@ ac_clean_files="$ac_clean_files a.out a.out.dSYM a.exe b.out"
 # Try to create an executable without -o first, disregard a.out.
 # It will help us diagnose broken compilers, and finding out an intuition
 # of exeext.
-{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking whether the C compiler works" >&5
-printf %s "checking whether the C compiler works... " >&6; }
-ac_link_default=`printf "%s\n" "$ac_link" | sed 's/ -o *conftest[^ ]*//'`
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking whether the C compiler works" >&5
+$as_echo_n "checking whether the C compiler works... " >&6; }
+ac_link_default=`$as_echo "$ac_link" | sed 's/ -o *conftest[^ ]*//'`
 
 # The possible output files:
 ac_files="a.out conftest.exe conftest a.exe a_out.exe b.out conftest.*"
@@ -3861,12 +3333,11 @@ case "(($ac_try" in
   *) ac_try_echo=$ac_try;;
 esac
 eval ac_try_echo="\"\$as_me:${as_lineno-$LINENO}: $ac_try_echo\""
-printf "%s\n" "$ac_try_echo"; } >&5
+$as_echo "$ac_try_echo"; } >&5
   (eval "$ac_link_default") 2>&5
   ac_status=$?
-  printf "%s\n" "$as_me:${as_lineno-$LINENO}: \$? = $ac_status" >&5
-  test $ac_status = 0; }
-then :
+  $as_echo "$as_me:${as_lineno-$LINENO}: \$? = $ac_status" >&5
+  test $ac_status = 0; }; then :
   # Autoconf-2.13 could set the ac_cv_exeext variable to `no'.
 # So ignore a value of `no', otherwise this would lead to `EXEEXT = no'
 # in a Makefile.  We should not override ac_cv_exeext if it was cached,
@@ -3883,7 +3354,7 @@ do
 	# certainly right.
 	break;;
     *.* )
-	if test ${ac_cv_exeext+y} && test "$ac_cv_exeext" != no;
+	if test "${ac_cv_exeext+set}" = set && test "$ac_cv_exeext" != no;
 	then :; else
 	   ac_cv_exeext=`expr "$ac_file" : '[^.]*\(\..*\)'`
 	fi
@@ -3899,46 +3370,44 @@ do
 done
 test "$ac_cv_exeext" = no && ac_cv_exeext=
 
-else $as_nop
+else
   ac_file=''
 fi
-if test -z "$ac_file"
-then :
-  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: no" >&5
-printf "%s\n" "no" >&6; }
-printf "%s\n" "$as_me: failed program was:" >&5
+if test -z "$ac_file"; then :
+  { $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
+$as_echo "no" >&6; }
+$as_echo "$as_me: failed program was:" >&5
 sed 's/^/| /' conftest.$ac_ext >&5
 
-{ { printf "%s\n" "$as_me:${as_lineno-$LINENO}: error: in \`$ac_pwd':" >&5
-printf "%s\n" "$as_me: error: in \`$ac_pwd':" >&2;}
+{ { $as_echo "$as_me:${as_lineno-$LINENO}: error: in \`$ac_pwd':" >&5
+$as_echo "$as_me: error: in \`$ac_pwd':" >&2;}
 as_fn_error 77 "C compiler cannot create executables
 See \`config.log' for more details" "$LINENO" 5; }
-else $as_nop
-  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: yes" >&5
-printf "%s\n" "yes" >&6; }
+else
+  { $as_echo "$as_me:${as_lineno-$LINENO}: result: yes" >&5
+$as_echo "yes" >&6; }
 fi
-{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for C compiler default output file name" >&5
-printf %s "checking for C compiler default output file name... " >&6; }
-{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $ac_file" >&5
-printf "%s\n" "$ac_file" >&6; }
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for C compiler default output file name" >&5
+$as_echo_n "checking for C compiler default output file name... " >&6; }
+{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_file" >&5
+$as_echo "$ac_file" >&6; }
 ac_exeext=$ac_cv_exeext
 
 rm -f -r a.out a.out.dSYM a.exe conftest$ac_cv_exeext b.out
 ac_clean_files=$ac_clean_files_save
-{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for suffix of executables" >&5
-printf %s "checking for suffix of executables... " >&6; }
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for suffix of executables" >&5
+$as_echo_n "checking for suffix of executables... " >&6; }
 if { { ac_try="$ac_link"
 case "(($ac_try" in
   *\"* | *\`* | *\\*) ac_try_echo=\$ac_try;;
   *) ac_try_echo=$ac_try;;
 esac
 eval ac_try_echo="\"\$as_me:${as_lineno-$LINENO}: $ac_try_echo\""
-printf "%s\n" "$ac_try_echo"; } >&5
+$as_echo "$ac_try_echo"; } >&5
   (eval "$ac_link") 2>&5
   ac_status=$?
-  printf "%s\n" "$as_me:${as_lineno-$LINENO}: \$? = $ac_status" >&5
-  test $ac_status = 0; }
-then :
+  $as_echo "$as_me:${as_lineno-$LINENO}: \$? = $ac_status" >&5
+  test $ac_status = 0; }; then :
   # If both `conftest.exe' and `conftest' are `present' (well, observable)
 # catch `conftest.exe'.  For instance with Cygwin, `ls conftest' will
 # work properly (i.e., refer to `conftest.exe'), while it won't with
@@ -3952,15 +3421,15 @@ for ac_file in conftest.exe conftest conftest.*; do
     * ) break;;
   esac
 done
-else $as_nop
-  { { printf "%s\n" "$as_me:${as_lineno-$LINENO}: error: in \`$ac_pwd':" >&5
-printf "%s\n" "$as_me: error: in \`$ac_pwd':" >&2;}
+else
+  { { $as_echo "$as_me:${as_lineno-$LINENO}: error: in \`$ac_pwd':" >&5
+$as_echo "$as_me: error: in \`$ac_pwd':" >&2;}
 as_fn_error $? "cannot compute suffix of executables: cannot compile and link
 See \`config.log' for more details" "$LINENO" 5; }
 fi
 rm -f conftest conftest$ac_cv_exeext
-{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $ac_cv_exeext" >&5
-printf "%s\n" "$ac_cv_exeext" >&6; }
+{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_exeext" >&5
+$as_echo "$ac_cv_exeext" >&6; }
 
 rm -f conftest.$ac_ext
 EXEEXT=$ac_cv_exeext
@@ -3969,7 +3438,7 @@ cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 /* end confdefs.h.  */
 #include <stdio.h>
 int
-main (void)
+main ()
 {
 FILE *f = fopen ("conftest.out", "w");
  return ferror (f) || fclose (f) != 0;
@@ -3981,8 +3450,8 @@ _ACEOF
 ac_clean_files="$ac_clean_files conftest.out"
 # Check that the compiler produces executables we can run.  If not, either
 # the compiler is broken, or we cross compile.
-{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking whether we are cross compiling" >&5
-printf %s "checking whether we are cross compiling... " >&6; }
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking whether we are cross compiling" >&5
+$as_echo_n "checking whether we are cross compiling... " >&6; }
 if test "$cross_compiling" != yes; then
   { { ac_try="$ac_link"
 case "(($ac_try" in
@@ -3990,10 +3459,10 @@ case "(($ac_try" in
   *) ac_try_echo=$ac_try;;
 esac
 eval ac_try_echo="\"\$as_me:${as_lineno-$LINENO}: $ac_try_echo\""
-printf "%s\n" "$ac_try_echo"; } >&5
+$as_echo "$ac_try_echo"; } >&5
   (eval "$ac_link") 2>&5
   ac_status=$?
-  printf "%s\n" "$as_me:${as_lineno-$LINENO}: \$? = $ac_status" >&5
+  $as_echo "$as_me:${as_lineno-$LINENO}: \$? = $ac_status" >&5
   test $ac_status = 0; }
   if { ac_try='./conftest$ac_cv_exeext'
   { { case "(($ac_try" in
@@ -4001,40 +3470,39 @@ printf "%s\n" "$ac_try_echo"; } >&5
   *) ac_try_echo=$ac_try;;
 esac
 eval ac_try_echo="\"\$as_me:${as_lineno-$LINENO}: $ac_try_echo\""
-printf "%s\n" "$ac_try_echo"; } >&5
+$as_echo "$ac_try_echo"; } >&5
   (eval "$ac_try") 2>&5
   ac_status=$?
-  printf "%s\n" "$as_me:${as_lineno-$LINENO}: \$? = $ac_status" >&5
+  $as_echo "$as_me:${as_lineno-$LINENO}: \$? = $ac_status" >&5
   test $ac_status = 0; }; }; then
     cross_compiling=no
   else
     if test "$cross_compiling" = maybe; then
 	cross_compiling=yes
     else
-	{ { printf "%s\n" "$as_me:${as_lineno-$LINENO}: error: in \`$ac_pwd':" >&5
-printf "%s\n" "$as_me: error: in \`$ac_pwd':" >&2;}
-as_fn_error 77 "cannot run C compiled programs.
+	{ { $as_echo "$as_me:${as_lineno-$LINENO}: error: in \`$ac_pwd':" >&5
+$as_echo "$as_me: error: in \`$ac_pwd':" >&2;}
+as_fn_error $? "cannot run C compiled programs.
 If you meant to cross compile, use \`--host'.
 See \`config.log' for more details" "$LINENO" 5; }
     fi
   fi
 fi
-{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $cross_compiling" >&5
-printf "%s\n" "$cross_compiling" >&6; }
+{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $cross_compiling" >&5
+$as_echo "$cross_compiling" >&6; }
 
 rm -f conftest.$ac_ext conftest$ac_cv_exeext conftest.out
 ac_clean_files=$ac_clean_files_save
-{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for suffix of object files" >&5
-printf %s "checking for suffix of object files... " >&6; }
-if test ${ac_cv_objext+y}
-then :
-  printf %s "(cached) " >&6
-else $as_nop
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for suffix of object files" >&5
+$as_echo_n "checking for suffix of object files... " >&6; }
+if ${ac_cv_objext+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
   cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 /* end confdefs.h.  */
 
 int
-main (void)
+main ()
 {
 
   ;
@@ -4048,12 +3516,11 @@ case "(($ac_try" in
   *) ac_try_echo=$ac_try;;
 esac
 eval ac_try_echo="\"\$as_me:${as_lineno-$LINENO}: $ac_try_echo\""
-printf "%s\n" "$ac_try_echo"; } >&5
+$as_echo "$ac_try_echo"; } >&5
   (eval "$ac_compile") 2>&5
   ac_status=$?
-  printf "%s\n" "$as_me:${as_lineno-$LINENO}: \$? = $ac_status" >&5
-  test $ac_status = 0; }
-then :
+  $as_echo "$as_me:${as_lineno-$LINENO}: \$? = $ac_status" >&5
+  test $ac_status = 0; }; then :
   for ac_file in conftest.o conftest.obj conftest.*; do
   test -f "$ac_file" || continue;
   case $ac_file in
@@ -4062,32 +3529,31 @@ then :
        break;;
   esac
 done
-else $as_nop
-  printf "%s\n" "$as_me: failed program was:" >&5
+else
+  $as_echo "$as_me: failed program was:" >&5
 sed 's/^/| /' conftest.$ac_ext >&5
 
-{ { printf "%s\n" "$as_me:${as_lineno-$LINENO}: error: in \`$ac_pwd':" >&5
-printf "%s\n" "$as_me: error: in \`$ac_pwd':" >&2;}
+{ { $as_echo "$as_me:${as_lineno-$LINENO}: error: in \`$ac_pwd':" >&5
+$as_echo "$as_me: error: in \`$ac_pwd':" >&2;}
 as_fn_error $? "cannot compute suffix of object files: cannot compile
 See \`config.log' for more details" "$LINENO" 5; }
 fi
 rm -f conftest.$ac_cv_objext conftest.$ac_ext
 fi
-{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $ac_cv_objext" >&5
-printf "%s\n" "$ac_cv_objext" >&6; }
+{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_objext" >&5
+$as_echo "$ac_cv_objext" >&6; }
 OBJEXT=$ac_cv_objext
 ac_objext=$OBJEXT
-{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking whether the compiler supports GNU C" >&5
-printf %s "checking whether the compiler supports GNU C... " >&6; }
-if test ${ac_cv_c_compiler_gnu+y}
-then :
-  printf %s "(cached) " >&6
-else $as_nop
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking whether we are using the GNU C compiler" >&5
+$as_echo_n "checking whether we are using the GNU C compiler... " >&6; }
+if ${ac_cv_c_compiler_gnu+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
   cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 /* end confdefs.h.  */
 
 int
-main (void)
+main ()
 {
 #ifndef __GNUC__
        choke me
@@ -4097,33 +3563,29 @@ main (void)
   return 0;
 }
 _ACEOF
-if ac_fn_c_try_compile "$LINENO"
-then :
+if ac_fn_c_try_compile "$LINENO"; then :
   ac_compiler_gnu=yes
-else $as_nop
+else
   ac_compiler_gnu=no
 fi
-rm -f core conftest.err conftest.$ac_objext conftest.beam conftest.$ac_ext
+rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
 ac_cv_c_compiler_gnu=$ac_compiler_gnu
 
 fi
-{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $ac_cv_c_compiler_gnu" >&5
-printf "%s\n" "$ac_cv_c_compiler_gnu" >&6; }
-ac_compiler_gnu=$ac_cv_c_compiler_gnu
-
+{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_c_compiler_gnu" >&5
+$as_echo "$ac_cv_c_compiler_gnu" >&6; }
 if test $ac_compiler_gnu = yes; then
   GCC=yes
 else
   GCC=
 fi
-ac_test_CFLAGS=${CFLAGS+y}
+ac_test_CFLAGS=${CFLAGS+set}
 ac_save_CFLAGS=$CFLAGS
-{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking whether $CC accepts -g" >&5
-printf %s "checking whether $CC accepts -g... " >&6; }
-if test ${ac_cv_prog_cc_g+y}
-then :
-  printf %s "(cached) " >&6
-else $as_nop
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking whether $CC accepts -g" >&5
+$as_echo_n "checking whether $CC accepts -g... " >&6; }
+if ${ac_cv_prog_cc_g+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
   ac_save_c_werror_flag=$ac_c_werror_flag
    ac_c_werror_flag=yes
    ac_cv_prog_cc_g=no
@@ -4132,60 +3594,57 @@ else $as_nop
 /* end confdefs.h.  */
 
 int
-main (void)
+main ()
 {
 
   ;
   return 0;
 }
 _ACEOF
-if ac_fn_c_try_compile "$LINENO"
-then :
+if ac_fn_c_try_compile "$LINENO"; then :
   ac_cv_prog_cc_g=yes
-else $as_nop
+else
   CFLAGS=""
       cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 /* end confdefs.h.  */
 
 int
-main (void)
+main ()
 {
 
   ;
   return 0;
 }
 _ACEOF
-if ac_fn_c_try_compile "$LINENO"
-then :
+if ac_fn_c_try_compile "$LINENO"; then :
 
-else $as_nop
+else
   ac_c_werror_flag=$ac_save_c_werror_flag
 	 CFLAGS="-g"
 	 cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 /* end confdefs.h.  */
 
 int
-main (void)
+main ()
 {
 
   ;
   return 0;
 }
 _ACEOF
-if ac_fn_c_try_compile "$LINENO"
-then :
+if ac_fn_c_try_compile "$LINENO"; then :
   ac_cv_prog_cc_g=yes
 fi
-rm -f core conftest.err conftest.$ac_objext conftest.beam conftest.$ac_ext
+rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
 fi
-rm -f core conftest.err conftest.$ac_objext conftest.beam conftest.$ac_ext
+rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
 fi
-rm -f core conftest.err conftest.$ac_objext conftest.beam conftest.$ac_ext
+rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
    ac_c_werror_flag=$ac_save_c_werror_flag
 fi
-{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $ac_cv_prog_cc_g" >&5
-printf "%s\n" "$ac_cv_prog_cc_g" >&6; }
-if test $ac_test_CFLAGS; then
+{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_prog_cc_g" >&5
+$as_echo "$ac_cv_prog_cc_g" >&6; }
+if test "$ac_test_CFLAGS" = set; then
   CFLAGS=$ac_save_CFLAGS
 elif test $ac_cv_prog_cc_g = yes; then
   if test "$GCC" = yes; then
@@ -4200,144 +3659,94 @@ else
     CFLAGS=
   fi
 fi
-ac_prog_cc_stdc=no
-if test x$ac_prog_cc_stdc = xno
-then :
-  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for $CC option to enable C11 features" >&5
-printf %s "checking for $CC option to enable C11 features... " >&6; }
-if test ${ac_cv_prog_cc_c11+y}
-then :
-  printf %s "(cached) " >&6
-else $as_nop
-  ac_cv_prog_cc_c11=no
-ac_save_CC=$CC
-cat confdefs.h - <<_ACEOF >conftest.$ac_ext
-/* end confdefs.h.  */
-$ac_c_conftest_c11_program
-_ACEOF
-for ac_arg in '' -std=gnu11
-do
-  CC="$ac_save_CC $ac_arg"
-  if ac_fn_c_try_compile "$LINENO"
-then :
-  ac_cv_prog_cc_c11=$ac_arg
-fi
-rm -f core conftest.err conftest.$ac_objext conftest.beam
-  test "x$ac_cv_prog_cc_c11" != "xno" && break
-done
-rm -f conftest.$ac_ext
-CC=$ac_save_CC
-fi
-
-if test "x$ac_cv_prog_cc_c11" = xno
-then :
-  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: unsupported" >&5
-printf "%s\n" "unsupported" >&6; }
-else $as_nop
-  if test "x$ac_cv_prog_cc_c11" = x
-then :
-  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: none needed" >&5
-printf "%s\n" "none needed" >&6; }
-else $as_nop
-  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $ac_cv_prog_cc_c11" >&5
-printf "%s\n" "$ac_cv_prog_cc_c11" >&6; }
-     CC="$CC $ac_cv_prog_cc_c11"
-fi
-  ac_cv_prog_cc_stdc=$ac_cv_prog_cc_c11
-  ac_prog_cc_stdc=c11
-fi
-fi
-if test x$ac_prog_cc_stdc = xno
-then :
-  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for $CC option to enable C99 features" >&5
-printf %s "checking for $CC option to enable C99 features... " >&6; }
-if test ${ac_cv_prog_cc_c99+y}
-then :
-  printf %s "(cached) " >&6
-else $as_nop
-  ac_cv_prog_cc_c99=no
-ac_save_CC=$CC
-cat confdefs.h - <<_ACEOF >conftest.$ac_ext
-/* end confdefs.h.  */
-$ac_c_conftest_c99_program
-_ACEOF
-for ac_arg in '' -std=gnu99 -std=c99 -c99 -qlanglvl=extc1x -qlanglvl=extc99 -AC99 -D_STDC_C99=
-do
-  CC="$ac_save_CC $ac_arg"
-  if ac_fn_c_try_compile "$LINENO"
-then :
-  ac_cv_prog_cc_c99=$ac_arg
-fi
-rm -f core conftest.err conftest.$ac_objext conftest.beam
-  test "x$ac_cv_prog_cc_c99" != "xno" && break
-done
-rm -f conftest.$ac_ext
-CC=$ac_save_CC
-fi
-
-if test "x$ac_cv_prog_cc_c99" = xno
-then :
-  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: unsupported" >&5
-printf "%s\n" "unsupported" >&6; }
-else $as_nop
-  if test "x$ac_cv_prog_cc_c99" = x
-then :
-  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: none needed" >&5
-printf "%s\n" "none needed" >&6; }
-else $as_nop
-  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $ac_cv_prog_cc_c99" >&5
-printf "%s\n" "$ac_cv_prog_cc_c99" >&6; }
-     CC="$CC $ac_cv_prog_cc_c99"
-fi
-  ac_cv_prog_cc_stdc=$ac_cv_prog_cc_c99
-  ac_prog_cc_stdc=c99
-fi
-fi
-if test x$ac_prog_cc_stdc = xno
-then :
-  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for $CC option to enable C89 features" >&5
-printf %s "checking for $CC option to enable C89 features... " >&6; }
-if test ${ac_cv_prog_cc_c89+y}
-then :
-  printf %s "(cached) " >&6
-else $as_nop
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for $CC option to accept ISO C89" >&5
+$as_echo_n "checking for $CC option to accept ISO C89... " >&6; }
+if ${ac_cv_prog_cc_c89+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
   ac_cv_prog_cc_c89=no
 ac_save_CC=$CC
 cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 /* end confdefs.h.  */
-$ac_c_conftest_c89_program
+#include <stdarg.h>
+#include <stdio.h>
+struct stat;
+/* Most of the following tests are stolen from RCS 5.7's src/conf.sh.  */
+struct buf { int x; };
+FILE * (*rcsopen) (struct buf *, struct stat *, int);
+static char *e (p, i)
+     char **p;
+     int i;
+{
+  return p[i];
+}
+static char *f (char * (*g) (char **, int), char **p, ...)
+{
+  char *s;
+  va_list v;
+  va_start (v,p);
+  s = g (p, va_arg (v,int));
+  va_end (v);
+  return s;
+}
+
+/* OSF 4.0 Compaq cc is some sort of almost-ANSI by default.  It has
+   function prototypes and stuff, but not '\xHH' hex character constants.
+   These don't provoke an error unfortunately, instead are silently treated
+   as 'x'.  The following induces an error, until -std is added to get
+   proper ANSI mode.  Curiously '\x00'!='x' always comes out true, for an
+   array size at least.  It's necessary to write '\x00'==0 to get something
+   that's true only with -std.  */
+int osf4_cc_array ['\x00' == 0 ? 1 : -1];
+
+/* IBM C 6 for AIX is almost-ANSI by default, but it replaces macro parameters
+   inside strings and character constants.  */
+#define FOO(x) 'x'
+int xlc6_cc_array[FOO(a) == 'x' ? 1 : -1];
+
+int test (int i, double x);
+struct s1 {int (*f) (int a);};
+struct s2 {int (*f) (double a);};
+int pairnames (int, char **, FILE *(*)(struct buf *, struct stat *, int), int, int);
+int argc;
+char **argv;
+int
+main ()
+{
+return f (e, argv, 0) != argv[0]  ||  f (e, argv, 1) != argv[1];
+  ;
+  return 0;
+}
 _ACEOF
-for ac_arg in '' -qlanglvl=extc89 -qlanglvl=ansi -std -Ae "-Aa -D_HPUX_SOURCE" "-Xc -D__EXTENSIONS__"
+for ac_arg in '' -qlanglvl=extc89 -qlanglvl=ansi -std \
+	-Ae "-Aa -D_HPUX_SOURCE" "-Xc -D__EXTENSIONS__"
 do
   CC="$ac_save_CC $ac_arg"
-  if ac_fn_c_try_compile "$LINENO"
-then :
+  if ac_fn_c_try_compile "$LINENO"; then :
   ac_cv_prog_cc_c89=$ac_arg
 fi
-rm -f core conftest.err conftest.$ac_objext conftest.beam
+rm -f core conftest.err conftest.$ac_objext
   test "x$ac_cv_prog_cc_c89" != "xno" && break
 done
 rm -f conftest.$ac_ext
 CC=$ac_save_CC
-fi
 
-if test "x$ac_cv_prog_cc_c89" = xno
-then :
-  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: unsupported" >&5
-printf "%s\n" "unsupported" >&6; }
-else $as_nop
-  if test "x$ac_cv_prog_cc_c89" = x
-then :
-  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: none needed" >&5
-printf "%s\n" "none needed" >&6; }
-else $as_nop
-  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $ac_cv_prog_cc_c89" >&5
-printf "%s\n" "$ac_cv_prog_cc_c89" >&6; }
-     CC="$CC $ac_cv_prog_cc_c89"
 fi
-  ac_cv_prog_cc_stdc=$ac_cv_prog_cc_c89
-  ac_prog_cc_stdc=c89
-fi
+# AC_CACHE_VAL
+case "x$ac_cv_prog_cc_c89" in
+  x)
+    { $as_echo "$as_me:${as_lineno-$LINENO}: result: none needed" >&5
+$as_echo "none needed" >&6; } ;;
+  xno)
+    { $as_echo "$as_me:${as_lineno-$LINENO}: result: unsupported" >&5
+$as_echo "unsupported" >&6; } ;;
+  *)
+    CC="$CC $ac_cv_prog_cc_c89"
+    { $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_prog_cc_c89" >&5
+$as_echo "$ac_cv_prog_cc_c89" >&6; } ;;
+esac
+if test "x$ac_cv_prog_cc_c89" != xno; then :
+
 fi
 
 ac_ext=c
@@ -4347,179 +3756,467 @@ ac_link='$CC -o conftest$ac_exeext $CFLAGS $CPPFLAGS $LDFLAGS conftest.$ac_ext $
 ac_compiler_gnu=$ac_cv_c_compiler_gnu
 
 
-ac_header= ac_cache=
-for ac_item in $ac_header_c_list
+ac_ext=c
+ac_cpp='$CPP $CPPFLAGS'
+ac_compile='$CC -c $CFLAGS $CPPFLAGS conftest.$ac_ext >&5'
+ac_link='$CC -o conftest$ac_exeext $CFLAGS $CPPFLAGS $LDFLAGS conftest.$ac_ext $LIBS >&5'
+ac_compiler_gnu=$ac_cv_c_compiler_gnu
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking how to run the C preprocessor" >&5
+$as_echo_n "checking how to run the C preprocessor... " >&6; }
+# On Suns, sometimes $CPP names a directory.
+if test -n "$CPP" && test -d "$CPP"; then
+  CPP=
+fi
+if test -z "$CPP"; then
+  if ${ac_cv_prog_CPP+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
+      # Double quotes because CPP needs to be expanded
+    for CPP in "$CC -E" "$CC -E -traditional-cpp" "/lib/cpp"
+    do
+      ac_preproc_ok=false
+for ac_c_preproc_warn_flag in '' yes
 do
-  if test $ac_cache; then
-    ac_fn_c_check_header_compile "$LINENO" $ac_header ac_cv_header_$ac_cache "$ac_includes_default"
-    if eval test \"x\$ac_cv_header_$ac_cache\" = xyes; then
-      printf "%s\n" "#define $ac_item 1" >> confdefs.h
+  # Use a header file that comes with gcc, so configuring glibc
+  # with a fresh cross-compiler works.
+  # Prefer <limits.h> to <assert.h> if __STDC__ is defined, since
+  # <limits.h> exists even on freestanding compilers.
+  # On the NeXT, cc -E runs the code through the compiler's parser,
+  # not just through cpp. "Syntax error" is here to catch this case.
+  cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+/* end confdefs.h.  */
+#ifdef __STDC__
+# include <limits.h>
+#else
+# include <assert.h>
+#endif
+		     Syntax error
+_ACEOF
+if ac_fn_c_try_cpp "$LINENO"; then :
+
+else
+  # Broken: fails on valid input.
+continue
+fi
+rm -f conftest.err conftest.i conftest.$ac_ext
+
+  # OK, works on sane cases.  Now check whether nonexistent headers
+  # can be detected and how.
+  cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+/* end confdefs.h.  */
+#include <ac_nonexistent.h>
+_ACEOF
+if ac_fn_c_try_cpp "$LINENO"; then :
+  # Broken: success on invalid input.
+continue
+else
+  # Passes both tests.
+ac_preproc_ok=:
+break
+fi
+rm -f conftest.err conftest.i conftest.$ac_ext
+
+done
+# Because of `break', _AC_PREPROC_IFELSE's cleaning code was skipped.
+rm -f conftest.i conftest.err conftest.$ac_ext
+if $ac_preproc_ok; then :
+  break
+fi
+
+    done
+    ac_cv_prog_CPP=$CPP
+
+fi
+  CPP=$ac_cv_prog_CPP
+else
+  ac_cv_prog_CPP=$CPP
+fi
+{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $CPP" >&5
+$as_echo "$CPP" >&6; }
+ac_preproc_ok=false
+for ac_c_preproc_warn_flag in '' yes
+do
+  # Use a header file that comes with gcc, so configuring glibc
+  # with a fresh cross-compiler works.
+  # Prefer <limits.h> to <assert.h> if __STDC__ is defined, since
+  # <limits.h> exists even on freestanding compilers.
+  # On the NeXT, cc -E runs the code through the compiler's parser,
+  # not just through cpp. "Syntax error" is here to catch this case.
+  cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+/* end confdefs.h.  */
+#ifdef __STDC__
+# include <limits.h>
+#else
+# include <assert.h>
+#endif
+		     Syntax error
+_ACEOF
+if ac_fn_c_try_cpp "$LINENO"; then :
+
+else
+  # Broken: fails on valid input.
+continue
+fi
+rm -f conftest.err conftest.i conftest.$ac_ext
+
+  # OK, works on sane cases.  Now check whether nonexistent headers
+  # can be detected and how.
+  cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+/* end confdefs.h.  */
+#include <ac_nonexistent.h>
+_ACEOF
+if ac_fn_c_try_cpp "$LINENO"; then :
+  # Broken: success on invalid input.
+continue
+else
+  # Passes both tests.
+ac_preproc_ok=:
+break
+fi
+rm -f conftest.err conftest.i conftest.$ac_ext
+
+done
+# Because of `break', _AC_PREPROC_IFELSE's cleaning code was skipped.
+rm -f conftest.i conftest.err conftest.$ac_ext
+if $ac_preproc_ok; then :
+
+else
+  { { $as_echo "$as_me:${as_lineno-$LINENO}: error: in \`$ac_pwd':" >&5
+$as_echo "$as_me: error: in \`$ac_pwd':" >&2;}
+as_fn_error $? "C preprocessor \"$CPP\" fails sanity check
+See \`config.log' for more details" "$LINENO" 5; }
+fi
+
+ac_ext=c
+ac_cpp='$CPP $CPPFLAGS'
+ac_compile='$CC -c $CFLAGS $CPPFLAGS conftest.$ac_ext >&5'
+ac_link='$CC -o conftest$ac_exeext $CFLAGS $CPPFLAGS $LDFLAGS conftest.$ac_ext $LIBS >&5'
+ac_compiler_gnu=$ac_cv_c_compiler_gnu
+
+
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for grep that handles long lines and -e" >&5
+$as_echo_n "checking for grep that handles long lines and -e... " >&6; }
+if ${ac_cv_path_GREP+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
+  if test -z "$GREP"; then
+  ac_path_GREP_found=false
+  # Loop through the user's path and test for each of PROGNAME-LIST
+  as_save_IFS=$IFS; IFS=$PATH_SEPARATOR
+for as_dir in $PATH$PATH_SEPARATOR/usr/xpg4/bin
+do
+  IFS=$as_save_IFS
+  test -z "$as_dir" && as_dir=.
+    for ac_prog in grep ggrep; do
+    for ac_exec_ext in '' $ac_executable_extensions; do
+      ac_path_GREP="$as_dir/$ac_prog$ac_exec_ext"
+      as_fn_executable_p "$ac_path_GREP" || continue
+# Check for GNU ac_path_GREP and select it if it is found.
+  # Check for GNU $ac_path_GREP
+case `"$ac_path_GREP" --version 2>&1` in
+*GNU*)
+  ac_cv_path_GREP="$ac_path_GREP" ac_path_GREP_found=:;;
+*)
+  ac_count=0
+  $as_echo_n 0123456789 >"conftest.in"
+  while :
+  do
+    cat "conftest.in" "conftest.in" >"conftest.tmp"
+    mv "conftest.tmp" "conftest.in"
+    cp "conftest.in" "conftest.nl"
+    $as_echo 'GREP' >> "conftest.nl"
+    "$ac_path_GREP" -e 'GREP$' -e '-(cannot match)-' < "conftest.nl" >"conftest.out" 2>/dev/null || break
+    diff "conftest.out" "conftest.nl" >/dev/null 2>&1 || break
+    as_fn_arith $ac_count + 1 && ac_count=$as_val
+    if test $ac_count -gt ${ac_path_GREP_max-0}; then
+      # Best one so far, save it but keep looking for a better one
+      ac_cv_path_GREP="$ac_path_GREP"
+      ac_path_GREP_max=$ac_count
     fi
-    ac_header= ac_cache=
-  elif test $ac_header; then
-    ac_cache=$ac_item
-  else
-    ac_header=$ac_item
+    # 10*(2^10) chars as input seems more than enough
+    test $ac_count -gt 10 && break
+  done
+  rm -f conftest.in conftest.tmp conftest.nl conftest.out;;
+esac
+
+      $ac_path_GREP_found && break 3
+    done
+  done
+  done
+IFS=$as_save_IFS
+  if test -z "$ac_cv_path_GREP"; then
+    as_fn_error $? "no acceptable grep could be found in $PATH$PATH_SEPARATOR/usr/xpg4/bin" "$LINENO" 5
   fi
+else
+  ac_cv_path_GREP=$GREP
+fi
+
+fi
+{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_path_GREP" >&5
+$as_echo "$ac_cv_path_GREP" >&6; }
+ GREP="$ac_cv_path_GREP"
+
+
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for egrep" >&5
+$as_echo_n "checking for egrep... " >&6; }
+if ${ac_cv_path_EGREP+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
+  if echo a | $GREP -E '(a|b)' >/dev/null 2>&1
+   then ac_cv_path_EGREP="$GREP -E"
+   else
+     if test -z "$EGREP"; then
+  ac_path_EGREP_found=false
+  # Loop through the user's path and test for each of PROGNAME-LIST
+  as_save_IFS=$IFS; IFS=$PATH_SEPARATOR
+for as_dir in $PATH$PATH_SEPARATOR/usr/xpg4/bin
+do
+  IFS=$as_save_IFS
+  test -z "$as_dir" && as_dir=.
+    for ac_prog in egrep; do
+    for ac_exec_ext in '' $ac_executable_extensions; do
+      ac_path_EGREP="$as_dir/$ac_prog$ac_exec_ext"
+      as_fn_executable_p "$ac_path_EGREP" || continue
+# Check for GNU ac_path_EGREP and select it if it is found.
+  # Check for GNU $ac_path_EGREP
+case `"$ac_path_EGREP" --version 2>&1` in
+*GNU*)
+  ac_cv_path_EGREP="$ac_path_EGREP" ac_path_EGREP_found=:;;
+*)
+  ac_count=0
+  $as_echo_n 0123456789 >"conftest.in"
+  while :
+  do
+    cat "conftest.in" "conftest.in" >"conftest.tmp"
+    mv "conftest.tmp" "conftest.in"
+    cp "conftest.in" "conftest.nl"
+    $as_echo 'EGREP' >> "conftest.nl"
+    "$ac_path_EGREP" 'EGREP$' < "conftest.nl" >"conftest.out" 2>/dev/null || break
+    diff "conftest.out" "conftest.nl" >/dev/null 2>&1 || break
+    as_fn_arith $ac_count + 1 && ac_count=$as_val
+    if test $ac_count -gt ${ac_path_EGREP_max-0}; then
+      # Best one so far, save it but keep looking for a better one
+      ac_cv_path_EGREP="$ac_path_EGREP"
+      ac_path_EGREP_max=$ac_count
+    fi
+    # 10*(2^10) chars as input seems more than enough
+    test $ac_count -gt 10 && break
+  done
+  rm -f conftest.in conftest.tmp conftest.nl conftest.out;;
+esac
+
+      $ac_path_EGREP_found && break 3
+    done
+  done
+  done
+IFS=$as_save_IFS
+  if test -z "$ac_cv_path_EGREP"; then
+    as_fn_error $? "no acceptable egrep could be found in $PATH$PATH_SEPARATOR/usr/xpg4/bin" "$LINENO" 5
+  fi
+else
+  ac_cv_path_EGREP=$EGREP
+fi
+
+   fi
+fi
+{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_path_EGREP" >&5
+$as_echo "$ac_cv_path_EGREP" >&6; }
+ EGREP="$ac_cv_path_EGREP"
+
+
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for ANSI C header files" >&5
+$as_echo_n "checking for ANSI C header files... " >&6; }
+if ${ac_cv_header_stdc+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
+  cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+/* end confdefs.h.  */
+#include <stdlib.h>
+#include <stdarg.h>
+#include <string.h>
+#include <float.h>
+
+int
+main ()
+{
+
+  ;
+  return 0;
+}
+_ACEOF
+if ac_fn_c_try_compile "$LINENO"; then :
+  ac_cv_header_stdc=yes
+else
+  ac_cv_header_stdc=no
+fi
+rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
+
+if test $ac_cv_header_stdc = yes; then
+  # SunOS 4.x string.h does not declare mem*, contrary to ANSI.
+  cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+/* end confdefs.h.  */
+#include <string.h>
+
+_ACEOF
+if (eval "$ac_cpp conftest.$ac_ext") 2>&5 |
+  $EGREP "memchr" >/dev/null 2>&1; then :
+
+else
+  ac_cv_header_stdc=no
+fi
+rm -f conftest*
+
+fi
+
+if test $ac_cv_header_stdc = yes; then
+  # ISC 2.0.2 stdlib.h does not declare free, contrary to ANSI.
+  cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+/* end confdefs.h.  */
+#include <stdlib.h>
+
+_ACEOF
+if (eval "$ac_cpp conftest.$ac_ext") 2>&5 |
+  $EGREP "free" >/dev/null 2>&1; then :
+
+else
+  ac_cv_header_stdc=no
+fi
+rm -f conftest*
+
+fi
+
+if test $ac_cv_header_stdc = yes; then
+  # /bin/cc in Irix-4.0.5 gets non-ANSI ctype macros unless using -ansi.
+  if test "$cross_compiling" = yes; then :
+  :
+else
+  cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+/* end confdefs.h.  */
+#include <ctype.h>
+#include <stdlib.h>
+#if ((' ' & 0x0FF) == 0x020)
+# define ISLOWER(c) ('a' <= (c) && (c) <= 'z')
+# define TOUPPER(c) (ISLOWER(c) ? 'A' + ((c) - 'a') : (c))
+#else
+# define ISLOWER(c) \
+		   (('a' <= (c) && (c) <= 'i') \
+		     || ('j' <= (c) && (c) <= 'r') \
+		     || ('s' <= (c) && (c) <= 'z'))
+# define TOUPPER(c) (ISLOWER(c) ? ((c) | 0x40) : (c))
+#endif
+
+#define XOR(e, f) (((e) && !(f)) || (!(e) && (f)))
+int
+main ()
+{
+  int i;
+  for (i = 0; i < 256; i++)
+    if (XOR (islower (i), ISLOWER (i))
+	|| toupper (i) != TOUPPER (i))
+      return 2;
+  return 0;
+}
+_ACEOF
+if ac_fn_c_try_run "$LINENO"; then :
+
+else
+  ac_cv_header_stdc=no
+fi
+rm -f core *.core core.conftest.* gmon.out bb.out conftest$ac_exeext \
+  conftest.$ac_objext conftest.beam conftest.$ac_ext
+fi
+
+fi
+fi
+{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_header_stdc" >&5
+$as_echo "$ac_cv_header_stdc" >&6; }
+if test $ac_cv_header_stdc = yes; then
+
+$as_echo "#define STDC_HEADERS 1" >>confdefs.h
+
+fi
+
+# On IRIX 5.3, sys/types and inttypes.h are conflicting.
+for ac_header in sys/types.h sys/stat.h stdlib.h string.h memory.h strings.h \
+		  inttypes.h stdint.h unistd.h
+do :
+  as_ac_Header=`$as_echo "ac_cv_header_$ac_header" | $as_tr_sh`
+ac_fn_c_check_header_compile "$LINENO" "$ac_header" "$as_ac_Header" "$ac_includes_default
+"
+if eval test \"x\$"$as_ac_Header"\" = x"yes"; then :
+  cat >>confdefs.h <<_ACEOF
+#define `$as_echo "HAVE_$ac_header" | $as_tr_cpp` 1
+_ACEOF
+
+fi
+
 done
 
 
 
-
-
-
-
-
-if test $ac_cv_header_stdlib_h = yes && test $ac_cv_header_string_h = yes
-then :
-
-printf "%s\n" "#define STDC_HEADERS 1" >>confdefs.h
-
+  ac_fn_c_check_header_mongrel "$LINENO" "minix/config.h" "ac_cv_header_minix_config_h" "$ac_includes_default"
+if test "x$ac_cv_header_minix_config_h" = xyes; then :
+  MINIX=yes
+else
+  MINIX=
 fi
 
 
+  if test "$MINIX" = yes; then
+
+$as_echo "#define _POSIX_SOURCE 1" >>confdefs.h
 
 
+$as_echo "#define _POSIX_1_SOURCE 2" >>confdefs.h
 
 
-  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking whether it is safe to define __EXTENSIONS__" >&5
-printf %s "checking whether it is safe to define __EXTENSIONS__... " >&6; }
-if test ${ac_cv_safe_to_define___extensions__+y}
-then :
-  printf %s "(cached) " >&6
-else $as_nop
+$as_echo "#define _MINIX 1" >>confdefs.h
+
+  fi
+
+
+  { $as_echo "$as_me:${as_lineno-$LINENO}: checking whether it is safe to define __EXTENSIONS__" >&5
+$as_echo_n "checking whether it is safe to define __EXTENSIONS__... " >&6; }
+if ${ac_cv_safe_to_define___extensions__+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
   cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 /* end confdefs.h.  */
 
 #         define __EXTENSIONS__ 1
           $ac_includes_default
 int
-main (void)
+main ()
 {
 
   ;
   return 0;
 }
 _ACEOF
-if ac_fn_c_try_compile "$LINENO"
-then :
+if ac_fn_c_try_compile "$LINENO"; then :
   ac_cv_safe_to_define___extensions__=yes
-else $as_nop
+else
   ac_cv_safe_to_define___extensions__=no
 fi
-rm -f core conftest.err conftest.$ac_objext conftest.beam conftest.$ac_ext
+rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
 fi
-{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $ac_cv_safe_to_define___extensions__" >&5
-printf "%s\n" "$ac_cv_safe_to_define___extensions__" >&6; }
+{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_safe_to_define___extensions__" >&5
+$as_echo "$ac_cv_safe_to_define___extensions__" >&6; }
+  test $ac_cv_safe_to_define___extensions__ = yes &&
+    $as_echo "#define __EXTENSIONS__ 1" >>confdefs.h
 
-  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking whether _XOPEN_SOURCE should be defined" >&5
-printf %s "checking whether _XOPEN_SOURCE should be defined... " >&6; }
-if test ${ac_cv_should_define__xopen_source+y}
-then :
-  printf %s "(cached) " >&6
-else $as_nop
-  ac_cv_should_define__xopen_source=no
-    if test $ac_cv_header_wchar_h = yes
-then :
-  cat confdefs.h - <<_ACEOF >conftest.$ac_ext
-/* end confdefs.h.  */
+  $as_echo "#define _ALL_SOURCE 1" >>confdefs.h
 
-          #include <wchar.h>
-          mbstate_t x;
-int
-main (void)
-{
+  $as_echo "#define _GNU_SOURCE 1" >>confdefs.h
 
-  ;
-  return 0;
-}
-_ACEOF
-if ac_fn_c_try_compile "$LINENO"
-then :
+  $as_echo "#define _POSIX_PTHREAD_SEMANTICS 1" >>confdefs.h
 
-else $as_nop
-  cat confdefs.h - <<_ACEOF >conftest.$ac_ext
-/* end confdefs.h.  */
+  $as_echo "#define _TANDEM_SOURCE 1" >>confdefs.h
 
-            #define _XOPEN_SOURCE 500
-            #include <wchar.h>
-            mbstate_t x;
-int
-main (void)
-{
-
-  ;
-  return 0;
-}
-_ACEOF
-if ac_fn_c_try_compile "$LINENO"
-then :
-  ac_cv_should_define__xopen_source=yes
-fi
-rm -f core conftest.err conftest.$ac_objext conftest.beam conftest.$ac_ext
-fi
-rm -f core conftest.err conftest.$ac_objext conftest.beam conftest.$ac_ext
-fi
-fi
-{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $ac_cv_should_define__xopen_source" >&5
-printf "%s\n" "$ac_cv_should_define__xopen_source" >&6; }
-
-  printf "%s\n" "#define _ALL_SOURCE 1" >>confdefs.h
-
-  printf "%s\n" "#define _DARWIN_C_SOURCE 1" >>confdefs.h
-
-  printf "%s\n" "#define _GNU_SOURCE 1" >>confdefs.h
-
-  printf "%s\n" "#define _HPUX_ALT_XOPEN_SOCKET_API 1" >>confdefs.h
-
-  printf "%s\n" "#define _NETBSD_SOURCE 1" >>confdefs.h
-
-  printf "%s\n" "#define _OPENBSD_SOURCE 1" >>confdefs.h
-
-  printf "%s\n" "#define _POSIX_PTHREAD_SEMANTICS 1" >>confdefs.h
-
-  printf "%s\n" "#define __STDC_WANT_IEC_60559_ATTRIBS_EXT__ 1" >>confdefs.h
-
-  printf "%s\n" "#define __STDC_WANT_IEC_60559_BFP_EXT__ 1" >>confdefs.h
-
-  printf "%s\n" "#define __STDC_WANT_IEC_60559_DFP_EXT__ 1" >>confdefs.h
-
-  printf "%s\n" "#define __STDC_WANT_IEC_60559_FUNCS_EXT__ 1" >>confdefs.h
-
-  printf "%s\n" "#define __STDC_WANT_IEC_60559_TYPES_EXT__ 1" >>confdefs.h
-
-  printf "%s\n" "#define __STDC_WANT_LIB_EXT2__ 1" >>confdefs.h
-
-  printf "%s\n" "#define __STDC_WANT_MATH_SPEC_FUNCS__ 1" >>confdefs.h
-
-  printf "%s\n" "#define _TANDEM_SOURCE 1" >>confdefs.h
-
-  if test $ac_cv_header_minix_config_h = yes
-then :
-  MINIX=yes
-    printf "%s\n" "#define _MINIX 1" >>confdefs.h
-
-    printf "%s\n" "#define _POSIX_SOURCE 1" >>confdefs.h
-
-    printf "%s\n" "#define _POSIX_1_SOURCE 2" >>confdefs.h
-
-else $as_nop
-  MINIX=
-fi
-  if test $ac_cv_safe_to_define___extensions__ = yes
-then :
-  printf "%s\n" "#define __EXTENSIONS__ 1" >>confdefs.h
-
-fi
-  if test $ac_cv_should_define__xopen_source = yes
-then :
-  printf "%s\n" "#define _XOPEN_SOURCE 500" >>confdefs.h
-
-fi
 
 if test "$ac_cv_header_minix_config_h" = "yes"; then
 
-printf "%s\n" "#define _NETBSD_SOURCE 1" >>confdefs.h
+$as_echo "#define _NETBSD_SOURCE 1" >>confdefs.h
 
 fi
 
@@ -4557,8 +4254,7 @@ else
 fi
 
 # Check whether --with-conf_file was given.
-if test ${with_conf_file+y}
-then :
+if test "${with_conf_file+set}" = set; then :
   withval=$with_conf_file; ub_conf_file="$withval"
 fi
 
@@ -4566,14 +4262,16 @@ fi
 hdr_config="`echo $ub_conf_file | sed -e 's/\\\\/\\\\\\\\/g'`"
 
 
-printf "%s\n" "#define CONFIGFILE \"$hdr_config\"" >>confdefs.h
+cat >>confdefs.h <<_ACEOF
+#define CONFIGFILE "$hdr_config"
+_ACEOF
 
 ub_conf_dir=`$as_dirname -- "$ub_conf_file" ||
 $as_expr X"$ub_conf_file" : 'X\(.*[^/]\)//*[^/][^/]*/*$' \| \
 	 X"$ub_conf_file" : 'X\(//\)[^/]' \| \
 	 X"$ub_conf_file" : 'X\(//\)$' \| \
 	 X"$ub_conf_file" : 'X\(/\)' \| . 2>/dev/null ||
-printf "%s\n" X"$ub_conf_file" |
+$as_echo X"$ub_conf_file" |
     sed '/^X\(.*[^/]\)\/\/*[^/][^/]*\/*$/{
 	    s//\1/
 	    q
@@ -4596,10 +4294,9 @@ printf "%s\n" X"$ub_conf_file" |
 # Determine run, chroot directory and pidfile locations
 
 # Check whether --with-run-dir was given.
-if test ${with_run_dir+y}
-then :
+if test "${with_run_dir+set}" = set; then :
   withval=$with_run_dir; UNBOUND_RUN_DIR="$withval"
-else $as_nop
+else
   if test $on_mingw = no; then
     UNBOUND_RUN_DIR=`dirname "$ub_conf_file"`
 else
@@ -4612,15 +4309,16 @@ fi
 hdr_run="`echo $UNBOUND_RUN_DIR | sed -e 's/\\\\/\\\\\\\\/g'`"
 
 
-printf "%s\n" "#define RUN_DIR \"$hdr_run\"" >>confdefs.h
+cat >>confdefs.h <<_ACEOF
+#define RUN_DIR "$hdr_run"
+_ACEOF
 
 
 
 # Check whether --with-chroot-dir was given.
-if test ${with_chroot_dir+y}
-then :
+if test "${with_chroot_dir+set}" = set; then :
   withval=$with_chroot_dir; UNBOUND_CHROOT_DIR="$withval"
-else $as_nop
+else
   if test $on_mingw = no; then
     UNBOUND_CHROOT_DIR="$UNBOUND_RUN_DIR"
 else
@@ -4633,29 +4331,31 @@ fi
 hdr_chroot="`echo $UNBOUND_CHROOT_DIR | sed -e 's/\\\\/\\\\\\\\/g'`"
 
 
-printf "%s\n" "#define CHROOT_DIR \"$hdr_chroot\"" >>confdefs.h
+cat >>confdefs.h <<_ACEOF
+#define CHROOT_DIR "$hdr_chroot"
+_ACEOF
 
 
 
 # Check whether --with-share-dir was given.
-if test ${with_share_dir+y}
-then :
+if test "${with_share_dir+set}" = set; then :
   withval=$with_share_dir; UNBOUND_SHARE_DIR="$withval"
-else $as_nop
+else
   UNBOUND_SHARE_DIR="$UNBOUND_RUN_DIR"
 fi
 
 
 
-printf "%s\n" "#define SHARE_DIR \"$UNBOUND_SHARE_DIR\"" >>confdefs.h
+cat >>confdefs.h <<_ACEOF
+#define SHARE_DIR "$UNBOUND_SHARE_DIR"
+_ACEOF
 
 
 
 # Check whether --with-pidfile was given.
-if test ${with_pidfile+y}
-then :
+if test "${with_pidfile+set}" = set; then :
   withval=$with_pidfile; UNBOUND_PIDFILE="$withval"
-else $as_nop
+else
   if test $on_mingw = no; then
     UNBOUND_PIDFILE="$UNBOUND_RUN_DIR/unbound.pid"
 else
@@ -4668,15 +4368,16 @@ fi
 hdr_pid="`echo $UNBOUND_PIDFILE | sed -e 's/\\\\/\\\\\\\\/g'`"
 
 
-printf "%s\n" "#define PIDFILE \"$hdr_pid\"" >>confdefs.h
+cat >>confdefs.h <<_ACEOF
+#define PIDFILE "$hdr_pid"
+_ACEOF
 
 
 
 # Check whether --with-rootkey-file was given.
-if test ${with_rootkey_file+y}
-then :
+if test "${with_rootkey_file+set}" = set; then :
   withval=$with_rootkey_file; UNBOUND_ROOTKEY_FILE="$withval"
-else $as_nop
+else
   if test $on_mingw = no; then
     UNBOUND_ROOTKEY_FILE="$UNBOUND_RUN_DIR/root.key"
 else
@@ -4689,15 +4390,16 @@ fi
 hdr_rkey="`echo $UNBOUND_ROOTKEY_FILE | sed -e 's/\\\\/\\\\\\\\/g'`"
 
 
-printf "%s\n" "#define ROOT_ANCHOR_FILE \"$hdr_rkey\"" >>confdefs.h
+cat >>confdefs.h <<_ACEOF
+#define ROOT_ANCHOR_FILE "$hdr_rkey"
+_ACEOF
 
 
 
 # Check whether --with-rootcert-file was given.
-if test ${with_rootcert_file+y}
-then :
+if test "${with_rootcert_file+set}" = set; then :
   withval=$with_rootcert_file; UNBOUND_ROOTCERT_FILE="$withval"
-else $as_nop
+else
   if test $on_mingw = no; then
     UNBOUND_ROOTCERT_FILE="$UNBOUND_RUN_DIR/icannbundle.pem"
 else
@@ -4710,44 +4412,48 @@ fi
 hdr_rpem="`echo $UNBOUND_ROOTCERT_FILE | sed -e 's/\\\\/\\\\\\\\/g'`"
 
 
-printf "%s\n" "#define ROOT_CERT_FILE \"$hdr_rpem\"" >>confdefs.h
+cat >>confdefs.h <<_ACEOF
+#define ROOT_CERT_FILE "$hdr_rpem"
+_ACEOF
 
 
 
 # Check whether --with-username was given.
-if test ${with_username+y}
-then :
+if test "${with_username+set}" = set; then :
   withval=$with_username; UNBOUND_USERNAME="$withval"
-else $as_nop
+else
   UNBOUND_USERNAME="unbound"
 fi
 
 
 
-printf "%s\n" "#define UB_USERNAME \"$UNBOUND_USERNAME\"" >>confdefs.h
+cat >>confdefs.h <<_ACEOF
+#define UB_USERNAME "$UNBOUND_USERNAME"
+_ACEOF
 
 
 
-printf "%s\n" "#define WINVER 0x0502" >>confdefs.h
+$as_echo "#define WINVER 0x0502" >>confdefs.h
 
 wnvs=`echo $PACKAGE_VERSION | sed -e 's/^[^0-9]*\([0-9][0-9]*\)[^0-9][^0-9]*\([0-9][0-9]*\)[^0-9][^0-9]*\([0-9][0-9]*\)[^0-9][^0-9]*\([0-9][0-9]*\).*$/\1,\2,\3,\4/' -e 's/^[^0-9]*\([0-9][0-9]*\)[^0-9][^0-9]*\([0-9][0-9]*\)[^0-9][^0-9]*\([0-9][0-9]*\)[^0-9]*$/\1,\2,\3,0/' `
 
 
-printf "%s\n" "#define RSRC_PACKAGE_VERSION $wnvs" >>confdefs.h
+cat >>confdefs.h <<_ACEOF
+#define RSRC_PACKAGE_VERSION $wnvs
+_ACEOF
 
 
 # Checks for typedefs, structures, and compiler characteristics.
-{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for an ANSI C-conforming const" >&5
-printf %s "checking for an ANSI C-conforming const... " >&6; }
-if test ${ac_cv_c_const+y}
-then :
-  printf %s "(cached) " >&6
-else $as_nop
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for an ANSI C-conforming const" >&5
+$as_echo_n "checking for an ANSI C-conforming const... " >&6; }
+if ${ac_cv_c_const+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
   cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 /* end confdefs.h.  */
 
 int
-main (void)
+main ()
 {
 
 #ifndef __cplusplus
@@ -4760,7 +4466,7 @@ main (void)
   /* NEC SVR4.0.2 mips cc rejects this.  */
   struct point {int x, y;};
   static struct point const zero = {0,0};
-  /* IBM XL C 1.02.0.0 rejects this.
+  /* AIX XL C 1.02.0.0 rejects this.
      It does not let you subtract one const X* pointer from another in
      an arm of an if-expression whose if-part is not a constant
      expression */
@@ -4788,7 +4494,7 @@ main (void)
     iptr p = 0;
     ++p;
   }
-  { /* IBM XL C 1.02.0.0 rejects this sort of thing, saying
+  { /* AIX XL C 1.02.0.0 rejects this sort of thing, saying
        "k.c", line 2.27: 1506-025 (S) Operand must be a modifiable lvalue. */
     struct s { int j; const int *ap[3]; } bx;
     struct s *b = &bx; b->j = 5;
@@ -4804,19 +4510,18 @@ main (void)
   return 0;
 }
 _ACEOF
-if ac_fn_c_try_compile "$LINENO"
-then :
+if ac_fn_c_try_compile "$LINENO"; then :
   ac_cv_c_const=yes
-else $as_nop
+else
   ac_cv_c_const=no
 fi
-rm -f core conftest.err conftest.$ac_objext conftest.beam conftest.$ac_ext
+rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
 fi
-{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $ac_cv_c_const" >&5
-printf "%s\n" "$ac_cv_c_const" >&6; }
+{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_c_const" >&5
+$as_echo "$ac_cv_c_const" >&6; }
 if test $ac_cv_c_const = no; then
 
-printf "%s\n" "#define const /**/" >>confdefs.h
+$as_echo "#define const /**/" >>confdefs.h
 
 fi
 
@@ -4831,13 +4536,12 @@ default_cflags=no
 if test "x$CFLAGS" = "x" ; then
 
 
-{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking whether $CC supports -g" >&5
-printf %s "checking whether $CC supports -g... " >&6; }
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking whether $CC supports -g" >&5
+$as_echo_n "checking whether $CC supports -g... " >&6; }
 cache=`echo g | sed 'y%.=/+-%___p_%'`
-if eval test \${cv_prog_cc_flag_$cache+y}
-then :
-  printf %s "(cached) " >&6
-else $as_nop
+if eval \${cv_prog_cc_flag_$cache+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
 
 echo 'void f(void){}' >conftest.c
 if test -z "`$CC $CPPFLAGS $CFLAGS -g -c conftest.c 2>&1`"; then
@@ -4850,26 +4554,25 @@ rm -f conftest conftest.o conftest.c
 fi
 
 if eval "test \"`echo '$cv_prog_cc_flag_'$cache`\" = yes"; then
-{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: yes" >&5
-printf "%s\n" "yes" >&6; }
+{ $as_echo "$as_me:${as_lineno-$LINENO}: result: yes" >&5
+$as_echo "yes" >&6; }
 :
 CFLAGS="$CFLAGS -g"
 else
-{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: no" >&5
-printf "%s\n" "no" >&6; }
+{ $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
+$as_echo "no" >&6; }
 :
 
 fi
 
 
 
-{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking whether $CC supports -O2" >&5
-printf %s "checking whether $CC supports -O2... " >&6; }
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking whether $CC supports -O2" >&5
+$as_echo_n "checking whether $CC supports -O2... " >&6; }
 cache=`echo O2 | sed 'y%.=/+-%___p_%'`
-if eval test \${cv_prog_cc_flag_$cache+y}
-then :
-  printf %s "(cached) " >&6
-else $as_nop
+if eval \${cv_prog_cc_flag_$cache+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
 
 echo 'void f(void){}' >conftest.c
 if test -z "`$CC $CPPFLAGS $CFLAGS -O2 -c conftest.c 2>&1`"; then
@@ -4882,13 +4585,13 @@ rm -f conftest conftest.o conftest.c
 fi
 
 if eval "test \"`echo '$cv_prog_cc_flag_'$cache`\" = yes"; then
-{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: yes" >&5
-printf "%s\n" "yes" >&6; }
+{ $as_echo "$as_me:${as_lineno-$LINENO}: result: yes" >&5
+$as_echo "yes" >&6; }
 :
 CFLAGS="$CFLAGS -O2"
 else
-{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: no" >&5
-printf "%s\n" "no" >&6; }
+{ $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
+$as_echo "no" >&6; }
 :
 
 fi
@@ -4903,12 +4606,11 @@ ac_compiler_gnu=$ac_cv_c_compiler_gnu
 if test -n "$ac_tool_prefix"; then
   # Extract the first word of "${ac_tool_prefix}gcc", so it can be a program name with args.
 set dummy ${ac_tool_prefix}gcc; ac_word=$2
-{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for $ac_word" >&5
-printf %s "checking for $ac_word... " >&6; }
-if test ${ac_cv_prog_CC+y}
-then :
-  printf %s "(cached) " >&6
-else $as_nop
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for $ac_word" >&5
+$as_echo_n "checking for $ac_word... " >&6; }
+if ${ac_cv_prog_CC+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
   if test -n "$CC"; then
   ac_cv_prog_CC="$CC" # Let the user override the test.
 else
@@ -4916,15 +4618,11 @@ as_save_IFS=$IFS; IFS=$PATH_SEPARATOR
 for as_dir in $PATH
 do
   IFS=$as_save_IFS
-  case $as_dir in #(((
-    '') as_dir=./ ;;
-    */) ;;
-    *) as_dir=$as_dir/ ;;
-  esac
+  test -z "$as_dir" && as_dir=.
     for ac_exec_ext in '' $ac_executable_extensions; do
-  if as_fn_executable_p "$as_dir$ac_word$ac_exec_ext"; then
+  if as_fn_executable_p "$as_dir/$ac_word$ac_exec_ext"; then
     ac_cv_prog_CC="${ac_tool_prefix}gcc"
-    printf "%s\n" "$as_me:${as_lineno-$LINENO}: found $as_dir$ac_word$ac_exec_ext" >&5
+    $as_echo "$as_me:${as_lineno-$LINENO}: found $as_dir/$ac_word$ac_exec_ext" >&5
     break 2
   fi
 done
@@ -4935,11 +4633,11 @@ fi
 fi
 CC=$ac_cv_prog_CC
 if test -n "$CC"; then
-  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $CC" >&5
-printf "%s\n" "$CC" >&6; }
+  { $as_echo "$as_me:${as_lineno-$LINENO}: result: $CC" >&5
+$as_echo "$CC" >&6; }
 else
-  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: no" >&5
-printf "%s\n" "no" >&6; }
+  { $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
+$as_echo "no" >&6; }
 fi
 
 
@@ -4948,12 +4646,11 @@ if test -z "$ac_cv_prog_CC"; then
   ac_ct_CC=$CC
   # Extract the first word of "gcc", so it can be a program name with args.
 set dummy gcc; ac_word=$2
-{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for $ac_word" >&5
-printf %s "checking for $ac_word... " >&6; }
-if test ${ac_cv_prog_ac_ct_CC+y}
-then :
-  printf %s "(cached) " >&6
-else $as_nop
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for $ac_word" >&5
+$as_echo_n "checking for $ac_word... " >&6; }
+if ${ac_cv_prog_ac_ct_CC+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
   if test -n "$ac_ct_CC"; then
   ac_cv_prog_ac_ct_CC="$ac_ct_CC" # Let the user override the test.
 else
@@ -4961,15 +4658,11 @@ as_save_IFS=$IFS; IFS=$PATH_SEPARATOR
 for as_dir in $PATH
 do
   IFS=$as_save_IFS
-  case $as_dir in #(((
-    '') as_dir=./ ;;
-    */) ;;
-    *) as_dir=$as_dir/ ;;
-  esac
+  test -z "$as_dir" && as_dir=.
     for ac_exec_ext in '' $ac_executable_extensions; do
-  if as_fn_executable_p "$as_dir$ac_word$ac_exec_ext"; then
+  if as_fn_executable_p "$as_dir/$ac_word$ac_exec_ext"; then
     ac_cv_prog_ac_ct_CC="gcc"
-    printf "%s\n" "$as_me:${as_lineno-$LINENO}: found $as_dir$ac_word$ac_exec_ext" >&5
+    $as_echo "$as_me:${as_lineno-$LINENO}: found $as_dir/$ac_word$ac_exec_ext" >&5
     break 2
   fi
 done
@@ -4980,11 +4673,11 @@ fi
 fi
 ac_ct_CC=$ac_cv_prog_ac_ct_CC
 if test -n "$ac_ct_CC"; then
-  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $ac_ct_CC" >&5
-printf "%s\n" "$ac_ct_CC" >&6; }
+  { $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_ct_CC" >&5
+$as_echo "$ac_ct_CC" >&6; }
 else
-  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: no" >&5
-printf "%s\n" "no" >&6; }
+  { $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
+$as_echo "no" >&6; }
 fi
 
   if test "x$ac_ct_CC" = x; then
@@ -4992,8 +4685,8 @@ fi
   else
     case $cross_compiling:$ac_tool_warned in
 yes:)
-{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: WARNING: using cross tools not prefixed with host triplet" >&5
-printf "%s\n" "$as_me: WARNING: using cross tools not prefixed with host triplet" >&2;}
+{ $as_echo "$as_me:${as_lineno-$LINENO}: WARNING: using cross tools not prefixed with host triplet" >&5
+$as_echo "$as_me: WARNING: using cross tools not prefixed with host triplet" >&2;}
 ac_tool_warned=yes ;;
 esac
     CC=$ac_ct_CC
@@ -5006,12 +4699,11 @@ if test -z "$CC"; then
           if test -n "$ac_tool_prefix"; then
     # Extract the first word of "${ac_tool_prefix}cc", so it can be a program name with args.
 set dummy ${ac_tool_prefix}cc; ac_word=$2
-{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for $ac_word" >&5
-printf %s "checking for $ac_word... " >&6; }
-if test ${ac_cv_prog_CC+y}
-then :
-  printf %s "(cached) " >&6
-else $as_nop
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for $ac_word" >&5
+$as_echo_n "checking for $ac_word... " >&6; }
+if ${ac_cv_prog_CC+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
   if test -n "$CC"; then
   ac_cv_prog_CC="$CC" # Let the user override the test.
 else
@@ -5019,15 +4711,11 @@ as_save_IFS=$IFS; IFS=$PATH_SEPARATOR
 for as_dir in $PATH
 do
   IFS=$as_save_IFS
-  case $as_dir in #(((
-    '') as_dir=./ ;;
-    */) ;;
-    *) as_dir=$as_dir/ ;;
-  esac
+  test -z "$as_dir" && as_dir=.
     for ac_exec_ext in '' $ac_executable_extensions; do
-  if as_fn_executable_p "$as_dir$ac_word$ac_exec_ext"; then
+  if as_fn_executable_p "$as_dir/$ac_word$ac_exec_ext"; then
     ac_cv_prog_CC="${ac_tool_prefix}cc"
-    printf "%s\n" "$as_me:${as_lineno-$LINENO}: found $as_dir$ac_word$ac_exec_ext" >&5
+    $as_echo "$as_me:${as_lineno-$LINENO}: found $as_dir/$ac_word$ac_exec_ext" >&5
     break 2
   fi
 done
@@ -5038,11 +4726,11 @@ fi
 fi
 CC=$ac_cv_prog_CC
 if test -n "$CC"; then
-  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $CC" >&5
-printf "%s\n" "$CC" >&6; }
+  { $as_echo "$as_me:${as_lineno-$LINENO}: result: $CC" >&5
+$as_echo "$CC" >&6; }
 else
-  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: no" >&5
-printf "%s\n" "no" >&6; }
+  { $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
+$as_echo "no" >&6; }
 fi
 
 
@@ -5051,12 +4739,11 @@ fi
 if test -z "$CC"; then
   # Extract the first word of "cc", so it can be a program name with args.
 set dummy cc; ac_word=$2
-{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for $ac_word" >&5
-printf %s "checking for $ac_word... " >&6; }
-if test ${ac_cv_prog_CC+y}
-then :
-  printf %s "(cached) " >&6
-else $as_nop
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for $ac_word" >&5
+$as_echo_n "checking for $ac_word... " >&6; }
+if ${ac_cv_prog_CC+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
   if test -n "$CC"; then
   ac_cv_prog_CC="$CC" # Let the user override the test.
 else
@@ -5065,19 +4752,15 @@ as_save_IFS=$IFS; IFS=$PATH_SEPARATOR
 for as_dir in $PATH
 do
   IFS=$as_save_IFS
-  case $as_dir in #(((
-    '') as_dir=./ ;;
-    */) ;;
-    *) as_dir=$as_dir/ ;;
-  esac
+  test -z "$as_dir" && as_dir=.
     for ac_exec_ext in '' $ac_executable_extensions; do
-  if as_fn_executable_p "$as_dir$ac_word$ac_exec_ext"; then
-    if test "$as_dir$ac_word$ac_exec_ext" = "/usr/ucb/cc"; then
+  if as_fn_executable_p "$as_dir/$ac_word$ac_exec_ext"; then
+    if test "$as_dir/$ac_word$ac_exec_ext" = "/usr/ucb/cc"; then
        ac_prog_rejected=yes
        continue
      fi
     ac_cv_prog_CC="cc"
-    printf "%s\n" "$as_me:${as_lineno-$LINENO}: found $as_dir$ac_word$ac_exec_ext" >&5
+    $as_echo "$as_me:${as_lineno-$LINENO}: found $as_dir/$ac_word$ac_exec_ext" >&5
     break 2
   fi
 done
@@ -5093,18 +4776,18 @@ if test $ac_prog_rejected = yes; then
     # However, it has the same basename, so the bogon will be chosen
     # first if we set CC to just the basename; use the full file name.
     shift
-    ac_cv_prog_CC="$as_dir$ac_word${1+' '}$@"
+    ac_cv_prog_CC="$as_dir/$ac_word${1+' '}$@"
   fi
 fi
 fi
 fi
 CC=$ac_cv_prog_CC
 if test -n "$CC"; then
-  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $CC" >&5
-printf "%s\n" "$CC" >&6; }
+  { $as_echo "$as_me:${as_lineno-$LINENO}: result: $CC" >&5
+$as_echo "$CC" >&6; }
 else
-  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: no" >&5
-printf "%s\n" "no" >&6; }
+  { $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
+$as_echo "no" >&6; }
 fi
 
 
@@ -5115,12 +4798,11 @@ if test -z "$CC"; then
   do
     # Extract the first word of "$ac_tool_prefix$ac_prog", so it can be a program name with args.
 set dummy $ac_tool_prefix$ac_prog; ac_word=$2
-{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for $ac_word" >&5
-printf %s "checking for $ac_word... " >&6; }
-if test ${ac_cv_prog_CC+y}
-then :
-  printf %s "(cached) " >&6
-else $as_nop
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for $ac_word" >&5
+$as_echo_n "checking for $ac_word... " >&6; }
+if ${ac_cv_prog_CC+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
   if test -n "$CC"; then
   ac_cv_prog_CC="$CC" # Let the user override the test.
 else
@@ -5128,15 +4810,11 @@ as_save_IFS=$IFS; IFS=$PATH_SEPARATOR
 for as_dir in $PATH
 do
   IFS=$as_save_IFS
-  case $as_dir in #(((
-    '') as_dir=./ ;;
-    */) ;;
-    *) as_dir=$as_dir/ ;;
-  esac
+  test -z "$as_dir" && as_dir=.
     for ac_exec_ext in '' $ac_executable_extensions; do
-  if as_fn_executable_p "$as_dir$ac_word$ac_exec_ext"; then
+  if as_fn_executable_p "$as_dir/$ac_word$ac_exec_ext"; then
     ac_cv_prog_CC="$ac_tool_prefix$ac_prog"
-    printf "%s\n" "$as_me:${as_lineno-$LINENO}: found $as_dir$ac_word$ac_exec_ext" >&5
+    $as_echo "$as_me:${as_lineno-$LINENO}: found $as_dir/$ac_word$ac_exec_ext" >&5
     break 2
   fi
 done
@@ -5147,11 +4825,11 @@ fi
 fi
 CC=$ac_cv_prog_CC
 if test -n "$CC"; then
-  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $CC" >&5
-printf "%s\n" "$CC" >&6; }
+  { $as_echo "$as_me:${as_lineno-$LINENO}: result: $CC" >&5
+$as_echo "$CC" >&6; }
 else
-  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: no" >&5
-printf "%s\n" "no" >&6; }
+  { $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
+$as_echo "no" >&6; }
 fi
 
 
@@ -5164,12 +4842,11 @@ if test -z "$CC"; then
 do
   # Extract the first word of "$ac_prog", so it can be a program name with args.
 set dummy $ac_prog; ac_word=$2
-{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for $ac_word" >&5
-printf %s "checking for $ac_word... " >&6; }
-if test ${ac_cv_prog_ac_ct_CC+y}
-then :
-  printf %s "(cached) " >&6
-else $as_nop
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for $ac_word" >&5
+$as_echo_n "checking for $ac_word... " >&6; }
+if ${ac_cv_prog_ac_ct_CC+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
   if test -n "$ac_ct_CC"; then
   ac_cv_prog_ac_ct_CC="$ac_ct_CC" # Let the user override the test.
 else
@@ -5177,15 +4854,11 @@ as_save_IFS=$IFS; IFS=$PATH_SEPARATOR
 for as_dir in $PATH
 do
   IFS=$as_save_IFS
-  case $as_dir in #(((
-    '') as_dir=./ ;;
-    */) ;;
-    *) as_dir=$as_dir/ ;;
-  esac
+  test -z "$as_dir" && as_dir=.
     for ac_exec_ext in '' $ac_executable_extensions; do
-  if as_fn_executable_p "$as_dir$ac_word$ac_exec_ext"; then
+  if as_fn_executable_p "$as_dir/$ac_word$ac_exec_ext"; then
     ac_cv_prog_ac_ct_CC="$ac_prog"
-    printf "%s\n" "$as_me:${as_lineno-$LINENO}: found $as_dir$ac_word$ac_exec_ext" >&5
+    $as_echo "$as_me:${as_lineno-$LINENO}: found $as_dir/$ac_word$ac_exec_ext" >&5
     break 2
   fi
 done
@@ -5196,11 +4869,11 @@ fi
 fi
 ac_ct_CC=$ac_cv_prog_ac_ct_CC
 if test -n "$ac_ct_CC"; then
-  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $ac_ct_CC" >&5
-printf "%s\n" "$ac_ct_CC" >&6; }
+  { $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_ct_CC" >&5
+$as_echo "$ac_ct_CC" >&6; }
 else
-  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: no" >&5
-printf "%s\n" "no" >&6; }
+  { $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
+$as_echo "no" >&6; }
 fi
 
 
@@ -5212,8 +4885,8 @@ done
   else
     case $cross_compiling:$ac_tool_warned in
 yes:)
-{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: WARNING: using cross tools not prefixed with host triplet" >&5
-printf "%s\n" "$as_me: WARNING: using cross tools not prefixed with host triplet" >&2;}
+{ $as_echo "$as_me:${as_lineno-$LINENO}: WARNING: using cross tools not prefixed with host triplet" >&5
+$as_echo "$as_me: WARNING: using cross tools not prefixed with host triplet" >&2;}
 ac_tool_warned=yes ;;
 esac
     CC=$ac_ct_CC
@@ -5221,129 +4894,25 @@ esac
 fi
 
 fi
-if test -z "$CC"; then
-  if test -n "$ac_tool_prefix"; then
-  # Extract the first word of "${ac_tool_prefix}clang", so it can be a program name with args.
-set dummy ${ac_tool_prefix}clang; ac_word=$2
-{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for $ac_word" >&5
-printf %s "checking for $ac_word... " >&6; }
-if test ${ac_cv_prog_CC+y}
-then :
-  printf %s "(cached) " >&6
-else $as_nop
-  if test -n "$CC"; then
-  ac_cv_prog_CC="$CC" # Let the user override the test.
-else
-as_save_IFS=$IFS; IFS=$PATH_SEPARATOR
-for as_dir in $PATH
-do
-  IFS=$as_save_IFS
-  case $as_dir in #(((
-    '') as_dir=./ ;;
-    */) ;;
-    *) as_dir=$as_dir/ ;;
-  esac
-    for ac_exec_ext in '' $ac_executable_extensions; do
-  if as_fn_executable_p "$as_dir$ac_word$ac_exec_ext"; then
-    ac_cv_prog_CC="${ac_tool_prefix}clang"
-    printf "%s\n" "$as_me:${as_lineno-$LINENO}: found $as_dir$ac_word$ac_exec_ext" >&5
-    break 2
-  fi
-done
-  done
-IFS=$as_save_IFS
-
-fi
-fi
-CC=$ac_cv_prog_CC
-if test -n "$CC"; then
-  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $CC" >&5
-printf "%s\n" "$CC" >&6; }
-else
-  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: no" >&5
-printf "%s\n" "no" >&6; }
-fi
 
 
-fi
-if test -z "$ac_cv_prog_CC"; then
-  ac_ct_CC=$CC
-  # Extract the first word of "clang", so it can be a program name with args.
-set dummy clang; ac_word=$2
-{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for $ac_word" >&5
-printf %s "checking for $ac_word... " >&6; }
-if test ${ac_cv_prog_ac_ct_CC+y}
-then :
-  printf %s "(cached) " >&6
-else $as_nop
-  if test -n "$ac_ct_CC"; then
-  ac_cv_prog_ac_ct_CC="$ac_ct_CC" # Let the user override the test.
-else
-as_save_IFS=$IFS; IFS=$PATH_SEPARATOR
-for as_dir in $PATH
-do
-  IFS=$as_save_IFS
-  case $as_dir in #(((
-    '') as_dir=./ ;;
-    */) ;;
-    *) as_dir=$as_dir/ ;;
-  esac
-    for ac_exec_ext in '' $ac_executable_extensions; do
-  if as_fn_executable_p "$as_dir$ac_word$ac_exec_ext"; then
-    ac_cv_prog_ac_ct_CC="clang"
-    printf "%s\n" "$as_me:${as_lineno-$LINENO}: found $as_dir$ac_word$ac_exec_ext" >&5
-    break 2
-  fi
-done
-  done
-IFS=$as_save_IFS
-
-fi
-fi
-ac_ct_CC=$ac_cv_prog_ac_ct_CC
-if test -n "$ac_ct_CC"; then
-  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $ac_ct_CC" >&5
-printf "%s\n" "$ac_ct_CC" >&6; }
-else
-  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: no" >&5
-printf "%s\n" "no" >&6; }
-fi
-
-  if test "x$ac_ct_CC" = x; then
-    CC=""
-  else
-    case $cross_compiling:$ac_tool_warned in
-yes:)
-{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: WARNING: using cross tools not prefixed with host triplet" >&5
-printf "%s\n" "$as_me: WARNING: using cross tools not prefixed with host triplet" >&2;}
-ac_tool_warned=yes ;;
-esac
-    CC=$ac_ct_CC
-  fi
-else
-  CC="$ac_cv_prog_CC"
-fi
-
-fi
-
-
-test -z "$CC" && { { printf "%s\n" "$as_me:${as_lineno-$LINENO}: error: in \`$ac_pwd':" >&5
-printf "%s\n" "$as_me: error: in \`$ac_pwd':" >&2;}
+test -z "$CC" && { { $as_echo "$as_me:${as_lineno-$LINENO}: error: in \`$ac_pwd':" >&5
+$as_echo "$as_me: error: in \`$ac_pwd':" >&2;}
 as_fn_error $? "no acceptable C compiler found in \$PATH
 See \`config.log' for more details" "$LINENO" 5; }
 
 # Provide some information about the compiler.
-printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for C compiler version" >&5
+$as_echo "$as_me:${as_lineno-$LINENO}: checking for C compiler version" >&5
 set X $ac_compile
 ac_compiler=$2
-for ac_option in --version -v -V -qversion -version; do
+for ac_option in --version -v -V -qversion; do
   { { ac_try="$ac_compiler $ac_option >&5"
 case "(($ac_try" in
   *\"* | *\`* | *\\*) ac_try_echo=\$ac_try;;
   *) ac_try_echo=$ac_try;;
 esac
 eval ac_try_echo="\"\$as_me:${as_lineno-$LINENO}: $ac_try_echo\""
-printf "%s\n" "$ac_try_echo"; } >&5
+$as_echo "$ac_try_echo"; } >&5
   (eval "$ac_compiler $ac_option >&5") 2>conftest.err
   ac_status=$?
   if test -s conftest.err; then
@@ -5353,21 +4922,20 @@ printf "%s\n" "$ac_try_echo"; } >&5
     cat conftest.er1 >&5
   fi
   rm -f conftest.er1 conftest.err
-  printf "%s\n" "$as_me:${as_lineno-$LINENO}: \$? = $ac_status" >&5
+  $as_echo "$as_me:${as_lineno-$LINENO}: \$? = $ac_status" >&5
   test $ac_status = 0; }
 done
 
-{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking whether the compiler supports GNU C" >&5
-printf %s "checking whether the compiler supports GNU C... " >&6; }
-if test ${ac_cv_c_compiler_gnu+y}
-then :
-  printf %s "(cached) " >&6
-else $as_nop
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking whether we are using the GNU C compiler" >&5
+$as_echo_n "checking whether we are using the GNU C compiler... " >&6; }
+if ${ac_cv_c_compiler_gnu+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
   cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 /* end confdefs.h.  */
 
 int
-main (void)
+main ()
 {
 #ifndef __GNUC__
        choke me
@@ -5377,33 +4945,29 @@ main (void)
   return 0;
 }
 _ACEOF
-if ac_fn_c_try_compile "$LINENO"
-then :
+if ac_fn_c_try_compile "$LINENO"; then :
   ac_compiler_gnu=yes
-else $as_nop
+else
   ac_compiler_gnu=no
 fi
-rm -f core conftest.err conftest.$ac_objext conftest.beam conftest.$ac_ext
+rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
 ac_cv_c_compiler_gnu=$ac_compiler_gnu
 
 fi
-{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $ac_cv_c_compiler_gnu" >&5
-printf "%s\n" "$ac_cv_c_compiler_gnu" >&6; }
-ac_compiler_gnu=$ac_cv_c_compiler_gnu
-
+{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_c_compiler_gnu" >&5
+$as_echo "$ac_cv_c_compiler_gnu" >&6; }
 if test $ac_compiler_gnu = yes; then
   GCC=yes
 else
   GCC=
 fi
-ac_test_CFLAGS=${CFLAGS+y}
+ac_test_CFLAGS=${CFLAGS+set}
 ac_save_CFLAGS=$CFLAGS
-{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking whether $CC accepts -g" >&5
-printf %s "checking whether $CC accepts -g... " >&6; }
-if test ${ac_cv_prog_cc_g+y}
-then :
-  printf %s "(cached) " >&6
-else $as_nop
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking whether $CC accepts -g" >&5
+$as_echo_n "checking whether $CC accepts -g... " >&6; }
+if ${ac_cv_prog_cc_g+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
   ac_save_c_werror_flag=$ac_c_werror_flag
    ac_c_werror_flag=yes
    ac_cv_prog_cc_g=no
@@ -5412,60 +4976,57 @@ else $as_nop
 /* end confdefs.h.  */
 
 int
-main (void)
+main ()
 {
 
   ;
   return 0;
 }
 _ACEOF
-if ac_fn_c_try_compile "$LINENO"
-then :
+if ac_fn_c_try_compile "$LINENO"; then :
   ac_cv_prog_cc_g=yes
-else $as_nop
+else
   CFLAGS=""
       cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 /* end confdefs.h.  */
 
 int
-main (void)
+main ()
 {
 
   ;
   return 0;
 }
 _ACEOF
-if ac_fn_c_try_compile "$LINENO"
-then :
+if ac_fn_c_try_compile "$LINENO"; then :
 
-else $as_nop
+else
   ac_c_werror_flag=$ac_save_c_werror_flag
 	 CFLAGS="-g"
 	 cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 /* end confdefs.h.  */
 
 int
-main (void)
+main ()
 {
 
   ;
   return 0;
 }
 _ACEOF
-if ac_fn_c_try_compile "$LINENO"
-then :
+if ac_fn_c_try_compile "$LINENO"; then :
   ac_cv_prog_cc_g=yes
 fi
-rm -f core conftest.err conftest.$ac_objext conftest.beam conftest.$ac_ext
+rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
 fi
-rm -f core conftest.err conftest.$ac_objext conftest.beam conftest.$ac_ext
+rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
 fi
-rm -f core conftest.err conftest.$ac_objext conftest.beam conftest.$ac_ext
+rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
    ac_c_werror_flag=$ac_save_c_werror_flag
 fi
-{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $ac_cv_prog_cc_g" >&5
-printf "%s\n" "$ac_cv_prog_cc_g" >&6; }
-if test $ac_test_CFLAGS; then
+{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_prog_cc_g" >&5
+$as_echo "$ac_cv_prog_cc_g" >&6; }
+if test "$ac_test_CFLAGS" = set; then
   CFLAGS=$ac_save_CFLAGS
 elif test $ac_cv_prog_cc_g = yes; then
   if test "$GCC" = yes; then
@@ -5480,144 +5041,94 @@ else
     CFLAGS=
   fi
 fi
-ac_prog_cc_stdc=no
-if test x$ac_prog_cc_stdc = xno
-then :
-  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for $CC option to enable C11 features" >&5
-printf %s "checking for $CC option to enable C11 features... " >&6; }
-if test ${ac_cv_prog_cc_c11+y}
-then :
-  printf %s "(cached) " >&6
-else $as_nop
-  ac_cv_prog_cc_c11=no
-ac_save_CC=$CC
-cat confdefs.h - <<_ACEOF >conftest.$ac_ext
-/* end confdefs.h.  */
-$ac_c_conftest_c11_program
-_ACEOF
-for ac_arg in '' -std=gnu11
-do
-  CC="$ac_save_CC $ac_arg"
-  if ac_fn_c_try_compile "$LINENO"
-then :
-  ac_cv_prog_cc_c11=$ac_arg
-fi
-rm -f core conftest.err conftest.$ac_objext conftest.beam
-  test "x$ac_cv_prog_cc_c11" != "xno" && break
-done
-rm -f conftest.$ac_ext
-CC=$ac_save_CC
-fi
-
-if test "x$ac_cv_prog_cc_c11" = xno
-then :
-  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: unsupported" >&5
-printf "%s\n" "unsupported" >&6; }
-else $as_nop
-  if test "x$ac_cv_prog_cc_c11" = x
-then :
-  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: none needed" >&5
-printf "%s\n" "none needed" >&6; }
-else $as_nop
-  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $ac_cv_prog_cc_c11" >&5
-printf "%s\n" "$ac_cv_prog_cc_c11" >&6; }
-     CC="$CC $ac_cv_prog_cc_c11"
-fi
-  ac_cv_prog_cc_stdc=$ac_cv_prog_cc_c11
-  ac_prog_cc_stdc=c11
-fi
-fi
-if test x$ac_prog_cc_stdc = xno
-then :
-  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for $CC option to enable C99 features" >&5
-printf %s "checking for $CC option to enable C99 features... " >&6; }
-if test ${ac_cv_prog_cc_c99+y}
-then :
-  printf %s "(cached) " >&6
-else $as_nop
-  ac_cv_prog_cc_c99=no
-ac_save_CC=$CC
-cat confdefs.h - <<_ACEOF >conftest.$ac_ext
-/* end confdefs.h.  */
-$ac_c_conftest_c99_program
-_ACEOF
-for ac_arg in '' -std=gnu99 -std=c99 -c99 -qlanglvl=extc1x -qlanglvl=extc99 -AC99 -D_STDC_C99=
-do
-  CC="$ac_save_CC $ac_arg"
-  if ac_fn_c_try_compile "$LINENO"
-then :
-  ac_cv_prog_cc_c99=$ac_arg
-fi
-rm -f core conftest.err conftest.$ac_objext conftest.beam
-  test "x$ac_cv_prog_cc_c99" != "xno" && break
-done
-rm -f conftest.$ac_ext
-CC=$ac_save_CC
-fi
-
-if test "x$ac_cv_prog_cc_c99" = xno
-then :
-  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: unsupported" >&5
-printf "%s\n" "unsupported" >&6; }
-else $as_nop
-  if test "x$ac_cv_prog_cc_c99" = x
-then :
-  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: none needed" >&5
-printf "%s\n" "none needed" >&6; }
-else $as_nop
-  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $ac_cv_prog_cc_c99" >&5
-printf "%s\n" "$ac_cv_prog_cc_c99" >&6; }
-     CC="$CC $ac_cv_prog_cc_c99"
-fi
-  ac_cv_prog_cc_stdc=$ac_cv_prog_cc_c99
-  ac_prog_cc_stdc=c99
-fi
-fi
-if test x$ac_prog_cc_stdc = xno
-then :
-  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for $CC option to enable C89 features" >&5
-printf %s "checking for $CC option to enable C89 features... " >&6; }
-if test ${ac_cv_prog_cc_c89+y}
-then :
-  printf %s "(cached) " >&6
-else $as_nop
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for $CC option to accept ISO C89" >&5
+$as_echo_n "checking for $CC option to accept ISO C89... " >&6; }
+if ${ac_cv_prog_cc_c89+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
   ac_cv_prog_cc_c89=no
 ac_save_CC=$CC
 cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 /* end confdefs.h.  */
-$ac_c_conftest_c89_program
+#include <stdarg.h>
+#include <stdio.h>
+struct stat;
+/* Most of the following tests are stolen from RCS 5.7's src/conf.sh.  */
+struct buf { int x; };
+FILE * (*rcsopen) (struct buf *, struct stat *, int);
+static char *e (p, i)
+     char **p;
+     int i;
+{
+  return p[i];
+}
+static char *f (char * (*g) (char **, int), char **p, ...)
+{
+  char *s;
+  va_list v;
+  va_start (v,p);
+  s = g (p, va_arg (v,int));
+  va_end (v);
+  return s;
+}
+
+/* OSF 4.0 Compaq cc is some sort of almost-ANSI by default.  It has
+   function prototypes and stuff, but not '\xHH' hex character constants.
+   These don't provoke an error unfortunately, instead are silently treated
+   as 'x'.  The following induces an error, until -std is added to get
+   proper ANSI mode.  Curiously '\x00'!='x' always comes out true, for an
+   array size at least.  It's necessary to write '\x00'==0 to get something
+   that's true only with -std.  */
+int osf4_cc_array ['\x00' == 0 ? 1 : -1];
+
+/* IBM C 6 for AIX is almost-ANSI by default, but it replaces macro parameters
+   inside strings and character constants.  */
+#define FOO(x) 'x'
+int xlc6_cc_array[FOO(a) == 'x' ? 1 : -1];
+
+int test (int i, double x);
+struct s1 {int (*f) (int a);};
+struct s2 {int (*f) (double a);};
+int pairnames (int, char **, FILE *(*)(struct buf *, struct stat *, int), int, int);
+int argc;
+char **argv;
+int
+main ()
+{
+return f (e, argv, 0) != argv[0]  ||  f (e, argv, 1) != argv[1];
+  ;
+  return 0;
+}
 _ACEOF
-for ac_arg in '' -qlanglvl=extc89 -qlanglvl=ansi -std -Ae "-Aa -D_HPUX_SOURCE" "-Xc -D__EXTENSIONS__"
+for ac_arg in '' -qlanglvl=extc89 -qlanglvl=ansi -std \
+	-Ae "-Aa -D_HPUX_SOURCE" "-Xc -D__EXTENSIONS__"
 do
   CC="$ac_save_CC $ac_arg"
-  if ac_fn_c_try_compile "$LINENO"
-then :
+  if ac_fn_c_try_compile "$LINENO"; then :
   ac_cv_prog_cc_c89=$ac_arg
 fi
-rm -f core conftest.err conftest.$ac_objext conftest.beam
+rm -f core conftest.err conftest.$ac_objext
   test "x$ac_cv_prog_cc_c89" != "xno" && break
 done
 rm -f conftest.$ac_ext
 CC=$ac_save_CC
-fi
 
-if test "x$ac_cv_prog_cc_c89" = xno
-then :
-  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: unsupported" >&5
-printf "%s\n" "unsupported" >&6; }
-else $as_nop
-  if test "x$ac_cv_prog_cc_c89" = x
-then :
-  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: none needed" >&5
-printf "%s\n" "none needed" >&6; }
-else $as_nop
-  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $ac_cv_prog_cc_c89" >&5
-printf "%s\n" "$ac_cv_prog_cc_c89" >&6; }
-     CC="$CC $ac_cv_prog_cc_c89"
 fi
-  ac_cv_prog_cc_stdc=$ac_cv_prog_cc_c89
-  ac_prog_cc_stdc=c89
-fi
+# AC_CACHE_VAL
+case "x$ac_cv_prog_cc_c89" in
+  x)
+    { $as_echo "$as_me:${as_lineno-$LINENO}: result: none needed" >&5
+$as_echo "none needed" >&6; } ;;
+  xno)
+    { $as_echo "$as_me:${as_lineno-$LINENO}: result: unsupported" >&5
+$as_echo "unsupported" >&6; } ;;
+  *)
+    CC="$CC $ac_cv_prog_cc_c89"
+    { $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_prog_cc_c89" >&5
+$as_echo "$ac_cv_prog_cc_c89" >&6; } ;;
+esac
+if test "x$ac_cv_prog_cc_c89" != xno; then :
+
 fi
 
 ac_ext=c
@@ -5627,8 +5138,8 @@ ac_link='$CC -o conftest$ac_exeext $CFLAGS $CPPFLAGS $LDFLAGS conftest.$ac_ext $
 ac_compiler_gnu=$ac_cv_c_compiler_gnu
 
 
-{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking $CC dependency flag" >&5
-printf %s "checking $CC dependency flag... " >&6; }
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking $CC dependency flag" >&5
+$as_echo_n "checking $CC dependency flag... " >&6; }
 echo 'void f(){}' >conftest.c
 if test "`$CC -MM conftest.c 2>&1`" = "conftest.o: conftest.c"; then
 	DEPFLAG="-MM"
@@ -5639,21 +5150,20 @@ else
 	DEPFLAG="-MM"  # dunno do something
   fi
 fi
-{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $DEPFLAG" >&5
-printf "%s\n" "$DEPFLAG" >&6; }
+{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $DEPFLAG" >&5
+$as_echo "$DEPFLAG" >&6; }
 rm -f conftest.c
 
 
 
 
 
-{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking whether $CC supports -Werror" >&5
-printf %s "checking whether $CC supports -Werror... " >&6; }
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking whether $CC supports -Werror" >&5
+$as_echo_n "checking whether $CC supports -Werror... " >&6; }
 cache=`echo Werror | sed 'y%.=/+-%___p_%'`
-if eval test \${cv_prog_cc_flag_$cache+y}
-then :
-  printf %s "(cached) " >&6
-else $as_nop
+if eval \${cv_prog_cc_flag_$cache+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
 
 echo 'void f(void){}' >conftest.c
 if test -z "`$CC $CPPFLAGS $CFLAGS -Werror -c conftest.c 2>&1`"; then
@@ -5666,26 +5176,25 @@ rm -f conftest conftest.o conftest.c
 fi
 
 if eval "test \"`echo '$cv_prog_cc_flag_'$cache`\" = yes"; then
-{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: yes" >&5
-printf "%s\n" "yes" >&6; }
+{ $as_echo "$as_me:${as_lineno-$LINENO}: result: yes" >&5
+$as_echo "yes" >&6; }
 :
 ERRFLAG="-Werror"
 else
-{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: no" >&5
-printf "%s\n" "no" >&6; }
+{ $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
+$as_echo "no" >&6; }
 :
 ERRFLAG="-errwarn"
 fi
 
 
 
-{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking whether $CC supports -Wall" >&5
-printf %s "checking whether $CC supports -Wall... " >&6; }
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking whether $CC supports -Wall" >&5
+$as_echo_n "checking whether $CC supports -Wall... " >&6; }
 cache=`echo Wall | sed 'y%.=/+-%___p_%'`
-if eval test \${cv_prog_cc_flag_$cache+y}
-then :
-  printf %s "(cached) " >&6
-else $as_nop
+if eval \${cv_prog_cc_flag_$cache+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
 
 echo 'void f(void){}' >conftest.c
 if test -z "`$CC $CPPFLAGS $CFLAGS -Wall -c conftest.c 2>&1`"; then
@@ -5698,13 +5207,13 @@ rm -f conftest conftest.o conftest.c
 fi
 
 if eval "test \"`echo '$cv_prog_cc_flag_'$cache`\" = yes"; then
-{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: yes" >&5
-printf "%s\n" "yes" >&6; }
+{ $as_echo "$as_me:${as_lineno-$LINENO}: result: yes" >&5
+$as_echo "yes" >&6; }
 :
 ERRFLAG="$ERRFLAG -Wall"
 else
-{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: no" >&5
-printf "%s\n" "no" >&6; }
+{ $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
+$as_echo "no" >&6; }
 :
 ERRFLAG="$ERRFLAG -errfmt"
 fi
@@ -5713,13 +5222,12 @@ fi
 
 
 
-{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking whether $CC supports -std=c99" >&5
-printf %s "checking whether $CC supports -std=c99... " >&6; }
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking whether $CC supports -std=c99" >&5
+$as_echo_n "checking whether $CC supports -std=c99... " >&6; }
 cache=`echo std=c99 | sed 'y%.=/+-%___p_%'`
-if eval test \${cv_prog_cc_flag_$cache+y}
-then :
-  printf %s "(cached) " >&6
-else $as_nop
+if eval \${cv_prog_cc_flag_$cache+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
 
 echo 'void f(void){}' >conftest.c
 if test -z "`$CC $CPPFLAGS $CFLAGS -std=c99 -c conftest.c 2>&1`"; then
@@ -5732,26 +5240,25 @@ rm -f conftest conftest.o conftest.c
 fi
 
 if eval "test \"`echo '$cv_prog_cc_flag_'$cache`\" = yes"; then
-{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: yes" >&5
-printf "%s\n" "yes" >&6; }
+{ $as_echo "$as_me:${as_lineno-$LINENO}: result: yes" >&5
+$as_echo "yes" >&6; }
 :
 C99FLAG="-std=c99"
 else
-{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: no" >&5
-printf "%s\n" "no" >&6; }
+{ $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
+$as_echo "no" >&6; }
 :
 
 fi
 
 
 
-{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking whether $CC supports -xc99" >&5
-printf %s "checking whether $CC supports -xc99... " >&6; }
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking whether $CC supports -xc99" >&5
+$as_echo_n "checking whether $CC supports -xc99... " >&6; }
 cache=`echo xc99 | sed 'y%.=/+-%___p_%'`
-if eval test \${cv_prog_cc_flag_$cache+y}
-then :
-  printf %s "(cached) " >&6
-else $as_nop
+if eval \${cv_prog_cc_flag_$cache+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
 
 echo 'void f(void){}' >conftest.c
 if test -z "`$CC $CPPFLAGS $CFLAGS -xc99 -c conftest.c 2>&1`"; then
@@ -5764,44 +5271,42 @@ rm -f conftest conftest.o conftest.c
 fi
 
 if eval "test \"`echo '$cv_prog_cc_flag_'$cache`\" = yes"; then
-{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: yes" >&5
-printf "%s\n" "yes" >&6; }
+{ $as_echo "$as_me:${as_lineno-$LINENO}: result: yes" >&5
+$as_echo "yes" >&6; }
 :
 C99FLAG="-xc99"
 else
-{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: no" >&5
-printf "%s\n" "no" >&6; }
+{ $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
+$as_echo "no" >&6; }
 :
 
 fi
 
 
-ac_fn_c_check_header_compile "$LINENO" "getopt.h" "ac_cv_header_getopt_h" "$ac_includes_default
+for ac_header in getopt.h time.h
+do :
+  as_ac_Header=`$as_echo "ac_cv_header_$ac_header" | $as_tr_sh`
+ac_fn_c_check_header_compile "$LINENO" "$ac_header" "$as_ac_Header" "$ac_includes_default
 "
-if test "x$ac_cv_header_getopt_h" = xyes
-then :
-  printf "%s\n" "#define HAVE_GETOPT_H 1" >>confdefs.h
-
-fi
-ac_fn_c_check_header_compile "$LINENO" "time.h" "ac_cv_header_time_h" "$ac_includes_default
-"
-if test "x$ac_cv_header_time_h" = xyes
-then :
-  printf "%s\n" "#define HAVE_TIME_H 1" >>confdefs.h
+if eval test \"x\$"$as_ac_Header"\" = x"yes"; then :
+  cat >>confdefs.h <<_ACEOF
+#define `$as_echo "HAVE_$ac_header" | $as_tr_cpp` 1
+_ACEOF
 
 fi
 
+done
 
 
 
 
-{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking whether we need $C99FLAG -D__EXTENSIONS__ -D_BSD_SOURCE -D_DEFAULT_SOURCE -D_POSIX_C_SOURCE=200112 -D_XOPEN_SOURCE=600 -D_XOPEN_SOURCE_EXTENDED=1 -D_ALL_SOURCE as a flag for $CC" >&5
-printf %s "checking whether we need $C99FLAG -D__EXTENSIONS__ -D_BSD_SOURCE -D_DEFAULT_SOURCE -D_POSIX_C_SOURCE=200112 -D_XOPEN_SOURCE=600 -D_XOPEN_SOURCE_EXTENDED=1 -D_ALL_SOURCE as a flag for $CC... " >&6; }
-cache=`printf "%s\n" "$C99FLAG -D__EXTENSIONS__ -D_BSD_SOURCE -D_DEFAULT_SOURCE -D_POSIX_C_SOURCE=200112 -D_XOPEN_SOURCE=600 -D_XOPEN_SOURCE_EXTENDED=1 -D_ALL_SOURCE" | $as_tr_sh`
-if eval test \${cv_prog_cc_flag_needed_$cache+y}
-then :
-  printf %s "(cached) " >&6
-else $as_nop
+
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking whether we need $C99FLAG -D__EXTENSIONS__ -D_BSD_SOURCE -D_DEFAULT_SOURCE -D_POSIX_C_SOURCE=200112 -D_XOPEN_SOURCE=600 -D_XOPEN_SOURCE_EXTENDED=1 -D_ALL_SOURCE as a flag for $CC" >&5
+$as_echo_n "checking whether we need $C99FLAG -D__EXTENSIONS__ -D_BSD_SOURCE -D_DEFAULT_SOURCE -D_POSIX_C_SOURCE=200112 -D_XOPEN_SOURCE=600 -D_XOPEN_SOURCE_EXTENDED=1 -D_ALL_SOURCE as a flag for $CC... " >&6; }
+cache=`$as_echo "$C99FLAG -D__EXTENSIONS__ -D_BSD_SOURCE -D_DEFAULT_SOURCE -D_POSIX_C_SOURCE=200112 -D_XOPEN_SOURCE=600 -D_XOPEN_SOURCE_EXTENDED=1 -D_ALL_SOURCE" | $as_tr_sh`
+if eval \${cv_prog_cc_flag_needed_$cache+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
 
 echo '
 #include "confdefs.h"
@@ -5860,14 +5365,14 @@ rm -f conftest conftest.c conftest.o
 fi
 
 if eval "test \"`echo '$cv_prog_cc_flag_needed_'$cache`\" = yes"; then
-{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: yes" >&5
-printf "%s\n" "yes" >&6; }
+{ $as_echo "$as_me:${as_lineno-$LINENO}: result: yes" >&5
+$as_echo "yes" >&6; }
 :
 CFLAGS="$CFLAGS $C99FLAG -D__EXTENSIONS__ -D_BSD_SOURCE -D_DEFAULT_SOURCE -D_POSIX_C_SOURCE=200112 -D_XOPEN_SOURCE=600 -D_XOPEN_SOURCE_EXTENDED=1 -D_ALL_SOURCE"
 else
 if eval "test \"`echo '$cv_prog_cc_flag_needed_'$cache`\" = no"; then
-{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: no" >&5
-printf "%s\n" "no" >&6; }
+{ $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
+$as_echo "no" >&6; }
 #echo 'Test with flag is no!'
 #cat conftest.c
 #echo "$CC $CPPFLAGS $CFLAGS $C99FLAG -D__EXTENSIONS__ -D_BSD_SOURCE -D_DEFAULT_SOURCE -D_POSIX_C_SOURCE=200112 -D_XOPEN_SOURCE=600 -D_XOPEN_SOURCE_EXTENDED=1 -D_ALL_SOURCE $ERRFLAG -c conftest.c 2>&1"
@@ -5876,8 +5381,8 @@ printf "%s\n" "no" >&6; }
 :
 
 else
-{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: failed" >&5
-printf "%s\n" "failed" >&6; }
+{ $as_echo "$as_me:${as_lineno-$LINENO}: result: failed" >&5
+$as_echo "failed" >&6; }
 :
 
 fi
@@ -5887,13 +5392,12 @@ fi
 
 
 
-{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking whether we need $C99FLAG -D__EXTENSIONS__ -D_BSD_SOURCE -D_DEFAULT_SOURCE -D_POSIX_C_SOURCE=200112 -D_XOPEN_SOURCE=600 -D_ALL_SOURCE as a flag for $CC" >&5
-printf %s "checking whether we need $C99FLAG -D__EXTENSIONS__ -D_BSD_SOURCE -D_DEFAULT_SOURCE -D_POSIX_C_SOURCE=200112 -D_XOPEN_SOURCE=600 -D_ALL_SOURCE as a flag for $CC... " >&6; }
-cache=`printf "%s\n" "$C99FLAG -D__EXTENSIONS__ -D_BSD_SOURCE -D_DEFAULT_SOURCE -D_POSIX_C_SOURCE=200112 -D_XOPEN_SOURCE=600 -D_ALL_SOURCE" | $as_tr_sh`
-if eval test \${cv_prog_cc_flag_needed_$cache+y}
-then :
-  printf %s "(cached) " >&6
-else $as_nop
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking whether we need $C99FLAG -D__EXTENSIONS__ -D_BSD_SOURCE -D_DEFAULT_SOURCE -D_POSIX_C_SOURCE=200112 -D_XOPEN_SOURCE=600 -D_ALL_SOURCE as a flag for $CC" >&5
+$as_echo_n "checking whether we need $C99FLAG -D__EXTENSIONS__ -D_BSD_SOURCE -D_DEFAULT_SOURCE -D_POSIX_C_SOURCE=200112 -D_XOPEN_SOURCE=600 -D_ALL_SOURCE as a flag for $CC... " >&6; }
+cache=`$as_echo "$C99FLAG -D__EXTENSIONS__ -D_BSD_SOURCE -D_DEFAULT_SOURCE -D_POSIX_C_SOURCE=200112 -D_XOPEN_SOURCE=600 -D_ALL_SOURCE" | $as_tr_sh`
+if eval \${cv_prog_cc_flag_needed_$cache+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
 
 echo '
 #include "confdefs.h"
@@ -5952,14 +5456,14 @@ rm -f conftest conftest.c conftest.o
 fi
 
 if eval "test \"`echo '$cv_prog_cc_flag_needed_'$cache`\" = yes"; then
-{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: yes" >&5
-printf "%s\n" "yes" >&6; }
+{ $as_echo "$as_me:${as_lineno-$LINENO}: result: yes" >&5
+$as_echo "yes" >&6; }
 :
 CFLAGS="$CFLAGS $C99FLAG -D__EXTENSIONS__ -D_BSD_SOURCE -D_DEFAULT_SOURCE -D_POSIX_C_SOURCE=200112 -D_XOPEN_SOURCE=600 -D_ALL_SOURCE"
 else
 if eval "test \"`echo '$cv_prog_cc_flag_needed_'$cache`\" = no"; then
-{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: no" >&5
-printf "%s\n" "no" >&6; }
+{ $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
+$as_echo "no" >&6; }
 #echo 'Test with flag is no!'
 #cat conftest.c
 #echo "$CC $CPPFLAGS $CFLAGS $C99FLAG -D__EXTENSIONS__ -D_BSD_SOURCE -D_DEFAULT_SOURCE -D_POSIX_C_SOURCE=200112 -D_XOPEN_SOURCE=600 -D_ALL_SOURCE $ERRFLAG -c conftest.c 2>&1"
@@ -5968,8 +5472,8 @@ printf "%s\n" "no" >&6; }
 :
 
 else
-{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: failed" >&5
-printf "%s\n" "failed" >&6; }
+{ $as_echo "$as_me:${as_lineno-$LINENO}: result: failed" >&5
+$as_echo "failed" >&6; }
 :
 
 fi
@@ -5979,13 +5483,12 @@ fi
 
 
 
-{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking whether we need $C99FLAG as a flag for $CC" >&5
-printf %s "checking whether we need $C99FLAG as a flag for $CC... " >&6; }
-cache=`printf "%s\n" "$C99FLAG" | $as_tr_sh`
-if eval test \${cv_prog_cc_flag_needed_$cache+y}
-then :
-  printf %s "(cached) " >&6
-else $as_nop
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking whether we need $C99FLAG as a flag for $CC" >&5
+$as_echo_n "checking whether we need $C99FLAG as a flag for $CC... " >&6; }
+cache=`$as_echo "$C99FLAG" | $as_tr_sh`
+if eval \${cv_prog_cc_flag_needed_$cache+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
 
 echo '
 #include <stdbool.h>
@@ -6017,14 +5520,14 @@ rm -f conftest conftest.c conftest.o
 fi
 
 if eval "test \"`echo '$cv_prog_cc_flag_needed_'$cache`\" = yes"; then
-{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: yes" >&5
-printf "%s\n" "yes" >&6; }
+{ $as_echo "$as_me:${as_lineno-$LINENO}: result: yes" >&5
+$as_echo "yes" >&6; }
 :
 CFLAGS="$CFLAGS $C99FLAG"
 else
 if eval "test \"`echo '$cv_prog_cc_flag_needed_'$cache`\" = no"; then
-{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: no" >&5
-printf "%s\n" "no" >&6; }
+{ $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
+$as_echo "no" >&6; }
 #echo 'Test with flag is no!'
 #cat conftest.c
 #echo "$CC $CPPFLAGS $CFLAGS $C99FLAG $ERRFLAG -c conftest.c 2>&1"
@@ -6033,8 +5536,8 @@ printf "%s\n" "no" >&6; }
 :
 
 else
-{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: failed" >&5
-printf "%s\n" "failed" >&6; }
+{ $as_echo "$as_me:${as_lineno-$LINENO}: result: failed" >&5
+$as_echo "failed" >&6; }
 :
 
 fi
@@ -6044,13 +5547,12 @@ fi
 
 
 
-{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking whether we need -D_BSD_SOURCE -D_DEFAULT_SOURCE as a flag for $CC" >&5
-printf %s "checking whether we need -D_BSD_SOURCE -D_DEFAULT_SOURCE as a flag for $CC... " >&6; }
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking whether we need -D_BSD_SOURCE -D_DEFAULT_SOURCE as a flag for $CC" >&5
+$as_echo_n "checking whether we need -D_BSD_SOURCE -D_DEFAULT_SOURCE as a flag for $CC... " >&6; }
 cache=_D_BSD_SOURCE__D_DEFAULT_SOURCE
-if eval test \${cv_prog_cc_flag_needed_$cache+y}
-then :
-  printf %s "(cached) " >&6
-else $as_nop
+if eval \${cv_prog_cc_flag_needed_$cache+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
 
 echo '
 #include <ctype.h>
@@ -6083,14 +5585,14 @@ rm -f conftest conftest.c conftest.o
 fi
 
 if eval "test \"`echo '$cv_prog_cc_flag_needed_'$cache`\" = yes"; then
-{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: yes" >&5
-printf "%s\n" "yes" >&6; }
+{ $as_echo "$as_me:${as_lineno-$LINENO}: result: yes" >&5
+$as_echo "yes" >&6; }
 :
 CFLAGS="$CFLAGS -D_BSD_SOURCE -D_DEFAULT_SOURCE"
 else
 if eval "test \"`echo '$cv_prog_cc_flag_needed_'$cache`\" = no"; then
-{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: no" >&5
-printf "%s\n" "no" >&6; }
+{ $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
+$as_echo "no" >&6; }
 #echo 'Test with flag is no!'
 #cat conftest.c
 #echo "$CC $CPPFLAGS $CFLAGS -D_BSD_SOURCE -D_DEFAULT_SOURCE $ERRFLAG -c conftest.c 2>&1"
@@ -6099,8 +5601,8 @@ printf "%s\n" "no" >&6; }
 :
 
 else
-{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: failed" >&5
-printf "%s\n" "failed" >&6; }
+{ $as_echo "$as_me:${as_lineno-$LINENO}: result: failed" >&5
+$as_echo "failed" >&6; }
 :
 
 fi
@@ -6110,13 +5612,12 @@ fi
 
 
 
-{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking whether we need -D_GNU_SOURCE as a flag for $CC" >&5
-printf %s "checking whether we need -D_GNU_SOURCE as a flag for $CC... " >&6; }
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking whether we need -D_GNU_SOURCE as a flag for $CC" >&5
+$as_echo_n "checking whether we need -D_GNU_SOURCE as a flag for $CC... " >&6; }
 cache=_D_GNU_SOURCE
-if eval test \${cv_prog_cc_flag_needed_$cache+y}
-then :
-  printf %s "(cached) " >&6
-else $as_nop
+if eval \${cv_prog_cc_flag_needed_$cache+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
 
 echo '
 #include <netinet/in.h>
@@ -6149,14 +5650,14 @@ rm -f conftest conftest.c conftest.o
 fi
 
 if eval "test \"`echo '$cv_prog_cc_flag_needed_'$cache`\" = yes"; then
-{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: yes" >&5
-printf "%s\n" "yes" >&6; }
+{ $as_echo "$as_me:${as_lineno-$LINENO}: result: yes" >&5
+$as_echo "yes" >&6; }
 :
 CFLAGS="$CFLAGS -D_GNU_SOURCE"
 else
 if eval "test \"`echo '$cv_prog_cc_flag_needed_'$cache`\" = no"; then
-{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: no" >&5
-printf "%s\n" "no" >&6; }
+{ $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
+$as_echo "no" >&6; }
 #echo 'Test with flag is no!'
 #cat conftest.c
 #echo "$CC $CPPFLAGS $CFLAGS -D_GNU_SOURCE $ERRFLAG -c conftest.c 2>&1"
@@ -6165,8 +5666,8 @@ printf "%s\n" "no" >&6; }
 :
 
 else
-{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: failed" >&5
-printf "%s\n" "failed" >&6; }
+{ $as_echo "$as_me:${as_lineno-$LINENO}: result: failed" >&5
+$as_echo "failed" >&6; }
 :
 
 fi
@@ -6179,13 +5680,12 @@ fi
 
 
 
-{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking whether we need -D_GNU_SOURCE -D_FRSRESGID as a flag for $CC" >&5
-printf %s "checking whether we need -D_GNU_SOURCE -D_FRSRESGID as a flag for $CC... " >&6; }
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking whether we need -D_GNU_SOURCE -D_FRSRESGID as a flag for $CC" >&5
+$as_echo_n "checking whether we need -D_GNU_SOURCE -D_FRSRESGID as a flag for $CC... " >&6; }
 cache=_D_GNU_SOURCE__D_FRSRESGID
-if eval test \${cv_prog_cc_flag_needed_$cache+y}
-then :
-  printf %s "(cached) " >&6
-else $as_nop
+if eval \${cv_prog_cc_flag_needed_$cache+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
 
 echo '
 #include <unistd.h>
@@ -6218,14 +5718,14 @@ rm -f conftest conftest.c conftest.o
 fi
 
 if eval "test \"`echo '$cv_prog_cc_flag_needed_'$cache`\" = yes"; then
-{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: yes" >&5
-printf "%s\n" "yes" >&6; }
+{ $as_echo "$as_me:${as_lineno-$LINENO}: result: yes" >&5
+$as_echo "yes" >&6; }
 :
 CFLAGS="$CFLAGS -D_GNU_SOURCE"
 else
 if eval "test \"`echo '$cv_prog_cc_flag_needed_'$cache`\" = no"; then
-{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: no" >&5
-printf "%s\n" "no" >&6; }
+{ $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
+$as_echo "no" >&6; }
 #echo 'Test with flag is no!'
 #cat conftest.c
 #echo "$CC $CPPFLAGS $CFLAGS -D_GNU_SOURCE -D_FRSRESGID $ERRFLAG -c conftest.c 2>&1"
@@ -6234,8 +5734,8 @@ printf "%s\n" "no" >&6; }
 :
 
 else
-{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: failed" >&5
-printf "%s\n" "failed" >&6; }
+{ $as_echo "$as_me:${as_lineno-$LINENO}: result: failed" >&5
+$as_echo "failed" >&6; }
 :
 
 fi
@@ -6245,13 +5745,12 @@ fi
 
 
 
-{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking whether we need -D_POSIX_C_SOURCE=200112 as a flag for $CC" >&5
-printf %s "checking whether we need -D_POSIX_C_SOURCE=200112 as a flag for $CC... " >&6; }
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking whether we need -D_POSIX_C_SOURCE=200112 as a flag for $CC" >&5
+$as_echo_n "checking whether we need -D_POSIX_C_SOURCE=200112 as a flag for $CC... " >&6; }
 cache=_D_POSIX_C_SOURCE_200112
-if eval test \${cv_prog_cc_flag_needed_$cache+y}
-then :
-  printf %s "(cached) " >&6
-else $as_nop
+if eval \${cv_prog_cc_flag_needed_$cache+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
 
 echo '
 #include "confdefs.h"
@@ -6295,14 +5794,14 @@ rm -f conftest conftest.c conftest.o
 fi
 
 if eval "test \"`echo '$cv_prog_cc_flag_needed_'$cache`\" = yes"; then
-{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: yes" >&5
-printf "%s\n" "yes" >&6; }
+{ $as_echo "$as_me:${as_lineno-$LINENO}: result: yes" >&5
+$as_echo "yes" >&6; }
 :
 CFLAGS="$CFLAGS -D_POSIX_C_SOURCE=200112"
 else
 if eval "test \"`echo '$cv_prog_cc_flag_needed_'$cache`\" = no"; then
-{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: no" >&5
-printf "%s\n" "no" >&6; }
+{ $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
+$as_echo "no" >&6; }
 #echo 'Test with flag is no!'
 #cat conftest.c
 #echo "$CC $CPPFLAGS $CFLAGS -D_POSIX_C_SOURCE=200112 $ERRFLAG -c conftest.c 2>&1"
@@ -6311,8 +5810,8 @@ printf "%s\n" "no" >&6; }
 :
 
 else
-{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: failed" >&5
-printf "%s\n" "failed" >&6; }
+{ $as_echo "$as_me:${as_lineno-$LINENO}: result: failed" >&5
+$as_echo "failed" >&6; }
 :
 
 fi
@@ -6322,13 +5821,12 @@ fi
 
 
 
-{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking whether we need -D__EXTENSIONS__ as a flag for $CC" >&5
-printf %s "checking whether we need -D__EXTENSIONS__ as a flag for $CC... " >&6; }
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking whether we need -D__EXTENSIONS__ as a flag for $CC" >&5
+$as_echo_n "checking whether we need -D__EXTENSIONS__ as a flag for $CC... " >&6; }
 cache=_D__EXTENSIONS__
-if eval test \${cv_prog_cc_flag_needed_$cache+y}
-then :
-  printf %s "(cached) " >&6
-else $as_nop
+if eval \${cv_prog_cc_flag_needed_$cache+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
 
 echo '
 #include "confdefs.h"
@@ -6378,14 +5876,14 @@ rm -f conftest conftest.c conftest.o
 fi
 
 if eval "test \"`echo '$cv_prog_cc_flag_needed_'$cache`\" = yes"; then
-{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: yes" >&5
-printf "%s\n" "yes" >&6; }
+{ $as_echo "$as_me:${as_lineno-$LINENO}: result: yes" >&5
+$as_echo "yes" >&6; }
 :
 CFLAGS="$CFLAGS -D__EXTENSIONS__"
 else
 if eval "test \"`echo '$cv_prog_cc_flag_needed_'$cache`\" = no"; then
-{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: no" >&5
-printf "%s\n" "no" >&6; }
+{ $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
+$as_echo "no" >&6; }
 #echo 'Test with flag is no!'
 #cat conftest.c
 #echo "$CC $CPPFLAGS $CFLAGS -D__EXTENSIONS__ $ERRFLAG -c conftest.c 2>&1"
@@ -6394,8 +5892,8 @@ printf "%s\n" "no" >&6; }
 :
 
 else
-{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: failed" >&5
-printf "%s\n" "failed" >&6; }
+{ $as_echo "$as_me:${as_lineno-$LINENO}: result: failed" >&5
+$as_echo "failed" >&6; }
 :
 
 fi
@@ -6406,14 +5904,12 @@ fi
 
 # debug mode flags warnings
 # Check whether --enable-checking was given.
-if test ${enable_checking+y}
-then :
+if test "${enable_checking+set}" = set; then :
   enableval=$enable_checking;
 fi
 
 # Check whether --enable-debug was given.
-if test ${enable_debug+y}
-then :
+if test "${enable_debug+set}" = set; then :
   enableval=$enable_debug;
 fi
 
@@ -6424,13 +5920,12 @@ case "$debug_enabled" in
         yes)
 
 
-{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking whether $CC supports -W" >&5
-printf %s "checking whether $CC supports -W... " >&6; }
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking whether $CC supports -W" >&5
+$as_echo_n "checking whether $CC supports -W... " >&6; }
 cache=`echo W | sed 'y%.=/+-%___p_%'`
-if eval test \${cv_prog_cc_flag_$cache+y}
-then :
-  printf %s "(cached) " >&6
-else $as_nop
+if eval \${cv_prog_cc_flag_$cache+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
 
 echo 'void f(void){}' >conftest.c
 if test -z "`$CC $CPPFLAGS $CFLAGS -W -c conftest.c 2>&1`"; then
@@ -6443,26 +5938,25 @@ rm -f conftest conftest.o conftest.c
 fi
 
 if eval "test \"`echo '$cv_prog_cc_flag_'$cache`\" = yes"; then
-{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: yes" >&5
-printf "%s\n" "yes" >&6; }
+{ $as_echo "$as_me:${as_lineno-$LINENO}: result: yes" >&5
+$as_echo "yes" >&6; }
 :
 CFLAGS="$CFLAGS -W"
 else
-{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: no" >&5
-printf "%s\n" "no" >&6; }
+{ $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
+$as_echo "no" >&6; }
 :
 
 fi
 
 
 
-{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking whether $CC supports -Wall" >&5
-printf %s "checking whether $CC supports -Wall... " >&6; }
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking whether $CC supports -Wall" >&5
+$as_echo_n "checking whether $CC supports -Wall... " >&6; }
 cache=`echo Wall | sed 'y%.=/+-%___p_%'`
-if eval test \${cv_prog_cc_flag_$cache+y}
-then :
-  printf %s "(cached) " >&6
-else $as_nop
+if eval \${cv_prog_cc_flag_$cache+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
 
 echo 'void f(void){}' >conftest.c
 if test -z "`$CC $CPPFLAGS $CFLAGS -Wall -c conftest.c 2>&1`"; then
@@ -6475,26 +5969,25 @@ rm -f conftest conftest.o conftest.c
 fi
 
 if eval "test \"`echo '$cv_prog_cc_flag_'$cache`\" = yes"; then
-{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: yes" >&5
-printf "%s\n" "yes" >&6; }
+{ $as_echo "$as_me:${as_lineno-$LINENO}: result: yes" >&5
+$as_echo "yes" >&6; }
 :
 CFLAGS="$CFLAGS -Wall"
 else
-{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: no" >&5
-printf "%s\n" "no" >&6; }
+{ $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
+$as_echo "no" >&6; }
 :
 
 fi
 
 
 
-{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking whether $CC supports -Wextra" >&5
-printf %s "checking whether $CC supports -Wextra... " >&6; }
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking whether $CC supports -Wextra" >&5
+$as_echo_n "checking whether $CC supports -Wextra... " >&6; }
 cache=`echo Wextra | sed 'y%.=/+-%___p_%'`
-if eval test \${cv_prog_cc_flag_$cache+y}
-then :
-  printf %s "(cached) " >&6
-else $as_nop
+if eval \${cv_prog_cc_flag_$cache+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
 
 echo 'void f(void){}' >conftest.c
 if test -z "`$CC $CPPFLAGS $CFLAGS -Wextra -c conftest.c 2>&1`"; then
@@ -6507,26 +6000,25 @@ rm -f conftest conftest.o conftest.c
 fi
 
 if eval "test \"`echo '$cv_prog_cc_flag_'$cache`\" = yes"; then
-{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: yes" >&5
-printf "%s\n" "yes" >&6; }
+{ $as_echo "$as_me:${as_lineno-$LINENO}: result: yes" >&5
+$as_echo "yes" >&6; }
 :
 CFLAGS="$CFLAGS -Wextra"
 else
-{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: no" >&5
-printf "%s\n" "no" >&6; }
+{ $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
+$as_echo "no" >&6; }
 :
 
 fi
 
 
 
-{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking whether $CC supports -Wdeclaration-after-statement" >&5
-printf %s "checking whether $CC supports -Wdeclaration-after-statement... " >&6; }
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking whether $CC supports -Wdeclaration-after-statement" >&5
+$as_echo_n "checking whether $CC supports -Wdeclaration-after-statement... " >&6; }
 cache=`echo Wdeclaration-after-statement | sed 'y%.=/+-%___p_%'`
-if eval test \${cv_prog_cc_flag_$cache+y}
-then :
-  printf %s "(cached) " >&6
-else $as_nop
+if eval \${cv_prog_cc_flag_$cache+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
 
 echo 'void f(void){}' >conftest.c
 if test -z "`$CC $CPPFLAGS $CFLAGS -Wdeclaration-after-statement -c conftest.c 2>&1`"; then
@@ -6539,19 +6031,19 @@ rm -f conftest conftest.o conftest.c
 fi
 
 if eval "test \"`echo '$cv_prog_cc_flag_'$cache`\" = yes"; then
-{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: yes" >&5
-printf "%s\n" "yes" >&6; }
+{ $as_echo "$as_me:${as_lineno-$LINENO}: result: yes" >&5
+$as_echo "yes" >&6; }
 :
 CFLAGS="$CFLAGS -Wdeclaration-after-statement"
 else
-{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: no" >&5
-printf "%s\n" "no" >&6; }
+{ $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
+$as_echo "no" >&6; }
 :
 
 fi
 
 
-printf "%s\n" "#define UNBOUND_DEBUG /**/" >>confdefs.h
+$as_echo "#define UNBOUND_DEBUG /**/" >>confdefs.h
 
 		;;
 	no|*)
@@ -6564,63 +6056,58 @@ if test "$default_cflags" = "yes"; then
 	# be able to turn off these options and set the CFLAGS wanted.
 
     # Check whether --enable-flto was given.
-if test ${enable_flto+y}
-then :
+if test "${enable_flto+set}" = set; then :
   enableval=$enable_flto;
 fi
 
-    if test "x$enable_flto" != "xno"
-then :
+    if test "x$enable_flto" != "xno"; then :
 
-        { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking if $CC supports -flto" >&5
-printf %s "checking if $CC supports -flto... " >&6; }
+        { $as_echo "$as_me:${as_lineno-$LINENO}: checking if $CC supports -flto" >&5
+$as_echo_n "checking if $CC supports -flto... " >&6; }
         BAKCFLAGS="$CFLAGS"
         CFLAGS="$CFLAGS -flto"
         cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 /* end confdefs.h.  */
 
 int
-main (void)
+main ()
 {
 
   ;
   return 0;
 }
 _ACEOF
-if ac_fn_c_try_link "$LINENO"
-then :
+if ac_fn_c_try_link "$LINENO"; then :
 
             if $CC $CFLAGS -o conftest conftest.c 2>&1 | $GREP -e "warning: no debug symbols in executable" -e "warning: object" >/dev/null; then
                 CFLAGS="$BAKCFLAGS"
-                { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: no" >&5
-printf "%s\n" "no" >&6; }
+                { $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
+$as_echo "no" >&6; }
             else
-                { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: yes" >&5
-printf "%s\n" "yes" >&6; }
+                { $as_echo "$as_me:${as_lineno-$LINENO}: result: yes" >&5
+$as_echo "yes" >&6; }
             fi
             rm -f conftest conftest.c conftest.o
 
-else $as_nop
-  CFLAGS="$BAKCFLAGS" ; { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: no" >&5
-printf "%s\n" "no" >&6; }
+else
+  CFLAGS="$BAKCFLAGS" ; { $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
+$as_echo "no" >&6; }
 fi
-rm -f core conftest.err conftest.$ac_objext conftest.beam \
+rm -f core conftest.err conftest.$ac_objext \
     conftest$ac_exeext conftest.$ac_ext
 
 fi
 
 
     # Check whether --enable-pie was given.
-if test ${enable_pie+y}
-then :
+if test "${enable_pie+set}" = set; then :
   enableval=$enable_pie;
 fi
 
-    if test "x$enable_pie" = "xyes"
-then :
+    if test "x$enable_pie" = "xyes"; then :
 
-	{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking if $CC supports PIE" >&5
-printf %s "checking if $CC supports PIE... " >&6; }
+	{ $as_echo "$as_me:${as_lineno-$LINENO}: checking if $CC supports PIE" >&5
+$as_echo_n "checking if $CC supports PIE... " >&6; }
 	BAKLDFLAGS="$LDFLAGS"
 	BAKCFLAGS="$CFLAGS"
 	LDFLAGS="$LDFLAGS -pie"
@@ -6629,112 +6116,106 @@ printf %s "checking if $CC supports PIE... " >&6; }
 /* end confdefs.h.  */
 
 int
-main (void)
+main ()
 {
 
   ;
   return 0;
 }
 _ACEOF
-if ac_fn_c_try_link "$LINENO"
-then :
+if ac_fn_c_try_link "$LINENO"; then :
 
 	    if $CC $CFLAGS $LDFLAGS -o conftest conftest.c 2>&1 | grep "warning: no debug symbols in executable" >/dev/null; then
 		LDFLAGS="$BAKLDFLAGS"
-		{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: no" >&5
-printf "%s\n" "no" >&6; }
+		{ $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
+$as_echo "no" >&6; }
 	    else
-		{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: yes" >&5
-printf "%s\n" "yes" >&6; }
+		{ $as_echo "$as_me:${as_lineno-$LINENO}: result: yes" >&5
+$as_echo "yes" >&6; }
 	    fi
 	    rm -f conftest conftest.c conftest.o
 
-else $as_nop
-  LDFLAGS="$BAKLDFLAGS" ; CFLAGS="$BAKCFLAGS" ; { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: no" >&5
-printf "%s\n" "no" >&6; }
+else
+  LDFLAGS="$BAKLDFLAGS" ; CFLAGS="$BAKCFLAGS" ; { $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
+$as_echo "no" >&6; }
 fi
-rm -f core conftest.err conftest.$ac_objext conftest.beam \
+rm -f core conftest.err conftest.$ac_objext \
     conftest$ac_exeext conftest.$ac_ext
 
 fi
 
 
     # Check whether --enable-relro_now was given.
-if test ${enable_relro_now+y}
-then :
+if test "${enable_relro_now+set}" = set; then :
   enableval=$enable_relro_now;
 fi
 
-    if test "x$enable_relro_now" = "xyes"
-then :
+    if test "x$enable_relro_now" = "xyes"; then :
 
-	{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking if $CC supports -Wl,-z,relro,-z,now" >&5
-printf %s "checking if $CC supports -Wl,-z,relro,-z,now... " >&6; }
+	{ $as_echo "$as_me:${as_lineno-$LINENO}: checking if $CC supports -Wl,-z,relro,-z,now" >&5
+$as_echo_n "checking if $CC supports -Wl,-z,relro,-z,now... " >&6; }
 	BAKLDFLAGS="$LDFLAGS"
 	LDFLAGS="$LDFLAGS -Wl,-z,relro,-z,now"
 	cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 /* end confdefs.h.  */
 
 int
-main (void)
+main ()
 {
 
   ;
   return 0;
 }
 _ACEOF
-if ac_fn_c_try_link "$LINENO"
-then :
+if ac_fn_c_try_link "$LINENO"; then :
 
 	    if $CC $CFLAGS $LDFLAGS -o conftest conftest.c 2>&1 | grep "warning: no debug symbols in executable" >/dev/null; then
 		LDFLAGS="$BAKLDFLAGS"
-		{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: no" >&5
-printf "%s\n" "no" >&6; }
+		{ $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
+$as_echo "no" >&6; }
 	    else
-		{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: yes" >&5
-printf "%s\n" "yes" >&6; }
+		{ $as_echo "$as_me:${as_lineno-$LINENO}: result: yes" >&5
+$as_echo "yes" >&6; }
 	    fi
 	    rm -f conftest conftest.c conftest.o
 
-else $as_nop
-  LDFLAGS="$BAKLDFLAGS" ; { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: no" >&5
-printf "%s\n" "no" >&6; }
+else
+  LDFLAGS="$BAKLDFLAGS" ; { $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
+$as_echo "no" >&6; }
 fi
-rm -f core conftest.err conftest.$ac_objext conftest.beam \
+rm -f core conftest.err conftest.$ac_objext \
     conftest$ac_exeext conftest.$ac_ext
 
 fi
 
 fi
 
-{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for inline" >&5
-printf %s "checking for inline... " >&6; }
-if test ${ac_cv_c_inline+y}
-then :
-  printf %s "(cached) " >&6
-else $as_nop
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for inline" >&5
+$as_echo_n "checking for inline... " >&6; }
+if ${ac_cv_c_inline+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
   ac_cv_c_inline=no
 for ac_kw in inline __inline__ __inline; do
   cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 /* end confdefs.h.  */
 #ifndef __cplusplus
 typedef int foo_t;
-static $ac_kw foo_t static_foo (void) {return 0; }
-$ac_kw foo_t foo (void) {return 0; }
+static $ac_kw foo_t static_foo () {return 0; }
+$ac_kw foo_t foo () {return 0; }
 #endif
 
 _ACEOF
-if ac_fn_c_try_compile "$LINENO"
-then :
+if ac_fn_c_try_compile "$LINENO"; then :
   ac_cv_c_inline=$ac_kw
 fi
-rm -f core conftest.err conftest.$ac_objext conftest.beam conftest.$ac_ext
+rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
   test "$ac_cv_c_inline" != no && break
 done
 
 fi
-{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $ac_cv_c_inline" >&5
-printf "%s\n" "$ac_cv_c_inline" >&6; }
+{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_c_inline" >&5
+$as_echo "$ac_cv_c_inline" >&6; }
 
 case $ac_cv_c_inline in
   inline | yes) ;;
@@ -6752,12 +6233,11 @@ _ACEOF
 esac
 
 
-{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking whether the C compiler (${CC-cc}) accepts the \"format\" attribute" >&5
-printf %s "checking whether the C compiler (${CC-cc}) accepts the \"format\" attribute... " >&6; }
-if test ${ac_cv_c_format_attribute+y}
-then :
-  printf %s "(cached) " >&6
-else $as_nop
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking whether the C compiler (${CC-cc}) accepts the \"format\" attribute" >&5
+$as_echo_n "checking whether the C compiler (${CC-cc}) accepts the \"format\" attribute... " >&6; }
+if ${ac_cv_c_format_attribute+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
   ac_cv_c_format_attribute=no
 cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 /* end confdefs.h.  */
@@ -6766,7 +6246,7 @@ void f (char *format, ...) __attribute__ ((format (printf, 1, 2)));
 void (*pf) (char *format, ...) __attribute__ ((format (printf, 1, 2)));
 
 int
-main (void)
+main ()
 {
 
    f ("%s", "str");
@@ -6775,32 +6255,30 @@ main (void)
   return 0;
 }
 _ACEOF
-if ac_fn_c_try_compile "$LINENO"
-then :
+if ac_fn_c_try_compile "$LINENO"; then :
   ac_cv_c_format_attribute="yes"
-else $as_nop
+else
   ac_cv_c_format_attribute="no"
 fi
-rm -f core conftest.err conftest.$ac_objext conftest.beam conftest.$ac_ext
+rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
 
 fi
 
 
-{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $ac_cv_c_format_attribute" >&5
-printf "%s\n" "$ac_cv_c_format_attribute" >&6; }
+{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_c_format_attribute" >&5
+$as_echo "$ac_cv_c_format_attribute" >&6; }
 if test $ac_cv_c_format_attribute = yes; then
 
-printf "%s\n" "#define HAVE_ATTR_FORMAT 1" >>confdefs.h
+$as_echo "#define HAVE_ATTR_FORMAT 1" >>confdefs.h
 
 fi
 
 
-{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking whether the C compiler (${CC-cc}) accepts the \"unused\" attribute" >&5
-printf %s "checking whether the C compiler (${CC-cc}) accepts the \"unused\" attribute... " >&6; }
-if test ${ac_cv_c_unused_attribute+y}
-then :
-  printf %s "(cached) " >&6
-else $as_nop
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking whether the C compiler (${CC-cc}) accepts the \"unused\" attribute" >&5
+$as_echo_n "checking whether the C compiler (${CC-cc}) accepts the \"unused\" attribute... " >&6; }
+if ${ac_cv_c_unused_attribute+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
   ac_cv_c_unused_attribute=no
 cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 /* end confdefs.h.  */
@@ -6808,7 +6286,7 @@ cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 void f (char *u __attribute__((unused)));
 
 int
-main (void)
+main ()
 {
 
    f ("x");
@@ -6817,36 +6295,34 @@ main (void)
   return 0;
 }
 _ACEOF
-if ac_fn_c_try_compile "$LINENO"
-then :
+if ac_fn_c_try_compile "$LINENO"; then :
   ac_cv_c_unused_attribute="yes"
-else $as_nop
+else
   ac_cv_c_unused_attribute="no"
 fi
-rm -f core conftest.err conftest.$ac_objext conftest.beam conftest.$ac_ext
+rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
 
 fi
 
 
 
 
-{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $ac_cv_c_unused_attribute" >&5
-printf "%s\n" "$ac_cv_c_unused_attribute" >&6; }
+{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_c_unused_attribute" >&5
+$as_echo "$ac_cv_c_unused_attribute" >&6; }
 if test $ac_cv_c_unused_attribute = yes; then
 
-printf "%s\n" "#define HAVE_ATTR_UNUSED 1" >>confdefs.h
+$as_echo "#define HAVE_ATTR_UNUSED 1" >>confdefs.h
 
 fi
 
 
 
 
-{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking whether the C compiler (${CC-cc}) accepts the \"weak\" attribute" >&5
-printf %s "checking whether the C compiler (${CC-cc}) accepts the \"weak\" attribute... " >&6; }
-if test ${ac_cv_c_weak_attribute+y}
-then :
-  printf %s "(cached) " >&6
-else $as_nop
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking whether the C compiler (${CC-cc}) accepts the \"weak\" attribute" >&5
+$as_echo_n "checking whether the C compiler (${CC-cc}) accepts the \"weak\" attribute... " >&6; }
+if ${ac_cv_c_weak_attribute+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
   ac_cv_c_weak_attribute=no
 cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 /* end confdefs.h.  */
@@ -6854,7 +6330,7 @@ cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 __attribute__((weak)) void f(int x) { printf("%d", x); }
 
 int
-main (void)
+main ()
 {
 
    f(1);
@@ -6863,37 +6339,35 @@ main (void)
   return 0;
 }
 _ACEOF
-if ac_fn_c_try_compile "$LINENO"
-then :
+if ac_fn_c_try_compile "$LINENO"; then :
   ac_cv_c_weak_attribute="yes"
-else $as_nop
+else
   ac_cv_c_weak_attribute="no"
 fi
-rm -f core conftest.err conftest.$ac_objext conftest.beam conftest.$ac_ext
+rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
 
 fi
 
 
-{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $ac_cv_c_weak_attribute" >&5
-printf "%s\n" "$ac_cv_c_weak_attribute" >&6; }
+{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_c_weak_attribute" >&5
+$as_echo "$ac_cv_c_weak_attribute" >&6; }
 if test $ac_cv_c_weak_attribute = yes; then
 
-printf "%s\n" "#define HAVE_ATTR_WEAK 1" >>confdefs.h
+$as_echo "#define HAVE_ATTR_WEAK 1" >>confdefs.h
 
 
-printf "%s\n" "#define ATTR_WEAK __attribute__((weak))" >>confdefs.h
+$as_echo "#define ATTR_WEAK __attribute__((weak))" >>confdefs.h
 
 fi
 
 
 
 
-{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking whether the C compiler (${CC-cc}) accepts the \"noreturn\" attribute" >&5
-printf %s "checking whether the C compiler (${CC-cc}) accepts the \"noreturn\" attribute... " >&6; }
-if test ${ac_cv_c_noreturn_attribute+y}
-then :
-  printf %s "(cached) " >&6
-else $as_nop
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking whether the C compiler (${CC-cc}) accepts the \"noreturn\" attribute" >&5
+$as_echo_n "checking whether the C compiler (${CC-cc}) accepts the \"noreturn\" attribute... " >&6; }
+if ${ac_cv_c_noreturn_attribute+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
   ac_cv_c_noreturn_attribute=no
 cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 /* end confdefs.h.  */
@@ -6901,7 +6375,7 @@ cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 __attribute__((noreturn)) void f(int x) { printf("%d", x); }
 
 int
-main (void)
+main ()
 {
 
    f(1);
@@ -6910,25 +6384,24 @@ main (void)
   return 0;
 }
 _ACEOF
-if ac_fn_c_try_compile "$LINENO"
-then :
+if ac_fn_c_try_compile "$LINENO"; then :
   ac_cv_c_noreturn_attribute="yes"
-else $as_nop
+else
   ac_cv_c_noreturn_attribute="no"
 fi
-rm -f core conftest.err conftest.$ac_objext conftest.beam conftest.$ac_ext
+rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
 
 fi
 
 
-{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $ac_cv_c_noreturn_attribute" >&5
-printf "%s\n" "$ac_cv_c_noreturn_attribute" >&6; }
+{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_c_noreturn_attribute" >&5
+$as_echo "$ac_cv_c_noreturn_attribute" >&6; }
 if test $ac_cv_c_noreturn_attribute = yes; then
 
-printf "%s\n" "#define HAVE_ATTR_NORETURN 1" >>confdefs.h
+$as_echo "#define HAVE_ATTR_NORETURN 1" >>confdefs.h
 
 
-printf "%s\n" "#define ATTR_NORETURN __attribute__((__noreturn__))" >>confdefs.h
+$as_echo "#define ATTR_NORETURN __attribute__((__noreturn__))" >>confdefs.h
 
 fi
 
@@ -6945,12 +6418,11 @@ for ac_prog in flex lex
 do
   # Extract the first word of "$ac_prog", so it can be a program name with args.
 set dummy $ac_prog; ac_word=$2
-{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for $ac_word" >&5
-printf %s "checking for $ac_word... " >&6; }
-if test ${ac_cv_prog_LEX+y}
-then :
-  printf %s "(cached) " >&6
-else $as_nop
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for $ac_word" >&5
+$as_echo_n "checking for $ac_word... " >&6; }
+if ${ac_cv_prog_LEX+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
   if test -n "$LEX"; then
   ac_cv_prog_LEX="$LEX" # Let the user override the test.
 else
@@ -6958,15 +6430,11 @@ as_save_IFS=$IFS; IFS=$PATH_SEPARATOR
 for as_dir in $PATH
 do
   IFS=$as_save_IFS
-  case $as_dir in #(((
-    '') as_dir=./ ;;
-    */) ;;
-    *) as_dir=$as_dir/ ;;
-  esac
+  test -z "$as_dir" && as_dir=.
     for ac_exec_ext in '' $ac_executable_extensions; do
-  if as_fn_executable_p "$as_dir$ac_word$ac_exec_ext"; then
+  if as_fn_executable_p "$as_dir/$ac_word$ac_exec_ext"; then
     ac_cv_prog_LEX="$ac_prog"
-    printf "%s\n" "$as_me:${as_lineno-$LINENO}: found $as_dir$ac_word$ac_exec_ext" >&5
+    $as_echo "$as_me:${as_lineno-$LINENO}: found $as_dir/$ac_word$ac_exec_ext" >&5
     break 2
   fi
 done
@@ -6977,11 +6445,11 @@ fi
 fi
 LEX=$ac_cv_prog_LEX
 if test -n "$LEX"; then
-  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $LEX" >&5
-printf "%s\n" "$LEX" >&6; }
+  { $as_echo "$as_me:${as_lineno-$LINENO}: result: $LEX" >&5
+$as_echo "$LEX" >&6; }
 else
-  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: no" >&5
-printf "%s\n" "no" >&6; }
+  { $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
+$as_echo "no" >&6; }
 fi
 
 
@@ -6989,26 +6457,15 @@ fi
 done
 test -n "$LEX" || LEX=":"
 
-  if test "x$LEX" != "x:"; then
-    cat >conftest.l <<_ACEOF
-%{
-#ifdef __cplusplus
-extern "C"
-#endif
-int yywrap(void);
-%}
+if test "x$LEX" != "x:"; then
+  cat >conftest.l <<_ACEOF
 %%
 a { ECHO; }
 b { REJECT; }
 c { yymore (); }
 d { yyless (1); }
 e { /* IRIX 6.5 flex 2.5.4 underquotes its yyless argument.  */
-#ifdef __cplusplus
-    yyless ((yyinput () != 0));
-#else
-    yyless ((input () != 0));
-#endif
-  }
+    yyless ((input () != 0)); }
 f { unput (yytext[0]); }
 . { BEGIN INITIAL; }
 %%
@@ -7016,144 +6473,101 @@ f { unput (yytext[0]); }
 extern char *yytext;
 #endif
 int
-yywrap (void)
-{
-  return 1;
-}
-int
 main (void)
 {
-  return ! yylex ();
+  return ! yylex () + ! yywrap ();
 }
 _ACEOF
-{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for lex output file root" >&5
-printf %s "checking for lex output file root... " >&6; }
-if test ${ac_cv_prog_lex_root+y}
-then :
-  printf %s "(cached) " >&6
-else $as_nop
-
-ac_cv_prog_lex_root=unknown
 { { ac_try="$LEX conftest.l"
 case "(($ac_try" in
   *\"* | *\`* | *\\*) ac_try_echo=\$ac_try;;
   *) ac_try_echo=$ac_try;;
 esac
 eval ac_try_echo="\"\$as_me:${as_lineno-$LINENO}: $ac_try_echo\""
-printf "%s\n" "$ac_try_echo"; } >&5
+$as_echo "$ac_try_echo"; } >&5
   (eval "$LEX conftest.l") 2>&5
   ac_status=$?
-  printf "%s\n" "$as_me:${as_lineno-$LINENO}: \$? = $ac_status" >&5
-  test $ac_status = 0; } &&
+  $as_echo "$as_me:${as_lineno-$LINENO}: \$? = $ac_status" >&5
+  test $ac_status = 0; }
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking lex output file root" >&5
+$as_echo_n "checking lex output file root... " >&6; }
+if ${ac_cv_prog_lex_root+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
+
 if test -f lex.yy.c; then
   ac_cv_prog_lex_root=lex.yy
 elif test -f lexyy.c; then
   ac_cv_prog_lex_root=lexyy
+else
+  as_fn_error $? "cannot find output from $LEX; giving up" "$LINENO" 5
 fi
 fi
-{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $ac_cv_prog_lex_root" >&5
-printf "%s\n" "$ac_cv_prog_lex_root" >&6; }
-if test "$ac_cv_prog_lex_root" = unknown
-then :
-  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: WARNING: cannot find output from $LEX; giving up on $LEX" >&5
-printf "%s\n" "$as_me: WARNING: cannot find output from $LEX; giving up on $LEX" >&2;}
-   LEX=: LEXLIB=
-fi
+{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_prog_lex_root" >&5
+$as_echo "$ac_cv_prog_lex_root" >&6; }
 LEX_OUTPUT_ROOT=$ac_cv_prog_lex_root
 
-if test ${LEXLIB+y}
-then :
+if test -z "${LEXLIB+set}"; then
+  { $as_echo "$as_me:${as_lineno-$LINENO}: checking lex library" >&5
+$as_echo_n "checking lex library... " >&6; }
+if ${ac_cv_lib_lex+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
 
-else $as_nop
-
-  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for lex library" >&5
-printf %s "checking for lex library... " >&6; }
-if test ${ac_cv_lib_lex+y}
-then :
-  printf %s "(cached) " >&6
-else $as_nop
-
-    ac_save_LIBS="$LIBS"
-    ac_found=false
-    for ac_cv_lib_lex in 'none needed' -lfl -ll 'not found'; do
-      case $ac_cv_lib_lex in #(
-  'none needed') :
-     ;; #(
-  'not found') :
-    break ;; #(
-  *) :
-    LIBS="$ac_cv_lib_lex $ac_save_LIBS" ;; #(
-  *) :
-     ;;
-esac
-
+    ac_save_LIBS=$LIBS
+    ac_cv_lib_lex='none needed'
+    for ac_lib in '' -lfl -ll; do
+      LIBS="$ac_lib $ac_save_LIBS"
       cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 /* end confdefs.h.  */
 `cat $LEX_OUTPUT_ROOT.c`
 _ACEOF
-if ac_fn_c_try_link "$LINENO"
-then :
-  ac_found=:
+if ac_fn_c_try_link "$LINENO"; then :
+  ac_cv_lib_lex=$ac_lib
 fi
-rm -f core conftest.err conftest.$ac_objext conftest.beam \
+rm -f core conftest.err conftest.$ac_objext \
     conftest$ac_exeext conftest.$ac_ext
-      if $ac_found; then
-        break
-      fi
+      test "$ac_cv_lib_lex" != 'none needed' && break
     done
-    LIBS="$ac_save_LIBS"
+    LIBS=$ac_save_LIBS
 
 fi
-{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $ac_cv_lib_lex" >&5
-printf "%s\n" "$ac_cv_lib_lex" >&6; }
-  if test "$ac_cv_lib_lex" = 'not found'
-then :
-  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: WARNING: required lex library not found; giving up on $LEX" >&5
-printf "%s\n" "$as_me: WARNING: required lex library not found; giving up on $LEX" >&2;}
-	 LEX=: LEXLIB=
-elif test "$ac_cv_lib_lex" = 'none needed'
-then :
-  LEXLIB=''
-else $as_nop
-  LEXLIB=$ac_cv_lib_lex
-fi
-
+{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_lib_lex" >&5
+$as_echo "$ac_cv_lib_lex" >&6; }
+  test "$ac_cv_lib_lex" != 'none needed' && LEXLIB=$ac_cv_lib_lex
 fi
 
 
-if test "$LEX" != :
-then :
-
-{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking whether yytext is a pointer" >&5
-printf %s "checking whether yytext is a pointer... " >&6; }
-if test ${ac_cv_prog_lex_yytext_pointer+y}
-then :
-  printf %s "(cached) " >&6
-else $as_nop
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking whether yytext is a pointer" >&5
+$as_echo_n "checking whether yytext is a pointer... " >&6; }
+if ${ac_cv_prog_lex_yytext_pointer+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
   # POSIX says lex can declare yytext either as a pointer or an array; the
 # default is implementation-dependent.  Figure out which it is, since
 # not all implementations provide the %pointer and %array declarations.
 ac_cv_prog_lex_yytext_pointer=no
+ac_save_LIBS=$LIBS
+LIBS="$LEXLIB $ac_save_LIBS"
 cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 /* end confdefs.h.  */
 
   #define YYTEXT_POINTER 1
 `cat $LEX_OUTPUT_ROOT.c`
 _ACEOF
-if ac_fn_c_try_compile "$LINENO"
-then :
+if ac_fn_c_try_link "$LINENO"; then :
   ac_cv_prog_lex_yytext_pointer=yes
 fi
-rm -f core conftest.err conftest.$ac_objext conftest.beam conftest.$ac_ext
+rm -f core conftest.err conftest.$ac_objext \
+    conftest$ac_exeext conftest.$ac_ext
+LIBS=$ac_save_LIBS
 
 fi
-{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $ac_cv_prog_lex_yytext_pointer" >&5
-printf "%s\n" "$ac_cv_prog_lex_yytext_pointer" >&6; }
+{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_prog_lex_yytext_pointer" >&5
+$as_echo "$ac_cv_prog_lex_yytext_pointer" >&6; }
 if test $ac_cv_prog_lex_yytext_pointer = yes; then
 
-printf "%s\n" "#define YYTEXT_POINTER 1" >>confdefs.h
-
-fi
+$as_echo "#define YYTEXT_POINTER 1" >>confdefs.h
 
 fi
 rm -f conftest.l $LEX_OUTPUT_ROOT.c
@@ -7161,32 +6575,32 @@ rm -f conftest.l $LEX_OUTPUT_ROOT.c
 fi
 if test "$LEX" != "" -a "$LEX" != ":"; then
 
-	{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for yylex_destroy" >&5
-printf %s "checking for yylex_destroy... " >&6; }
+	{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for yylex_destroy" >&5
+$as_echo_n "checking for yylex_destroy... " >&6; }
 	if echo %% | $LEX -t 2>&1 | grep yylex_destroy >/dev/null 2>&1; then
 
-printf "%s\n" "#define LEX_HAS_YYLEX_DESTROY 1" >>confdefs.h
+$as_echo "#define LEX_HAS_YYLEX_DESTROY 1" >>confdefs.h
 
-		{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: yes" >&5
-printf "%s\n" "yes" >&6; }
-	else { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: no" >&5
-printf "%s\n" "no" >&6; };
+		{ $as_echo "$as_me:${as_lineno-$LINENO}: result: yes" >&5
+$as_echo "yes" >&6; }
+	else { $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
+$as_echo "no" >&6; };
 		LEX=":"
 	fi
 
 fi
 if test "$LEX" != "" -a "$LEX" != ":"; then
 
-	{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for lex %option" >&5
-printf %s "checking for lex %option... " >&6; }
+	{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for lex %option" >&5
+$as_echo_n "checking for lex %option... " >&6; }
 	if cat <<EOF | $LEX -t 2>&1 | grep yy_delete_buffer >/dev/null 2>&1; then
 %option nounput
 %%
 EOF
-		{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: yes" >&5
-printf "%s\n" "yes" >&6; }
-	else { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: no" >&5
-printf "%s\n" "no" >&6; };
+		{ $as_echo "$as_me:${as_lineno-$LINENO}: result: yes" >&5
+$as_echo "yes" >&6; }
+	else { $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
+$as_echo "no" >&6; };
 		LEX=":"
 	fi
 
@@ -7195,12 +6609,11 @@ for ac_prog in 'bison -y' byacc
 do
   # Extract the first word of "$ac_prog", so it can be a program name with args.
 set dummy $ac_prog; ac_word=$2
-{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for $ac_word" >&5
-printf %s "checking for $ac_word... " >&6; }
-if test ${ac_cv_prog_YACC+y}
-then :
-  printf %s "(cached) " >&6
-else $as_nop
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for $ac_word" >&5
+$as_echo_n "checking for $ac_word... " >&6; }
+if ${ac_cv_prog_YACC+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
   if test -n "$YACC"; then
   ac_cv_prog_YACC="$YACC" # Let the user override the test.
 else
@@ -7208,15 +6621,11 @@ as_save_IFS=$IFS; IFS=$PATH_SEPARATOR
 for as_dir in $PATH
 do
   IFS=$as_save_IFS
-  case $as_dir in #(((
-    '') as_dir=./ ;;
-    */) ;;
-    *) as_dir=$as_dir/ ;;
-  esac
+  test -z "$as_dir" && as_dir=.
     for ac_exec_ext in '' $ac_executable_extensions; do
-  if as_fn_executable_p "$as_dir$ac_word$ac_exec_ext"; then
+  if as_fn_executable_p "$as_dir/$ac_word$ac_exec_ext"; then
     ac_cv_prog_YACC="$ac_prog"
-    printf "%s\n" "$as_me:${as_lineno-$LINENO}: found $as_dir$ac_word$ac_exec_ext" >&5
+    $as_echo "$as_me:${as_lineno-$LINENO}: found $as_dir/$ac_word$ac_exec_ext" >&5
     break 2
   fi
 done
@@ -7227,11 +6636,11 @@ fi
 fi
 YACC=$ac_cv_prog_YACC
 if test -n "$YACC"; then
-  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $YACC" >&5
-printf "%s\n" "$YACC" >&6; }
+  { $as_echo "$as_me:${as_lineno-$LINENO}: result: $YACC" >&5
+$as_echo "$YACC" >&6; }
 else
-  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: no" >&5
-printf "%s\n" "no" >&6; }
+  { $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
+$as_echo "no" >&6; }
 fi
 
 
@@ -7241,12 +6650,11 @@ test -n "$YACC" || YACC="yacc"
 
 # Extract the first word of "doxygen", so it can be a program name with args.
 set dummy doxygen; ac_word=$2
-{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for $ac_word" >&5
-printf %s "checking for $ac_word... " >&6; }
-if test ${ac_cv_prog_doxygen+y}
-then :
-  printf %s "(cached) " >&6
-else $as_nop
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for $ac_word" >&5
+$as_echo_n "checking for $ac_word... " >&6; }
+if ${ac_cv_prog_doxygen+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
   if test -n "$doxygen"; then
   ac_cv_prog_doxygen="$doxygen" # Let the user override the test.
 else
@@ -7254,15 +6662,11 @@ as_save_IFS=$IFS; IFS=$PATH_SEPARATOR
 for as_dir in $PATH
 do
   IFS=$as_save_IFS
-  case $as_dir in #(((
-    '') as_dir=./ ;;
-    */) ;;
-    *) as_dir=$as_dir/ ;;
-  esac
+  test -z "$as_dir" && as_dir=.
     for ac_exec_ext in '' $ac_executable_extensions; do
-  if as_fn_executable_p "$as_dir$ac_word$ac_exec_ext"; then
+  if as_fn_executable_p "$as_dir/$ac_word$ac_exec_ext"; then
     ac_cv_prog_doxygen="doxygen"
-    printf "%s\n" "$as_me:${as_lineno-$LINENO}: found $as_dir$ac_word$ac_exec_ext" >&5
+    $as_echo "$as_me:${as_lineno-$LINENO}: found $as_dir/$ac_word$ac_exec_ext" >&5
     break 2
   fi
 done
@@ -7273,23 +6677,22 @@ fi
 fi
 doxygen=$ac_cv_prog_doxygen
 if test -n "$doxygen"; then
-  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $doxygen" >&5
-printf "%s\n" "$doxygen" >&6; }
+  { $as_echo "$as_me:${as_lineno-$LINENO}: result: $doxygen" >&5
+$as_echo "$doxygen" >&6; }
 else
-  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: no" >&5
-printf "%s\n" "no" >&6; }
+  { $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
+$as_echo "no" >&6; }
 fi
 
 
 if test -n "$ac_tool_prefix"; then
   # Extract the first word of "${ac_tool_prefix}strip", so it can be a program name with args.
 set dummy ${ac_tool_prefix}strip; ac_word=$2
-{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for $ac_word" >&5
-printf %s "checking for $ac_word... " >&6; }
-if test ${ac_cv_prog_STRIP+y}
-then :
-  printf %s "(cached) " >&6
-else $as_nop
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for $ac_word" >&5
+$as_echo_n "checking for $ac_word... " >&6; }
+if ${ac_cv_prog_STRIP+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
   if test -n "$STRIP"; then
   ac_cv_prog_STRIP="$STRIP" # Let the user override the test.
 else
@@ -7297,15 +6700,11 @@ as_save_IFS=$IFS; IFS=$PATH_SEPARATOR
 for as_dir in $PATH
 do
   IFS=$as_save_IFS
-  case $as_dir in #(((
-    '') as_dir=./ ;;
-    */) ;;
-    *) as_dir=$as_dir/ ;;
-  esac
+  test -z "$as_dir" && as_dir=.
     for ac_exec_ext in '' $ac_executable_extensions; do
-  if as_fn_executable_p "$as_dir$ac_word$ac_exec_ext"; then
+  if as_fn_executable_p "$as_dir/$ac_word$ac_exec_ext"; then
     ac_cv_prog_STRIP="${ac_tool_prefix}strip"
-    printf "%s\n" "$as_me:${as_lineno-$LINENO}: found $as_dir$ac_word$ac_exec_ext" >&5
+    $as_echo "$as_me:${as_lineno-$LINENO}: found $as_dir/$ac_word$ac_exec_ext" >&5
     break 2
   fi
 done
@@ -7316,11 +6715,11 @@ fi
 fi
 STRIP=$ac_cv_prog_STRIP
 if test -n "$STRIP"; then
-  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $STRIP" >&5
-printf "%s\n" "$STRIP" >&6; }
+  { $as_echo "$as_me:${as_lineno-$LINENO}: result: $STRIP" >&5
+$as_echo "$STRIP" >&6; }
 else
-  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: no" >&5
-printf "%s\n" "no" >&6; }
+  { $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
+$as_echo "no" >&6; }
 fi
 
 
@@ -7329,12 +6728,11 @@ if test -z "$ac_cv_prog_STRIP"; then
   ac_ct_STRIP=$STRIP
   # Extract the first word of "strip", so it can be a program name with args.
 set dummy strip; ac_word=$2
-{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for $ac_word" >&5
-printf %s "checking for $ac_word... " >&6; }
-if test ${ac_cv_prog_ac_ct_STRIP+y}
-then :
-  printf %s "(cached) " >&6
-else $as_nop
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for $ac_word" >&5
+$as_echo_n "checking for $ac_word... " >&6; }
+if ${ac_cv_prog_ac_ct_STRIP+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
   if test -n "$ac_ct_STRIP"; then
   ac_cv_prog_ac_ct_STRIP="$ac_ct_STRIP" # Let the user override the test.
 else
@@ -7342,15 +6740,11 @@ as_save_IFS=$IFS; IFS=$PATH_SEPARATOR
 for as_dir in $PATH
 do
   IFS=$as_save_IFS
-  case $as_dir in #(((
-    '') as_dir=./ ;;
-    */) ;;
-    *) as_dir=$as_dir/ ;;
-  esac
+  test -z "$as_dir" && as_dir=.
     for ac_exec_ext in '' $ac_executable_extensions; do
-  if as_fn_executable_p "$as_dir$ac_word$ac_exec_ext"; then
+  if as_fn_executable_p "$as_dir/$ac_word$ac_exec_ext"; then
     ac_cv_prog_ac_ct_STRIP="strip"
-    printf "%s\n" "$as_me:${as_lineno-$LINENO}: found $as_dir$ac_word$ac_exec_ext" >&5
+    $as_echo "$as_me:${as_lineno-$LINENO}: found $as_dir/$ac_word$ac_exec_ext" >&5
     break 2
   fi
 done
@@ -7361,11 +6755,11 @@ fi
 fi
 ac_ct_STRIP=$ac_cv_prog_ac_ct_STRIP
 if test -n "$ac_ct_STRIP"; then
-  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $ac_ct_STRIP" >&5
-printf "%s\n" "$ac_ct_STRIP" >&6; }
+  { $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_ct_STRIP" >&5
+$as_echo "$ac_ct_STRIP" >&6; }
 else
-  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: no" >&5
-printf "%s\n" "no" >&6; }
+  { $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
+$as_echo "no" >&6; }
 fi
 
   if test "x$ac_ct_STRIP" = x; then
@@ -7373,8 +6767,8 @@ fi
   else
     case $cross_compiling:$ac_tool_warned in
 yes:)
-{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: WARNING: using cross tools not prefixed with host triplet" >&5
-printf "%s\n" "$as_me: WARNING: using cross tools not prefixed with host triplet" >&2;}
+{ $as_echo "$as_me:${as_lineno-$LINENO}: WARNING: using cross tools not prefixed with host triplet" >&5
+$as_echo "$as_me: WARNING: using cross tools not prefixed with host triplet" >&2;}
 ac_tool_warned=yes ;;
 esac
     STRIP=$ac_ct_STRIP
@@ -7383,30 +6777,55 @@ else
   STRIP="$ac_cv_prog_STRIP"
 fi
 
+ac_aux_dir=
+for ac_dir in "$srcdir" "$srcdir/.." "$srcdir/../.."; do
+  if test -f "$ac_dir/install-sh"; then
+    ac_aux_dir=$ac_dir
+    ac_install_sh="$ac_aux_dir/install-sh -c"
+    break
+  elif test -f "$ac_dir/install.sh"; then
+    ac_aux_dir=$ac_dir
+    ac_install_sh="$ac_aux_dir/install.sh -c"
+    break
+  elif test -f "$ac_dir/shtool"; then
+    ac_aux_dir=$ac_dir
+    ac_install_sh="$ac_aux_dir/shtool install -c"
+    break
+  fi
+done
+if test -z "$ac_aux_dir"; then
+  as_fn_error $? "cannot find install-sh, install.sh, or shtool in \"$srcdir\" \"$srcdir/..\" \"$srcdir/../..\"" "$LINENO" 5
+fi
+
+# These three variables are undocumented and unsupported,
+# and are intended to be withdrawn in a future Autoconf release.
+# They can cause serious problems if a builder's source tree is in a directory
+# whose full name contains unusual characters.
+ac_config_guess="$SHELL $ac_aux_dir/config.guess"  # Please don't use this var.
+ac_config_sub="$SHELL $ac_aux_dir/config.sub"  # Please don't use this var.
+ac_configure="$SHELL $ac_aux_dir/configure"  # Please don't use this var.
 
 
+# Make sure we can run config.sub.
+$SHELL "$ac_aux_dir/config.sub" sun4 >/dev/null 2>&1 ||
+  as_fn_error $? "cannot run $SHELL $ac_aux_dir/config.sub" "$LINENO" 5
 
-  # Make sure we can run config.sub.
-$SHELL "${ac_aux_dir}config.sub" sun4 >/dev/null 2>&1 ||
-  as_fn_error $? "cannot run $SHELL ${ac_aux_dir}config.sub" "$LINENO" 5
-
-{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking build system type" >&5
-printf %s "checking build system type... " >&6; }
-if test ${ac_cv_build+y}
-then :
-  printf %s "(cached) " >&6
-else $as_nop
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking build system type" >&5
+$as_echo_n "checking build system type... " >&6; }
+if ${ac_cv_build+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
   ac_build_alias=$build_alias
 test "x$ac_build_alias" = x &&
-  ac_build_alias=`$SHELL "${ac_aux_dir}config.guess"`
+  ac_build_alias=`$SHELL "$ac_aux_dir/config.guess"`
 test "x$ac_build_alias" = x &&
   as_fn_error $? "cannot guess build type; you must specify one" "$LINENO" 5
-ac_cv_build=`$SHELL "${ac_aux_dir}config.sub" $ac_build_alias` ||
-  as_fn_error $? "$SHELL ${ac_aux_dir}config.sub $ac_build_alias failed" "$LINENO" 5
+ac_cv_build=`$SHELL "$ac_aux_dir/config.sub" $ac_build_alias` ||
+  as_fn_error $? "$SHELL $ac_aux_dir/config.sub $ac_build_alias failed" "$LINENO" 5
 
 fi
-{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $ac_cv_build" >&5
-printf "%s\n" "$ac_cv_build" >&6; }
+{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_build" >&5
+$as_echo "$ac_cv_build" >&6; }
 case $ac_cv_build in
 *-*-*) ;;
 *) as_fn_error $? "invalid value of canonical build" "$LINENO" 5;;
@@ -7425,22 +6844,21 @@ IFS=$ac_save_IFS
 case $build_os in *\ *) build_os=`echo "$build_os" | sed 's/ /-/g'`;; esac
 
 
-{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking host system type" >&5
-printf %s "checking host system type... " >&6; }
-if test ${ac_cv_host+y}
-then :
-  printf %s "(cached) " >&6
-else $as_nop
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking host system type" >&5
+$as_echo_n "checking host system type... " >&6; }
+if ${ac_cv_host+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
   if test "x$host_alias" = x; then
   ac_cv_host=$ac_cv_build
 else
-  ac_cv_host=`$SHELL "${ac_aux_dir}config.sub" $host_alias` ||
-    as_fn_error $? "$SHELL ${ac_aux_dir}config.sub $host_alias failed" "$LINENO" 5
+  ac_cv_host=`$SHELL "$ac_aux_dir/config.sub" $host_alias` ||
+    as_fn_error $? "$SHELL $ac_aux_dir/config.sub $host_alias failed" "$LINENO" 5
 fi
 
 fi
-{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $ac_cv_host" >&5
-printf "%s\n" "$ac_cv_host" >&6; }
+{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_host" >&5
+$as_echo "$ac_cv_host" >&6; }
 case $ac_cv_host in
 *-*-*) ;;
 *) as_fn_error $? "invalid value of canonical host" "$LINENO" 5;;
@@ -7482,12 +6900,11 @@ fi
 if test -n "$ac_tool_prefix"; then
   # Extract the first word of "${ac_tool_prefix}ar", so it can be a program name with args.
 set dummy ${ac_tool_prefix}ar; ac_word=$2
-{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for $ac_word" >&5
-printf %s "checking for $ac_word... " >&6; }
-if test ${ac_cv_path_AR+y}
-then :
-  printf %s "(cached) " >&6
-else $as_nop
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for $ac_word" >&5
+$as_echo_n "checking for $ac_word... " >&6; }
+if ${ac_cv_path_AR+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
   case $AR in
   [\\/]* | ?:[\\/]*)
   ac_cv_path_AR="$AR" # Let the user override the test with a path.
@@ -7497,15 +6914,11 @@ else $as_nop
 for as_dir in $PATH
 do
   IFS=$as_save_IFS
-  case $as_dir in #(((
-    '') as_dir=./ ;;
-    */) ;;
-    *) as_dir=$as_dir/ ;;
-  esac
+  test -z "$as_dir" && as_dir=.
     for ac_exec_ext in '' $ac_executable_extensions; do
-  if as_fn_executable_p "$as_dir$ac_word$ac_exec_ext"; then
-    ac_cv_path_AR="$as_dir$ac_word$ac_exec_ext"
-    printf "%s\n" "$as_me:${as_lineno-$LINENO}: found $as_dir$ac_word$ac_exec_ext" >&5
+  if as_fn_executable_p "$as_dir/$ac_word$ac_exec_ext"; then
+    ac_cv_path_AR="$as_dir/$ac_word$ac_exec_ext"
+    $as_echo "$as_me:${as_lineno-$LINENO}: found $as_dir/$ac_word$ac_exec_ext" >&5
     break 2
   fi
 done
@@ -7517,11 +6930,11 @@ esac
 fi
 AR=$ac_cv_path_AR
 if test -n "$AR"; then
-  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $AR" >&5
-printf "%s\n" "$AR" >&6; }
+  { $as_echo "$as_me:${as_lineno-$LINENO}: result: $AR" >&5
+$as_echo "$AR" >&6; }
 else
-  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: no" >&5
-printf "%s\n" "no" >&6; }
+  { $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
+$as_echo "no" >&6; }
 fi
 
 
@@ -7530,12 +6943,11 @@ if test -z "$ac_cv_path_AR"; then
   ac_pt_AR=$AR
   # Extract the first word of "ar", so it can be a program name with args.
 set dummy ar; ac_word=$2
-{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for $ac_word" >&5
-printf %s "checking for $ac_word... " >&6; }
-if test ${ac_cv_path_ac_pt_AR+y}
-then :
-  printf %s "(cached) " >&6
-else $as_nop
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for $ac_word" >&5
+$as_echo_n "checking for $ac_word... " >&6; }
+if ${ac_cv_path_ac_pt_AR+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
   case $ac_pt_AR in
   [\\/]* | ?:[\\/]*)
   ac_cv_path_ac_pt_AR="$ac_pt_AR" # Let the user override the test with a path.
@@ -7545,15 +6957,11 @@ else $as_nop
 for as_dir in $PATH
 do
   IFS=$as_save_IFS
-  case $as_dir in #(((
-    '') as_dir=./ ;;
-    */) ;;
-    *) as_dir=$as_dir/ ;;
-  esac
+  test -z "$as_dir" && as_dir=.
     for ac_exec_ext in '' $ac_executable_extensions; do
-  if as_fn_executable_p "$as_dir$ac_word$ac_exec_ext"; then
-    ac_cv_path_ac_pt_AR="$as_dir$ac_word$ac_exec_ext"
-    printf "%s\n" "$as_me:${as_lineno-$LINENO}: found $as_dir$ac_word$ac_exec_ext" >&5
+  if as_fn_executable_p "$as_dir/$ac_word$ac_exec_ext"; then
+    ac_cv_path_ac_pt_AR="$as_dir/$ac_word$ac_exec_ext"
+    $as_echo "$as_me:${as_lineno-$LINENO}: found $as_dir/$ac_word$ac_exec_ext" >&5
     break 2
   fi
 done
@@ -7565,11 +6973,11 @@ esac
 fi
 ac_pt_AR=$ac_cv_path_ac_pt_AR
 if test -n "$ac_pt_AR"; then
-  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $ac_pt_AR" >&5
-printf "%s\n" "$ac_pt_AR" >&6; }
+  { $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_pt_AR" >&5
+$as_echo "$ac_pt_AR" >&6; }
 else
-  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: no" >&5
-printf "%s\n" "no" >&6; }
+  { $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
+$as_echo "no" >&6; }
 fi
 
   if test "x$ac_pt_AR" = x; then
@@ -7577,8 +6985,8 @@ fi
   else
     case $cross_compiling:$ac_tool_warned in
 yes:)
-{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: WARNING: using cross tools not prefixed with host triplet" >&5
-printf "%s\n" "$as_me: WARNING: using cross tools not prefixed with host triplet" >&2;}
+{ $as_echo "$as_me:${as_lineno-$LINENO}: WARNING: using cross tools not prefixed with host triplet" >&5
+$as_echo "$as_me: WARNING: using cross tools not prefixed with host triplet" >&2;}
 ac_tool_warned=yes ;;
 esac
     AR=$ac_pt_AR
@@ -7591,18 +6999,16 @@ if test $AR = false; then
 	as_fn_error $? "Cannot find 'ar', please extend PATH to include it" "$LINENO" 5
 fi
 
-
 case `pwd` in
   *\ * | *\	*)
-    { printf "%s\n" "$as_me:${as_lineno-$LINENO}: WARNING: Libtool does not cope well with whitespace in \`pwd\`" >&5
-printf "%s\n" "$as_me: WARNING: Libtool does not cope well with whitespace in \`pwd\`" >&2;} ;;
+    { $as_echo "$as_me:${as_lineno-$LINENO}: WARNING: Libtool does not cope well with whitespace in \`pwd\`" >&5
+$as_echo "$as_me: WARNING: Libtool does not cope well with whitespace in \`pwd\`" >&2;} ;;
 esac
 
 
 
 macro_version='2.4.6'
 macro_revision='2.4.6'
-
 
 
 
@@ -7639,8 +7045,8 @@ ECHO='\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\
 ECHO=$ECHO$ECHO$ECHO$ECHO$ECHO
 ECHO=$ECHO$ECHO$ECHO$ECHO$ECHO$ECHO
 
-{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking how to print strings" >&5
-printf %s "checking how to print strings... " >&6; }
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking how to print strings" >&5
+$as_echo_n "checking how to print strings... " >&6; }
 # Test print first, because it will be a builtin if present.
 if test "X`( print -r -- -n ) 2>/dev/null`" = X-n && \
    test "X`print -r -- $ECHO 2>/dev/null`" = "X$ECHO"; then
@@ -7666,12 +7072,12 @@ func_echo_all ()
 }
 
 case $ECHO in
-  printf*) { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: printf" >&5
-printf "%s\n" "printf" >&6; } ;;
-  print*) { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: print -r" >&5
-printf "%s\n" "print -r" >&6; } ;;
-  *) { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: cat" >&5
-printf "%s\n" "cat" >&6; } ;;
+  printf*) { $as_echo "$as_me:${as_lineno-$LINENO}: result: printf" >&5
+$as_echo "printf" >&6; } ;;
+  print*) { $as_echo "$as_me:${as_lineno-$LINENO}: result: print -r" >&5
+$as_echo "print -r" >&6; } ;;
+  *) { $as_echo "$as_me:${as_lineno-$LINENO}: result: cat" >&5
+$as_echo "cat" >&6; } ;;
 esac
 
 
@@ -7687,12 +7093,11 @@ esac
 
 
 
-{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for a sed that does not truncate output" >&5
-printf %s "checking for a sed that does not truncate output... " >&6; }
-if test ${ac_cv_path_SED+y}
-then :
-  printf %s "(cached) " >&6
-else $as_nop
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for a sed that does not truncate output" >&5
+$as_echo_n "checking for a sed that does not truncate output... " >&6; }
+if ${ac_cv_path_SED+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
             ac_script=s/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb/
      for ac_i in 1 2 3 4 5 6 7; do
        ac_script="$ac_script$as_nl$ac_script"
@@ -7706,15 +7111,10 @@ else $as_nop
 for as_dir in $PATH
 do
   IFS=$as_save_IFS
-  case $as_dir in #(((
-    '') as_dir=./ ;;
-    */) ;;
-    *) as_dir=$as_dir/ ;;
-  esac
-    for ac_prog in sed gsed
-   do
+  test -z "$as_dir" && as_dir=.
+    for ac_prog in sed gsed; do
     for ac_exec_ext in '' $ac_executable_extensions; do
-      ac_path_SED="$as_dir$ac_prog$ac_exec_ext"
+      ac_path_SED="$as_dir/$ac_prog$ac_exec_ext"
       as_fn_executable_p "$ac_path_SED" || continue
 # Check for GNU ac_path_SED and select it if it is found.
   # Check for GNU $ac_path_SED
@@ -7723,13 +7123,13 @@ case `"$ac_path_SED" --version 2>&1` in
   ac_cv_path_SED="$ac_path_SED" ac_path_SED_found=:;;
 *)
   ac_count=0
-  printf %s 0123456789 >"conftest.in"
+  $as_echo_n 0123456789 >"conftest.in"
   while :
   do
     cat "conftest.in" "conftest.in" >"conftest.tmp"
     mv "conftest.tmp" "conftest.in"
     cp "conftest.in" "conftest.nl"
-    printf "%s\n" '' >> "conftest.nl"
+    $as_echo '' >> "conftest.nl"
     "$ac_path_SED" -f conftest.sed < "conftest.nl" >"conftest.out" 2>/dev/null || break
     diff "conftest.out" "conftest.nl" >/dev/null 2>&1 || break
     as_fn_arith $ac_count + 1 && ac_count=$as_val
@@ -7757,8 +7157,8 @@ else
 fi
 
 fi
-{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $ac_cv_path_SED" >&5
-printf "%s\n" "$ac_cv_path_SED" >&6; }
+{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_path_SED" >&5
+$as_echo "$ac_cv_path_SED" >&6; }
  SED="$ac_cv_path_SED"
   rm -f conftest.sed
 
@@ -7775,154 +7175,11 @@ Xsed="$SED -e 1s/^X//"
 
 
 
-{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for grep that handles long lines and -e" >&5
-printf %s "checking for grep that handles long lines and -e... " >&6; }
-if test ${ac_cv_path_GREP+y}
-then :
-  printf %s "(cached) " >&6
-else $as_nop
-  if test -z "$GREP"; then
-  ac_path_GREP_found=false
-  # Loop through the user's path and test for each of PROGNAME-LIST
-  as_save_IFS=$IFS; IFS=$PATH_SEPARATOR
-for as_dir in $PATH$PATH_SEPARATOR/usr/xpg4/bin
-do
-  IFS=$as_save_IFS
-  case $as_dir in #(((
-    '') as_dir=./ ;;
-    */) ;;
-    *) as_dir=$as_dir/ ;;
-  esac
-    for ac_prog in grep ggrep
-   do
-    for ac_exec_ext in '' $ac_executable_extensions; do
-      ac_path_GREP="$as_dir$ac_prog$ac_exec_ext"
-      as_fn_executable_p "$ac_path_GREP" || continue
-# Check for GNU ac_path_GREP and select it if it is found.
-  # Check for GNU $ac_path_GREP
-case `"$ac_path_GREP" --version 2>&1` in
-*GNU*)
-  ac_cv_path_GREP="$ac_path_GREP" ac_path_GREP_found=:;;
-*)
-  ac_count=0
-  printf %s 0123456789 >"conftest.in"
-  while :
-  do
-    cat "conftest.in" "conftest.in" >"conftest.tmp"
-    mv "conftest.tmp" "conftest.in"
-    cp "conftest.in" "conftest.nl"
-    printf "%s\n" 'GREP' >> "conftest.nl"
-    "$ac_path_GREP" -e 'GREP$' -e '-(cannot match)-' < "conftest.nl" >"conftest.out" 2>/dev/null || break
-    diff "conftest.out" "conftest.nl" >/dev/null 2>&1 || break
-    as_fn_arith $ac_count + 1 && ac_count=$as_val
-    if test $ac_count -gt ${ac_path_GREP_max-0}; then
-      # Best one so far, save it but keep looking for a better one
-      ac_cv_path_GREP="$ac_path_GREP"
-      ac_path_GREP_max=$ac_count
-    fi
-    # 10*(2^10) chars as input seems more than enough
-    test $ac_count -gt 10 && break
-  done
-  rm -f conftest.in conftest.tmp conftest.nl conftest.out;;
-esac
-
-      $ac_path_GREP_found && break 3
-    done
-  done
-  done
-IFS=$as_save_IFS
-  if test -z "$ac_cv_path_GREP"; then
-    as_fn_error $? "no acceptable grep could be found in $PATH$PATH_SEPARATOR/usr/xpg4/bin" "$LINENO" 5
-  fi
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for fgrep" >&5
+$as_echo_n "checking for fgrep... " >&6; }
+if ${ac_cv_path_FGREP+:} false; then :
+  $as_echo_n "(cached) " >&6
 else
-  ac_cv_path_GREP=$GREP
-fi
-
-fi
-{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $ac_cv_path_GREP" >&5
-printf "%s\n" "$ac_cv_path_GREP" >&6; }
- GREP="$ac_cv_path_GREP"
-
-
-{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for egrep" >&5
-printf %s "checking for egrep... " >&6; }
-if test ${ac_cv_path_EGREP+y}
-then :
-  printf %s "(cached) " >&6
-else $as_nop
-  if echo a | $GREP -E '(a|b)' >/dev/null 2>&1
-   then ac_cv_path_EGREP="$GREP -E"
-   else
-     if test -z "$EGREP"; then
-  ac_path_EGREP_found=false
-  # Loop through the user's path and test for each of PROGNAME-LIST
-  as_save_IFS=$IFS; IFS=$PATH_SEPARATOR
-for as_dir in $PATH$PATH_SEPARATOR/usr/xpg4/bin
-do
-  IFS=$as_save_IFS
-  case $as_dir in #(((
-    '') as_dir=./ ;;
-    */) ;;
-    *) as_dir=$as_dir/ ;;
-  esac
-    for ac_prog in egrep
-   do
-    for ac_exec_ext in '' $ac_executable_extensions; do
-      ac_path_EGREP="$as_dir$ac_prog$ac_exec_ext"
-      as_fn_executable_p "$ac_path_EGREP" || continue
-# Check for GNU ac_path_EGREP and select it if it is found.
-  # Check for GNU $ac_path_EGREP
-case `"$ac_path_EGREP" --version 2>&1` in
-*GNU*)
-  ac_cv_path_EGREP="$ac_path_EGREP" ac_path_EGREP_found=:;;
-*)
-  ac_count=0
-  printf %s 0123456789 >"conftest.in"
-  while :
-  do
-    cat "conftest.in" "conftest.in" >"conftest.tmp"
-    mv "conftest.tmp" "conftest.in"
-    cp "conftest.in" "conftest.nl"
-    printf "%s\n" 'EGREP' >> "conftest.nl"
-    "$ac_path_EGREP" 'EGREP$' < "conftest.nl" >"conftest.out" 2>/dev/null || break
-    diff "conftest.out" "conftest.nl" >/dev/null 2>&1 || break
-    as_fn_arith $ac_count + 1 && ac_count=$as_val
-    if test $ac_count -gt ${ac_path_EGREP_max-0}; then
-      # Best one so far, save it but keep looking for a better one
-      ac_cv_path_EGREP="$ac_path_EGREP"
-      ac_path_EGREP_max=$ac_count
-    fi
-    # 10*(2^10) chars as input seems more than enough
-    test $ac_count -gt 10 && break
-  done
-  rm -f conftest.in conftest.tmp conftest.nl conftest.out;;
-esac
-
-      $ac_path_EGREP_found && break 3
-    done
-  done
-  done
-IFS=$as_save_IFS
-  if test -z "$ac_cv_path_EGREP"; then
-    as_fn_error $? "no acceptable egrep could be found in $PATH$PATH_SEPARATOR/usr/xpg4/bin" "$LINENO" 5
-  fi
-else
-  ac_cv_path_EGREP=$EGREP
-fi
-
-   fi
-fi
-{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $ac_cv_path_EGREP" >&5
-printf "%s\n" "$ac_cv_path_EGREP" >&6; }
- EGREP="$ac_cv_path_EGREP"
-
-
-{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for fgrep" >&5
-printf %s "checking for fgrep... " >&6; }
-if test ${ac_cv_path_FGREP+y}
-then :
-  printf %s "(cached) " >&6
-else $as_nop
   if echo 'ab*c' | $GREP -F 'ab*c' >/dev/null 2>&1
    then ac_cv_path_FGREP="$GREP -F"
    else
@@ -7933,15 +7190,10 @@ else $as_nop
 for as_dir in $PATH$PATH_SEPARATOR/usr/xpg4/bin
 do
   IFS=$as_save_IFS
-  case $as_dir in #(((
-    '') as_dir=./ ;;
-    */) ;;
-    *) as_dir=$as_dir/ ;;
-  esac
-    for ac_prog in fgrep
-   do
+  test -z "$as_dir" && as_dir=.
+    for ac_prog in fgrep; do
     for ac_exec_ext in '' $ac_executable_extensions; do
-      ac_path_FGREP="$as_dir$ac_prog$ac_exec_ext"
+      ac_path_FGREP="$as_dir/$ac_prog$ac_exec_ext"
       as_fn_executable_p "$ac_path_FGREP" || continue
 # Check for GNU ac_path_FGREP and select it if it is found.
   # Check for GNU $ac_path_FGREP
@@ -7950,13 +7202,13 @@ case `"$ac_path_FGREP" --version 2>&1` in
   ac_cv_path_FGREP="$ac_path_FGREP" ac_path_FGREP_found=:;;
 *)
   ac_count=0
-  printf %s 0123456789 >"conftest.in"
+  $as_echo_n 0123456789 >"conftest.in"
   while :
   do
     cat "conftest.in" "conftest.in" >"conftest.tmp"
     mv "conftest.tmp" "conftest.in"
     cp "conftest.in" "conftest.nl"
-    printf "%s\n" 'FGREP' >> "conftest.nl"
+    $as_echo 'FGREP' >> "conftest.nl"
     "$ac_path_FGREP" FGREP < "conftest.nl" >"conftest.out" 2>/dev/null || break
     diff "conftest.out" "conftest.nl" >/dev/null 2>&1 || break
     as_fn_arith $ac_count + 1 && ac_count=$as_val
@@ -7985,8 +7237,8 @@ fi
 
    fi
 fi
-{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $ac_cv_path_FGREP" >&5
-printf "%s\n" "$ac_cv_path_FGREP" >&6; }
+{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_path_FGREP" >&5
+$as_echo "$ac_cv_path_FGREP" >&6; }
  FGREP="$ac_cv_path_FGREP"
 
 
@@ -8011,18 +7263,17 @@ test -z "$GREP" && GREP=grep
 
 
 # Check whether --with-gnu-ld was given.
-if test ${with_gnu_ld+y}
-then :
+if test "${with_gnu_ld+set}" = set; then :
   withval=$with_gnu_ld; test no = "$withval" || with_gnu_ld=yes
-else $as_nop
+else
   with_gnu_ld=no
 fi
 
 ac_prog=ld
 if test yes = "$GCC"; then
   # Check if gcc -print-prog-name=ld gives a path.
-  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for ld used by $CC" >&5
-printf %s "checking for ld used by $CC... " >&6; }
+  { $as_echo "$as_me:${as_lineno-$LINENO}: checking for ld used by $CC" >&5
+$as_echo_n "checking for ld used by $CC... " >&6; }
   case $host in
   *-*-mingw*)
     # gcc leaves a trailing carriage return, which upsets mingw
@@ -8051,16 +7302,15 @@ printf %s "checking for ld used by $CC... " >&6; }
     ;;
   esac
 elif test yes = "$with_gnu_ld"; then
-  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for GNU ld" >&5
-printf %s "checking for GNU ld... " >&6; }
+  { $as_echo "$as_me:${as_lineno-$LINENO}: checking for GNU ld" >&5
+$as_echo_n "checking for GNU ld... " >&6; }
 else
-  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for non-GNU ld" >&5
-printf %s "checking for non-GNU ld... " >&6; }
+  { $as_echo "$as_me:${as_lineno-$LINENO}: checking for non-GNU ld" >&5
+$as_echo_n "checking for non-GNU ld... " >&6; }
 fi
-if test ${lt_cv_path_LD+y}
-then :
-  printf %s "(cached) " >&6
-else $as_nop
+if ${lt_cv_path_LD+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
   if test -z "$LD"; then
   lt_save_ifs=$IFS; IFS=$PATH_SEPARATOR
   for ac_dir in $PATH; do
@@ -8089,19 +7339,18 @@ fi
 
 LD=$lt_cv_path_LD
 if test -n "$LD"; then
-  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $LD" >&5
-printf "%s\n" "$LD" >&6; }
+  { $as_echo "$as_me:${as_lineno-$LINENO}: result: $LD" >&5
+$as_echo "$LD" >&6; }
 else
-  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: no" >&5
-printf "%s\n" "no" >&6; }
+  { $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
+$as_echo "no" >&6; }
 fi
 test -z "$LD" && as_fn_error $? "no acceptable ld found in \$PATH" "$LINENO" 5
-{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking if the linker ($LD) is GNU ld" >&5
-printf %s "checking if the linker ($LD) is GNU ld... " >&6; }
-if test ${lt_cv_prog_gnu_ld+y}
-then :
-  printf %s "(cached) " >&6
-else $as_nop
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking if the linker ($LD) is GNU ld" >&5
+$as_echo_n "checking if the linker ($LD) is GNU ld... " >&6; }
+if ${lt_cv_prog_gnu_ld+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
   # I'd rather use --version here, but apparently some GNU lds only accept -v.
 case `$LD -v 2>&1 </dev/null` in
 *GNU* | *'with BFD'*)
@@ -8112,8 +7361,8 @@ case `$LD -v 2>&1 </dev/null` in
   ;;
 esac
 fi
-{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $lt_cv_prog_gnu_ld" >&5
-printf "%s\n" "$lt_cv_prog_gnu_ld" >&6; }
+{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $lt_cv_prog_gnu_ld" >&5
+$as_echo "$lt_cv_prog_gnu_ld" >&6; }
 with_gnu_ld=$lt_cv_prog_gnu_ld
 
 
@@ -8124,12 +7373,11 @@ with_gnu_ld=$lt_cv_prog_gnu_ld
 
 
 
-{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for BSD- or MS-compatible name lister (nm)" >&5
-printf %s "checking for BSD- or MS-compatible name lister (nm)... " >&6; }
-if test ${lt_cv_path_NM+y}
-then :
-  printf %s "(cached) " >&6
-else $as_nop
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for BSD- or MS-compatible name lister (nm)" >&5
+$as_echo_n "checking for BSD- or MS-compatible name lister (nm)... " >&6; }
+if ${lt_cv_path_NM+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
   if test -n "$NM"; then
   # Let the user override the test.
   lt_cv_path_NM=$NM
@@ -8179,8 +7427,8 @@ else
   : ${lt_cv_path_NM=no}
 fi
 fi
-{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $lt_cv_path_NM" >&5
-printf "%s\n" "$lt_cv_path_NM" >&6; }
+{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $lt_cv_path_NM" >&5
+$as_echo "$lt_cv_path_NM" >&6; }
 if test no != "$lt_cv_path_NM"; then
   NM=$lt_cv_path_NM
 else
@@ -8193,12 +7441,11 @@ else
   do
     # Extract the first word of "$ac_tool_prefix$ac_prog", so it can be a program name with args.
 set dummy $ac_tool_prefix$ac_prog; ac_word=$2
-{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for $ac_word" >&5
-printf %s "checking for $ac_word... " >&6; }
-if test ${ac_cv_prog_DUMPBIN+y}
-then :
-  printf %s "(cached) " >&6
-else $as_nop
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for $ac_word" >&5
+$as_echo_n "checking for $ac_word... " >&6; }
+if ${ac_cv_prog_DUMPBIN+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
   if test -n "$DUMPBIN"; then
   ac_cv_prog_DUMPBIN="$DUMPBIN" # Let the user override the test.
 else
@@ -8206,15 +7453,11 @@ as_save_IFS=$IFS; IFS=$PATH_SEPARATOR
 for as_dir in $PATH
 do
   IFS=$as_save_IFS
-  case $as_dir in #(((
-    '') as_dir=./ ;;
-    */) ;;
-    *) as_dir=$as_dir/ ;;
-  esac
+  test -z "$as_dir" && as_dir=.
     for ac_exec_ext in '' $ac_executable_extensions; do
-  if as_fn_executable_p "$as_dir$ac_word$ac_exec_ext"; then
+  if as_fn_executable_p "$as_dir/$ac_word$ac_exec_ext"; then
     ac_cv_prog_DUMPBIN="$ac_tool_prefix$ac_prog"
-    printf "%s\n" "$as_me:${as_lineno-$LINENO}: found $as_dir$ac_word$ac_exec_ext" >&5
+    $as_echo "$as_me:${as_lineno-$LINENO}: found $as_dir/$ac_word$ac_exec_ext" >&5
     break 2
   fi
 done
@@ -8225,11 +7468,11 @@ fi
 fi
 DUMPBIN=$ac_cv_prog_DUMPBIN
 if test -n "$DUMPBIN"; then
-  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $DUMPBIN" >&5
-printf "%s\n" "$DUMPBIN" >&6; }
+  { $as_echo "$as_me:${as_lineno-$LINENO}: result: $DUMPBIN" >&5
+$as_echo "$DUMPBIN" >&6; }
 else
-  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: no" >&5
-printf "%s\n" "no" >&6; }
+  { $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
+$as_echo "no" >&6; }
 fi
 
 
@@ -8242,12 +7485,11 @@ if test -z "$DUMPBIN"; then
 do
   # Extract the first word of "$ac_prog", so it can be a program name with args.
 set dummy $ac_prog; ac_word=$2
-{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for $ac_word" >&5
-printf %s "checking for $ac_word... " >&6; }
-if test ${ac_cv_prog_ac_ct_DUMPBIN+y}
-then :
-  printf %s "(cached) " >&6
-else $as_nop
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for $ac_word" >&5
+$as_echo_n "checking for $ac_word... " >&6; }
+if ${ac_cv_prog_ac_ct_DUMPBIN+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
   if test -n "$ac_ct_DUMPBIN"; then
   ac_cv_prog_ac_ct_DUMPBIN="$ac_ct_DUMPBIN" # Let the user override the test.
 else
@@ -8255,15 +7497,11 @@ as_save_IFS=$IFS; IFS=$PATH_SEPARATOR
 for as_dir in $PATH
 do
   IFS=$as_save_IFS
-  case $as_dir in #(((
-    '') as_dir=./ ;;
-    */) ;;
-    *) as_dir=$as_dir/ ;;
-  esac
+  test -z "$as_dir" && as_dir=.
     for ac_exec_ext in '' $ac_executable_extensions; do
-  if as_fn_executable_p "$as_dir$ac_word$ac_exec_ext"; then
+  if as_fn_executable_p "$as_dir/$ac_word$ac_exec_ext"; then
     ac_cv_prog_ac_ct_DUMPBIN="$ac_prog"
-    printf "%s\n" "$as_me:${as_lineno-$LINENO}: found $as_dir$ac_word$ac_exec_ext" >&5
+    $as_echo "$as_me:${as_lineno-$LINENO}: found $as_dir/$ac_word$ac_exec_ext" >&5
     break 2
   fi
 done
@@ -8274,11 +7512,11 @@ fi
 fi
 ac_ct_DUMPBIN=$ac_cv_prog_ac_ct_DUMPBIN
 if test -n "$ac_ct_DUMPBIN"; then
-  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $ac_ct_DUMPBIN" >&5
-printf "%s\n" "$ac_ct_DUMPBIN" >&6; }
+  { $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_ct_DUMPBIN" >&5
+$as_echo "$ac_ct_DUMPBIN" >&6; }
 else
-  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: no" >&5
-printf "%s\n" "no" >&6; }
+  { $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
+$as_echo "no" >&6; }
 fi
 
 
@@ -8290,8 +7528,8 @@ done
   else
     case $cross_compiling:$ac_tool_warned in
 yes:)
-{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: WARNING: using cross tools not prefixed with host triplet" >&5
-printf "%s\n" "$as_me: WARNING: using cross tools not prefixed with host triplet" >&2;}
+{ $as_echo "$as_me:${as_lineno-$LINENO}: WARNING: using cross tools not prefixed with host triplet" >&5
+$as_echo "$as_me: WARNING: using cross tools not prefixed with host triplet" >&2;}
 ac_tool_warned=yes ;;
 esac
     DUMPBIN=$ac_ct_DUMPBIN
@@ -8319,12 +7557,11 @@ test -z "$NM" && NM=nm
 
 
 
-{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking the name lister ($NM) interface" >&5
-printf %s "checking the name lister ($NM) interface... " >&6; }
-if test ${lt_cv_nm_interface+y}
-then :
-  printf %s "(cached) " >&6
-else $as_nop
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking the name lister ($NM) interface" >&5
+$as_echo_n "checking the name lister ($NM) interface... " >&6; }
+if ${lt_cv_nm_interface+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
   lt_cv_nm_interface="BSD nm"
   echo "int some_variable = 0;" > conftest.$ac_ext
   (eval echo "\"\$as_me:$LINENO: $ac_compile\"" >&5)
@@ -8340,27 +7577,26 @@ else $as_nop
   fi
   rm -f conftest*
 fi
-{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $lt_cv_nm_interface" >&5
-printf "%s\n" "$lt_cv_nm_interface" >&6; }
+{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $lt_cv_nm_interface" >&5
+$as_echo "$lt_cv_nm_interface" >&6; }
 
-{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking whether ln -s works" >&5
-printf %s "checking whether ln -s works... " >&6; }
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking whether ln -s works" >&5
+$as_echo_n "checking whether ln -s works... " >&6; }
 LN_S=$as_ln_s
 if test "$LN_S" = "ln -s"; then
-  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: yes" >&5
-printf "%s\n" "yes" >&6; }
+  { $as_echo "$as_me:${as_lineno-$LINENO}: result: yes" >&5
+$as_echo "yes" >&6; }
 else
-  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: no, using $LN_S" >&5
-printf "%s\n" "no, using $LN_S" >&6; }
+  { $as_echo "$as_me:${as_lineno-$LINENO}: result: no, using $LN_S" >&5
+$as_echo "no, using $LN_S" >&6; }
 fi
 
 # find the maximum length of command line arguments
-{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking the maximum length of command line arguments" >&5
-printf %s "checking the maximum length of command line arguments... " >&6; }
-if test ${lt_cv_sys_max_cmd_len+y}
-then :
-  printf %s "(cached) " >&6
-else $as_nop
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking the maximum length of command line arguments" >&5
+$as_echo_n "checking the maximum length of command line arguments... " >&6; }
+if ${lt_cv_sys_max_cmd_len+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
     i=0
   teststring=ABCD
 
@@ -8487,11 +7723,11 @@ else $as_nop
 fi
 
 if test -n "$lt_cv_sys_max_cmd_len"; then
-  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $lt_cv_sys_max_cmd_len" >&5
-printf "%s\n" "$lt_cv_sys_max_cmd_len" >&6; }
+  { $as_echo "$as_me:${as_lineno-$LINENO}: result: $lt_cv_sys_max_cmd_len" >&5
+$as_echo "$lt_cv_sys_max_cmd_len" >&6; }
 else
-  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: none" >&5
-printf "%s\n" "none" >&6; }
+  { $as_echo "$as_me:${as_lineno-$LINENO}: result: none" >&5
+$as_echo "none" >&6; }
 fi
 max_cmd_len=$lt_cv_sys_max_cmd_len
 
@@ -8535,12 +7771,11 @@ esac
 
 
 
-{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking how to convert $build file names to $host format" >&5
-printf %s "checking how to convert $build file names to $host format... " >&6; }
-if test ${lt_cv_to_host_file_cmd+y}
-then :
-  printf %s "(cached) " >&6
-else $as_nop
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking how to convert $build file names to $host format" >&5
+$as_echo_n "checking how to convert $build file names to $host format... " >&6; }
+if ${lt_cv_to_host_file_cmd+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
   case $host in
   *-*-mingw* )
     case $build in
@@ -8576,19 +7811,18 @@ esac
 fi
 
 to_host_file_cmd=$lt_cv_to_host_file_cmd
-{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $lt_cv_to_host_file_cmd" >&5
-printf "%s\n" "$lt_cv_to_host_file_cmd" >&6; }
+{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $lt_cv_to_host_file_cmd" >&5
+$as_echo "$lt_cv_to_host_file_cmd" >&6; }
 
 
 
 
 
-{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking how to convert $build file names to toolchain format" >&5
-printf %s "checking how to convert $build file names to toolchain format... " >&6; }
-if test ${lt_cv_to_tool_file_cmd+y}
-then :
-  printf %s "(cached) " >&6
-else $as_nop
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking how to convert $build file names to toolchain format" >&5
+$as_echo_n "checking how to convert $build file names to toolchain format... " >&6; }
+if ${lt_cv_to_tool_file_cmd+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
   #assume ordinary cross tools, or native build.
 lt_cv_to_tool_file_cmd=func_convert_file_noop
 case $host in
@@ -8604,23 +7838,22 @@ esac
 fi
 
 to_tool_file_cmd=$lt_cv_to_tool_file_cmd
-{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $lt_cv_to_tool_file_cmd" >&5
-printf "%s\n" "$lt_cv_to_tool_file_cmd" >&6; }
+{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $lt_cv_to_tool_file_cmd" >&5
+$as_echo "$lt_cv_to_tool_file_cmd" >&6; }
 
 
 
 
 
-{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for $LD option to reload object files" >&5
-printf %s "checking for $LD option to reload object files... " >&6; }
-if test ${lt_cv_ld_reload_flag+y}
-then :
-  printf %s "(cached) " >&6
-else $as_nop
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for $LD option to reload object files" >&5
+$as_echo_n "checking for $LD option to reload object files... " >&6; }
+if ${lt_cv_ld_reload_flag+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
   lt_cv_ld_reload_flag='-r'
 fi
-{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $lt_cv_ld_reload_flag" >&5
-printf "%s\n" "$lt_cv_ld_reload_flag" >&6; }
+{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $lt_cv_ld_reload_flag" >&5
+$as_echo "$lt_cv_ld_reload_flag" >&6; }
 reload_flag=$lt_cv_ld_reload_flag
 case $reload_flag in
 "" | " "*) ;;
@@ -8653,12 +7886,11 @@ esac
 if test -n "$ac_tool_prefix"; then
   # Extract the first word of "${ac_tool_prefix}objdump", so it can be a program name with args.
 set dummy ${ac_tool_prefix}objdump; ac_word=$2
-{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for $ac_word" >&5
-printf %s "checking for $ac_word... " >&6; }
-if test ${ac_cv_prog_OBJDUMP+y}
-then :
-  printf %s "(cached) " >&6
-else $as_nop
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for $ac_word" >&5
+$as_echo_n "checking for $ac_word... " >&6; }
+if ${ac_cv_prog_OBJDUMP+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
   if test -n "$OBJDUMP"; then
   ac_cv_prog_OBJDUMP="$OBJDUMP" # Let the user override the test.
 else
@@ -8666,15 +7898,11 @@ as_save_IFS=$IFS; IFS=$PATH_SEPARATOR
 for as_dir in $PATH
 do
   IFS=$as_save_IFS
-  case $as_dir in #(((
-    '') as_dir=./ ;;
-    */) ;;
-    *) as_dir=$as_dir/ ;;
-  esac
+  test -z "$as_dir" && as_dir=.
     for ac_exec_ext in '' $ac_executable_extensions; do
-  if as_fn_executable_p "$as_dir$ac_word$ac_exec_ext"; then
+  if as_fn_executable_p "$as_dir/$ac_word$ac_exec_ext"; then
     ac_cv_prog_OBJDUMP="${ac_tool_prefix}objdump"
-    printf "%s\n" "$as_me:${as_lineno-$LINENO}: found $as_dir$ac_word$ac_exec_ext" >&5
+    $as_echo "$as_me:${as_lineno-$LINENO}: found $as_dir/$ac_word$ac_exec_ext" >&5
     break 2
   fi
 done
@@ -8685,11 +7913,11 @@ fi
 fi
 OBJDUMP=$ac_cv_prog_OBJDUMP
 if test -n "$OBJDUMP"; then
-  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $OBJDUMP" >&5
-printf "%s\n" "$OBJDUMP" >&6; }
+  { $as_echo "$as_me:${as_lineno-$LINENO}: result: $OBJDUMP" >&5
+$as_echo "$OBJDUMP" >&6; }
 else
-  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: no" >&5
-printf "%s\n" "no" >&6; }
+  { $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
+$as_echo "no" >&6; }
 fi
 
 
@@ -8698,12 +7926,11 @@ if test -z "$ac_cv_prog_OBJDUMP"; then
   ac_ct_OBJDUMP=$OBJDUMP
   # Extract the first word of "objdump", so it can be a program name with args.
 set dummy objdump; ac_word=$2
-{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for $ac_word" >&5
-printf %s "checking for $ac_word... " >&6; }
-if test ${ac_cv_prog_ac_ct_OBJDUMP+y}
-then :
-  printf %s "(cached) " >&6
-else $as_nop
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for $ac_word" >&5
+$as_echo_n "checking for $ac_word... " >&6; }
+if ${ac_cv_prog_ac_ct_OBJDUMP+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
   if test -n "$ac_ct_OBJDUMP"; then
   ac_cv_prog_ac_ct_OBJDUMP="$ac_ct_OBJDUMP" # Let the user override the test.
 else
@@ -8711,15 +7938,11 @@ as_save_IFS=$IFS; IFS=$PATH_SEPARATOR
 for as_dir in $PATH
 do
   IFS=$as_save_IFS
-  case $as_dir in #(((
-    '') as_dir=./ ;;
-    */) ;;
-    *) as_dir=$as_dir/ ;;
-  esac
+  test -z "$as_dir" && as_dir=.
     for ac_exec_ext in '' $ac_executable_extensions; do
-  if as_fn_executable_p "$as_dir$ac_word$ac_exec_ext"; then
+  if as_fn_executable_p "$as_dir/$ac_word$ac_exec_ext"; then
     ac_cv_prog_ac_ct_OBJDUMP="objdump"
-    printf "%s\n" "$as_me:${as_lineno-$LINENO}: found $as_dir$ac_word$ac_exec_ext" >&5
+    $as_echo "$as_me:${as_lineno-$LINENO}: found $as_dir/$ac_word$ac_exec_ext" >&5
     break 2
   fi
 done
@@ -8730,11 +7953,11 @@ fi
 fi
 ac_ct_OBJDUMP=$ac_cv_prog_ac_ct_OBJDUMP
 if test -n "$ac_ct_OBJDUMP"; then
-  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $ac_ct_OBJDUMP" >&5
-printf "%s\n" "$ac_ct_OBJDUMP" >&6; }
+  { $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_ct_OBJDUMP" >&5
+$as_echo "$ac_ct_OBJDUMP" >&6; }
 else
-  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: no" >&5
-printf "%s\n" "no" >&6; }
+  { $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
+$as_echo "no" >&6; }
 fi
 
   if test "x$ac_ct_OBJDUMP" = x; then
@@ -8742,8 +7965,8 @@ fi
   else
     case $cross_compiling:$ac_tool_warned in
 yes:)
-{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: WARNING: using cross tools not prefixed with host triplet" >&5
-printf "%s\n" "$as_me: WARNING: using cross tools not prefixed with host triplet" >&2;}
+{ $as_echo "$as_me:${as_lineno-$LINENO}: WARNING: using cross tools not prefixed with host triplet" >&5
+$as_echo "$as_me: WARNING: using cross tools not prefixed with host triplet" >&2;}
 ac_tool_warned=yes ;;
 esac
     OBJDUMP=$ac_ct_OBJDUMP
@@ -8762,12 +7985,11 @@ test -z "$OBJDUMP" && OBJDUMP=objdump
 
 
 
-{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking how to recognize dependent libraries" >&5
-printf %s "checking how to recognize dependent libraries... " >&6; }
-if test ${lt_cv_deplibs_check_method+y}
-then :
-  printf %s "(cached) " >&6
-else $as_nop
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking how to recognize dependent libraries" >&5
+$as_echo_n "checking how to recognize dependent libraries... " >&6; }
+if ${lt_cv_deplibs_check_method+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
   lt_cv_file_magic_cmd='$MAGIC_CMD'
 lt_cv_file_magic_test_file=
 lt_cv_deplibs_check_method='unknown'
@@ -8963,8 +8185,8 @@ os2*)
 esac
 
 fi
-{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $lt_cv_deplibs_check_method" >&5
-printf "%s\n" "$lt_cv_deplibs_check_method" >&6; }
+{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $lt_cv_deplibs_check_method" >&5
+$as_echo "$lt_cv_deplibs_check_method" >&6; }
 
 file_magic_glob=
 want_nocaseglob=no
@@ -9008,12 +8230,11 @@ test -z "$deplibs_check_method" && deplibs_check_method=unknown
 if test -n "$ac_tool_prefix"; then
   # Extract the first word of "${ac_tool_prefix}dlltool", so it can be a program name with args.
 set dummy ${ac_tool_prefix}dlltool; ac_word=$2
-{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for $ac_word" >&5
-printf %s "checking for $ac_word... " >&6; }
-if test ${ac_cv_prog_DLLTOOL+y}
-then :
-  printf %s "(cached) " >&6
-else $as_nop
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for $ac_word" >&5
+$as_echo_n "checking for $ac_word... " >&6; }
+if ${ac_cv_prog_DLLTOOL+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
   if test -n "$DLLTOOL"; then
   ac_cv_prog_DLLTOOL="$DLLTOOL" # Let the user override the test.
 else
@@ -9021,15 +8242,11 @@ as_save_IFS=$IFS; IFS=$PATH_SEPARATOR
 for as_dir in $PATH
 do
   IFS=$as_save_IFS
-  case $as_dir in #(((
-    '') as_dir=./ ;;
-    */) ;;
-    *) as_dir=$as_dir/ ;;
-  esac
+  test -z "$as_dir" && as_dir=.
     for ac_exec_ext in '' $ac_executable_extensions; do
-  if as_fn_executable_p "$as_dir$ac_word$ac_exec_ext"; then
+  if as_fn_executable_p "$as_dir/$ac_word$ac_exec_ext"; then
     ac_cv_prog_DLLTOOL="${ac_tool_prefix}dlltool"
-    printf "%s\n" "$as_me:${as_lineno-$LINENO}: found $as_dir$ac_word$ac_exec_ext" >&5
+    $as_echo "$as_me:${as_lineno-$LINENO}: found $as_dir/$ac_word$ac_exec_ext" >&5
     break 2
   fi
 done
@@ -9040,11 +8257,11 @@ fi
 fi
 DLLTOOL=$ac_cv_prog_DLLTOOL
 if test -n "$DLLTOOL"; then
-  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $DLLTOOL" >&5
-printf "%s\n" "$DLLTOOL" >&6; }
+  { $as_echo "$as_me:${as_lineno-$LINENO}: result: $DLLTOOL" >&5
+$as_echo "$DLLTOOL" >&6; }
 else
-  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: no" >&5
-printf "%s\n" "no" >&6; }
+  { $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
+$as_echo "no" >&6; }
 fi
 
 
@@ -9053,12 +8270,11 @@ if test -z "$ac_cv_prog_DLLTOOL"; then
   ac_ct_DLLTOOL=$DLLTOOL
   # Extract the first word of "dlltool", so it can be a program name with args.
 set dummy dlltool; ac_word=$2
-{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for $ac_word" >&5
-printf %s "checking for $ac_word... " >&6; }
-if test ${ac_cv_prog_ac_ct_DLLTOOL+y}
-then :
-  printf %s "(cached) " >&6
-else $as_nop
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for $ac_word" >&5
+$as_echo_n "checking for $ac_word... " >&6; }
+if ${ac_cv_prog_ac_ct_DLLTOOL+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
   if test -n "$ac_ct_DLLTOOL"; then
   ac_cv_prog_ac_ct_DLLTOOL="$ac_ct_DLLTOOL" # Let the user override the test.
 else
@@ -9066,15 +8282,11 @@ as_save_IFS=$IFS; IFS=$PATH_SEPARATOR
 for as_dir in $PATH
 do
   IFS=$as_save_IFS
-  case $as_dir in #(((
-    '') as_dir=./ ;;
-    */) ;;
-    *) as_dir=$as_dir/ ;;
-  esac
+  test -z "$as_dir" && as_dir=.
     for ac_exec_ext in '' $ac_executable_extensions; do
-  if as_fn_executable_p "$as_dir$ac_word$ac_exec_ext"; then
+  if as_fn_executable_p "$as_dir/$ac_word$ac_exec_ext"; then
     ac_cv_prog_ac_ct_DLLTOOL="dlltool"
-    printf "%s\n" "$as_me:${as_lineno-$LINENO}: found $as_dir$ac_word$ac_exec_ext" >&5
+    $as_echo "$as_me:${as_lineno-$LINENO}: found $as_dir/$ac_word$ac_exec_ext" >&5
     break 2
   fi
 done
@@ -9085,11 +8297,11 @@ fi
 fi
 ac_ct_DLLTOOL=$ac_cv_prog_ac_ct_DLLTOOL
 if test -n "$ac_ct_DLLTOOL"; then
-  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $ac_ct_DLLTOOL" >&5
-printf "%s\n" "$ac_ct_DLLTOOL" >&6; }
+  { $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_ct_DLLTOOL" >&5
+$as_echo "$ac_ct_DLLTOOL" >&6; }
 else
-  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: no" >&5
-printf "%s\n" "no" >&6; }
+  { $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
+$as_echo "no" >&6; }
 fi
 
   if test "x$ac_ct_DLLTOOL" = x; then
@@ -9097,8 +8309,8 @@ fi
   else
     case $cross_compiling:$ac_tool_warned in
 yes:)
-{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: WARNING: using cross tools not prefixed with host triplet" >&5
-printf "%s\n" "$as_me: WARNING: using cross tools not prefixed with host triplet" >&2;}
+{ $as_echo "$as_me:${as_lineno-$LINENO}: WARNING: using cross tools not prefixed with host triplet" >&5
+$as_echo "$as_me: WARNING: using cross tools not prefixed with host triplet" >&2;}
 ac_tool_warned=yes ;;
 esac
     DLLTOOL=$ac_ct_DLLTOOL
@@ -9118,12 +8330,11 @@ test -z "$DLLTOOL" && DLLTOOL=dlltool
 
 
 
-{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking how to associate runtime and link libraries" >&5
-printf %s "checking how to associate runtime and link libraries... " >&6; }
-if test ${lt_cv_sharedlib_from_linklib_cmd+y}
-then :
-  printf %s "(cached) " >&6
-else $as_nop
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking how to associate runtime and link libraries" >&5
+$as_echo_n "checking how to associate runtime and link libraries... " >&6; }
+if ${lt_cv_sharedlib_from_linklib_cmd+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
   lt_cv_sharedlib_from_linklib_cmd='unknown'
 
 case $host_os in
@@ -9146,8 +8357,8 @@ cygwin* | mingw* | pw32* | cegcc*)
 esac
 
 fi
-{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $lt_cv_sharedlib_from_linklib_cmd" >&5
-printf "%s\n" "$lt_cv_sharedlib_from_linklib_cmd" >&6; }
+{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $lt_cv_sharedlib_from_linklib_cmd" >&5
+$as_echo "$lt_cv_sharedlib_from_linklib_cmd" >&6; }
 sharedlib_from_linklib_cmd=$lt_cv_sharedlib_from_linklib_cmd
 test -z "$sharedlib_from_linklib_cmd" && sharedlib_from_linklib_cmd=$ECHO
 
@@ -9162,12 +8373,11 @@ if test -n "$ac_tool_prefix"; then
   do
     # Extract the first word of "$ac_tool_prefix$ac_prog", so it can be a program name with args.
 set dummy $ac_tool_prefix$ac_prog; ac_word=$2
-{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for $ac_word" >&5
-printf %s "checking for $ac_word... " >&6; }
-if test ${ac_cv_prog_AR+y}
-then :
-  printf %s "(cached) " >&6
-else $as_nop
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for $ac_word" >&5
+$as_echo_n "checking for $ac_word... " >&6; }
+if ${ac_cv_prog_AR+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
   if test -n "$AR"; then
   ac_cv_prog_AR="$AR" # Let the user override the test.
 else
@@ -9175,15 +8385,11 @@ as_save_IFS=$IFS; IFS=$PATH_SEPARATOR
 for as_dir in $PATH
 do
   IFS=$as_save_IFS
-  case $as_dir in #(((
-    '') as_dir=./ ;;
-    */) ;;
-    *) as_dir=$as_dir/ ;;
-  esac
+  test -z "$as_dir" && as_dir=.
     for ac_exec_ext in '' $ac_executable_extensions; do
-  if as_fn_executable_p "$as_dir$ac_word$ac_exec_ext"; then
+  if as_fn_executable_p "$as_dir/$ac_word$ac_exec_ext"; then
     ac_cv_prog_AR="$ac_tool_prefix$ac_prog"
-    printf "%s\n" "$as_me:${as_lineno-$LINENO}: found $as_dir$ac_word$ac_exec_ext" >&5
+    $as_echo "$as_me:${as_lineno-$LINENO}: found $as_dir/$ac_word$ac_exec_ext" >&5
     break 2
   fi
 done
@@ -9194,11 +8400,11 @@ fi
 fi
 AR=$ac_cv_prog_AR
 if test -n "$AR"; then
-  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $AR" >&5
-printf "%s\n" "$AR" >&6; }
+  { $as_echo "$as_me:${as_lineno-$LINENO}: result: $AR" >&5
+$as_echo "$AR" >&6; }
 else
-  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: no" >&5
-printf "%s\n" "no" >&6; }
+  { $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
+$as_echo "no" >&6; }
 fi
 
 
@@ -9211,12 +8417,11 @@ if test -z "$AR"; then
 do
   # Extract the first word of "$ac_prog", so it can be a program name with args.
 set dummy $ac_prog; ac_word=$2
-{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for $ac_word" >&5
-printf %s "checking for $ac_word... " >&6; }
-if test ${ac_cv_prog_ac_ct_AR+y}
-then :
-  printf %s "(cached) " >&6
-else $as_nop
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for $ac_word" >&5
+$as_echo_n "checking for $ac_word... " >&6; }
+if ${ac_cv_prog_ac_ct_AR+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
   if test -n "$ac_ct_AR"; then
   ac_cv_prog_ac_ct_AR="$ac_ct_AR" # Let the user override the test.
 else
@@ -9224,15 +8429,11 @@ as_save_IFS=$IFS; IFS=$PATH_SEPARATOR
 for as_dir in $PATH
 do
   IFS=$as_save_IFS
-  case $as_dir in #(((
-    '') as_dir=./ ;;
-    */) ;;
-    *) as_dir=$as_dir/ ;;
-  esac
+  test -z "$as_dir" && as_dir=.
     for ac_exec_ext in '' $ac_executable_extensions; do
-  if as_fn_executable_p "$as_dir$ac_word$ac_exec_ext"; then
+  if as_fn_executable_p "$as_dir/$ac_word$ac_exec_ext"; then
     ac_cv_prog_ac_ct_AR="$ac_prog"
-    printf "%s\n" "$as_me:${as_lineno-$LINENO}: found $as_dir$ac_word$ac_exec_ext" >&5
+    $as_echo "$as_me:${as_lineno-$LINENO}: found $as_dir/$ac_word$ac_exec_ext" >&5
     break 2
   fi
 done
@@ -9243,11 +8444,11 @@ fi
 fi
 ac_ct_AR=$ac_cv_prog_ac_ct_AR
 if test -n "$ac_ct_AR"; then
-  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $ac_ct_AR" >&5
-printf "%s\n" "$ac_ct_AR" >&6; }
+  { $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_ct_AR" >&5
+$as_echo "$ac_ct_AR" >&6; }
 else
-  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: no" >&5
-printf "%s\n" "no" >&6; }
+  { $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
+$as_echo "no" >&6; }
 fi
 
 
@@ -9259,8 +8460,8 @@ done
   else
     case $cross_compiling:$ac_tool_warned in
 yes:)
-{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: WARNING: using cross tools not prefixed with host triplet" >&5
-printf "%s\n" "$as_me: WARNING: using cross tools not prefixed with host triplet" >&2;}
+{ $as_echo "$as_me:${as_lineno-$LINENO}: WARNING: using cross tools not prefixed with host triplet" >&5
+$as_echo "$as_me: WARNING: using cross tools not prefixed with host triplet" >&2;}
 ac_tool_warned=yes ;;
 esac
     AR=$ac_ct_AR
@@ -9280,32 +8481,30 @@ fi
 
 
 
-{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for archiver @FILE support" >&5
-printf %s "checking for archiver @FILE support... " >&6; }
-if test ${lt_cv_ar_at_file+y}
-then :
-  printf %s "(cached) " >&6
-else $as_nop
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for archiver @FILE support" >&5
+$as_echo_n "checking for archiver @FILE support... " >&6; }
+if ${lt_cv_ar_at_file+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
   lt_cv_ar_at_file=no
    cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 /* end confdefs.h.  */
 
 int
-main (void)
+main ()
 {
 
   ;
   return 0;
 }
 _ACEOF
-if ac_fn_c_try_compile "$LINENO"
-then :
+if ac_fn_c_try_compile "$LINENO"; then :
   echo conftest.$ac_objext > conftest.lst
       lt_ar_try='$AR $AR_FLAGS libconftest.a @conftest.lst >&5'
       { { eval echo "\"\$as_me\":${as_lineno-$LINENO}: \"$lt_ar_try\""; } >&5
   (eval $lt_ar_try) 2>&5
   ac_status=$?
-  printf "%s\n" "$as_me:${as_lineno-$LINENO}: \$? = $ac_status" >&5
+  $as_echo "$as_me:${as_lineno-$LINENO}: \$? = $ac_status" >&5
   test $ac_status = 0; }
       if test 0 -eq "$ac_status"; then
 	# Ensure the archiver fails upon bogus file names.
@@ -9313,7 +8512,7 @@ then :
 	{ { eval echo "\"\$as_me\":${as_lineno-$LINENO}: \"$lt_ar_try\""; } >&5
   (eval $lt_ar_try) 2>&5
   ac_status=$?
-  printf "%s\n" "$as_me:${as_lineno-$LINENO}: \$? = $ac_status" >&5
+  $as_echo "$as_me:${as_lineno-$LINENO}: \$? = $ac_status" >&5
   test $ac_status = 0; }
 	if test 0 -ne "$ac_status"; then
           lt_cv_ar_at_file=@
@@ -9322,11 +8521,11 @@ then :
       rm -f conftest.* libconftest.a
 
 fi
-rm -f core conftest.err conftest.$ac_objext conftest.beam conftest.$ac_ext
+rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
 
 fi
-{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $lt_cv_ar_at_file" >&5
-printf "%s\n" "$lt_cv_ar_at_file" >&6; }
+{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $lt_cv_ar_at_file" >&5
+$as_echo "$lt_cv_ar_at_file" >&6; }
 
 if test no = "$lt_cv_ar_at_file"; then
   archiver_list_spec=
@@ -9343,12 +8542,11 @@ fi
 if test -n "$ac_tool_prefix"; then
   # Extract the first word of "${ac_tool_prefix}strip", so it can be a program name with args.
 set dummy ${ac_tool_prefix}strip; ac_word=$2
-{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for $ac_word" >&5
-printf %s "checking for $ac_word... " >&6; }
-if test ${ac_cv_prog_STRIP+y}
-then :
-  printf %s "(cached) " >&6
-else $as_nop
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for $ac_word" >&5
+$as_echo_n "checking for $ac_word... " >&6; }
+if ${ac_cv_prog_STRIP+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
   if test -n "$STRIP"; then
   ac_cv_prog_STRIP="$STRIP" # Let the user override the test.
 else
@@ -9356,15 +8554,11 @@ as_save_IFS=$IFS; IFS=$PATH_SEPARATOR
 for as_dir in $PATH
 do
   IFS=$as_save_IFS
-  case $as_dir in #(((
-    '') as_dir=./ ;;
-    */) ;;
-    *) as_dir=$as_dir/ ;;
-  esac
+  test -z "$as_dir" && as_dir=.
     for ac_exec_ext in '' $ac_executable_extensions; do
-  if as_fn_executable_p "$as_dir$ac_word$ac_exec_ext"; then
+  if as_fn_executable_p "$as_dir/$ac_word$ac_exec_ext"; then
     ac_cv_prog_STRIP="${ac_tool_prefix}strip"
-    printf "%s\n" "$as_me:${as_lineno-$LINENO}: found $as_dir$ac_word$ac_exec_ext" >&5
+    $as_echo "$as_me:${as_lineno-$LINENO}: found $as_dir/$ac_word$ac_exec_ext" >&5
     break 2
   fi
 done
@@ -9375,11 +8569,11 @@ fi
 fi
 STRIP=$ac_cv_prog_STRIP
 if test -n "$STRIP"; then
-  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $STRIP" >&5
-printf "%s\n" "$STRIP" >&6; }
+  { $as_echo "$as_me:${as_lineno-$LINENO}: result: $STRIP" >&5
+$as_echo "$STRIP" >&6; }
 else
-  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: no" >&5
-printf "%s\n" "no" >&6; }
+  { $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
+$as_echo "no" >&6; }
 fi
 
 
@@ -9388,12 +8582,11 @@ if test -z "$ac_cv_prog_STRIP"; then
   ac_ct_STRIP=$STRIP
   # Extract the first word of "strip", so it can be a program name with args.
 set dummy strip; ac_word=$2
-{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for $ac_word" >&5
-printf %s "checking for $ac_word... " >&6; }
-if test ${ac_cv_prog_ac_ct_STRIP+y}
-then :
-  printf %s "(cached) " >&6
-else $as_nop
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for $ac_word" >&5
+$as_echo_n "checking for $ac_word... " >&6; }
+if ${ac_cv_prog_ac_ct_STRIP+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
   if test -n "$ac_ct_STRIP"; then
   ac_cv_prog_ac_ct_STRIP="$ac_ct_STRIP" # Let the user override the test.
 else
@@ -9401,15 +8594,11 @@ as_save_IFS=$IFS; IFS=$PATH_SEPARATOR
 for as_dir in $PATH
 do
   IFS=$as_save_IFS
-  case $as_dir in #(((
-    '') as_dir=./ ;;
-    */) ;;
-    *) as_dir=$as_dir/ ;;
-  esac
+  test -z "$as_dir" && as_dir=.
     for ac_exec_ext in '' $ac_executable_extensions; do
-  if as_fn_executable_p "$as_dir$ac_word$ac_exec_ext"; then
+  if as_fn_executable_p "$as_dir/$ac_word$ac_exec_ext"; then
     ac_cv_prog_ac_ct_STRIP="strip"
-    printf "%s\n" "$as_me:${as_lineno-$LINENO}: found $as_dir$ac_word$ac_exec_ext" >&5
+    $as_echo "$as_me:${as_lineno-$LINENO}: found $as_dir/$ac_word$ac_exec_ext" >&5
     break 2
   fi
 done
@@ -9420,11 +8609,11 @@ fi
 fi
 ac_ct_STRIP=$ac_cv_prog_ac_ct_STRIP
 if test -n "$ac_ct_STRIP"; then
-  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $ac_ct_STRIP" >&5
-printf "%s\n" "$ac_ct_STRIP" >&6; }
+  { $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_ct_STRIP" >&5
+$as_echo "$ac_ct_STRIP" >&6; }
 else
-  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: no" >&5
-printf "%s\n" "no" >&6; }
+  { $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
+$as_echo "no" >&6; }
 fi
 
   if test "x$ac_ct_STRIP" = x; then
@@ -9432,8 +8621,8 @@ fi
   else
     case $cross_compiling:$ac_tool_warned in
 yes:)
-{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: WARNING: using cross tools not prefixed with host triplet" >&5
-printf "%s\n" "$as_me: WARNING: using cross tools not prefixed with host triplet" >&2;}
+{ $as_echo "$as_me:${as_lineno-$LINENO}: WARNING: using cross tools not prefixed with host triplet" >&5
+$as_echo "$as_me: WARNING: using cross tools not prefixed with host triplet" >&2;}
 ac_tool_warned=yes ;;
 esac
     STRIP=$ac_ct_STRIP
@@ -9452,12 +8641,11 @@ test -z "$STRIP" && STRIP=:
 if test -n "$ac_tool_prefix"; then
   # Extract the first word of "${ac_tool_prefix}ranlib", so it can be a program name with args.
 set dummy ${ac_tool_prefix}ranlib; ac_word=$2
-{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for $ac_word" >&5
-printf %s "checking for $ac_word... " >&6; }
-if test ${ac_cv_prog_RANLIB+y}
-then :
-  printf %s "(cached) " >&6
-else $as_nop
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for $ac_word" >&5
+$as_echo_n "checking for $ac_word... " >&6; }
+if ${ac_cv_prog_RANLIB+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
   if test -n "$RANLIB"; then
   ac_cv_prog_RANLIB="$RANLIB" # Let the user override the test.
 else
@@ -9465,15 +8653,11 @@ as_save_IFS=$IFS; IFS=$PATH_SEPARATOR
 for as_dir in $PATH
 do
   IFS=$as_save_IFS
-  case $as_dir in #(((
-    '') as_dir=./ ;;
-    */) ;;
-    *) as_dir=$as_dir/ ;;
-  esac
+  test -z "$as_dir" && as_dir=.
     for ac_exec_ext in '' $ac_executable_extensions; do
-  if as_fn_executable_p "$as_dir$ac_word$ac_exec_ext"; then
+  if as_fn_executable_p "$as_dir/$ac_word$ac_exec_ext"; then
     ac_cv_prog_RANLIB="${ac_tool_prefix}ranlib"
-    printf "%s\n" "$as_me:${as_lineno-$LINENO}: found $as_dir$ac_word$ac_exec_ext" >&5
+    $as_echo "$as_me:${as_lineno-$LINENO}: found $as_dir/$ac_word$ac_exec_ext" >&5
     break 2
   fi
 done
@@ -9484,11 +8668,11 @@ fi
 fi
 RANLIB=$ac_cv_prog_RANLIB
 if test -n "$RANLIB"; then
-  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $RANLIB" >&5
-printf "%s\n" "$RANLIB" >&6; }
+  { $as_echo "$as_me:${as_lineno-$LINENO}: result: $RANLIB" >&5
+$as_echo "$RANLIB" >&6; }
 else
-  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: no" >&5
-printf "%s\n" "no" >&6; }
+  { $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
+$as_echo "no" >&6; }
 fi
 
 
@@ -9497,12 +8681,11 @@ if test -z "$ac_cv_prog_RANLIB"; then
   ac_ct_RANLIB=$RANLIB
   # Extract the first word of "ranlib", so it can be a program name with args.
 set dummy ranlib; ac_word=$2
-{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for $ac_word" >&5
-printf %s "checking for $ac_word... " >&6; }
-if test ${ac_cv_prog_ac_ct_RANLIB+y}
-then :
-  printf %s "(cached) " >&6
-else $as_nop
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for $ac_word" >&5
+$as_echo_n "checking for $ac_word... " >&6; }
+if ${ac_cv_prog_ac_ct_RANLIB+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
   if test -n "$ac_ct_RANLIB"; then
   ac_cv_prog_ac_ct_RANLIB="$ac_ct_RANLIB" # Let the user override the test.
 else
@@ -9510,15 +8693,11 @@ as_save_IFS=$IFS; IFS=$PATH_SEPARATOR
 for as_dir in $PATH
 do
   IFS=$as_save_IFS
-  case $as_dir in #(((
-    '') as_dir=./ ;;
-    */) ;;
-    *) as_dir=$as_dir/ ;;
-  esac
+  test -z "$as_dir" && as_dir=.
     for ac_exec_ext in '' $ac_executable_extensions; do
-  if as_fn_executable_p "$as_dir$ac_word$ac_exec_ext"; then
+  if as_fn_executable_p "$as_dir/$ac_word$ac_exec_ext"; then
     ac_cv_prog_ac_ct_RANLIB="ranlib"
-    printf "%s\n" "$as_me:${as_lineno-$LINENO}: found $as_dir$ac_word$ac_exec_ext" >&5
+    $as_echo "$as_me:${as_lineno-$LINENO}: found $as_dir/$ac_word$ac_exec_ext" >&5
     break 2
   fi
 done
@@ -9529,11 +8708,11 @@ fi
 fi
 ac_ct_RANLIB=$ac_cv_prog_ac_ct_RANLIB
 if test -n "$ac_ct_RANLIB"; then
-  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $ac_ct_RANLIB" >&5
-printf "%s\n" "$ac_ct_RANLIB" >&6; }
+  { $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_ct_RANLIB" >&5
+$as_echo "$ac_ct_RANLIB" >&6; }
 else
-  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: no" >&5
-printf "%s\n" "no" >&6; }
+  { $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
+$as_echo "no" >&6; }
 fi
 
   if test "x$ac_ct_RANLIB" = x; then
@@ -9541,8 +8720,8 @@ fi
   else
     case $cross_compiling:$ac_tool_warned in
 yes:)
-{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: WARNING: using cross tools not prefixed with host triplet" >&5
-printf "%s\n" "$as_me: WARNING: using cross tools not prefixed with host triplet" >&2;}
+{ $as_echo "$as_me:${as_lineno-$LINENO}: WARNING: using cross tools not prefixed with host triplet" >&5
+$as_echo "$as_me: WARNING: using cross tools not prefixed with host triplet" >&2;}
 ac_tool_warned=yes ;;
 esac
     RANLIB=$ac_ct_RANLIB
@@ -9606,12 +8785,11 @@ for ac_prog in gawk mawk nawk awk
 do
   # Extract the first word of "$ac_prog", so it can be a program name with args.
 set dummy $ac_prog; ac_word=$2
-{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for $ac_word" >&5
-printf %s "checking for $ac_word... " >&6; }
-if test ${ac_cv_prog_AWK+y}
-then :
-  printf %s "(cached) " >&6
-else $as_nop
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for $ac_word" >&5
+$as_echo_n "checking for $ac_word... " >&6; }
+if ${ac_cv_prog_AWK+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
   if test -n "$AWK"; then
   ac_cv_prog_AWK="$AWK" # Let the user override the test.
 else
@@ -9619,15 +8797,11 @@ as_save_IFS=$IFS; IFS=$PATH_SEPARATOR
 for as_dir in $PATH
 do
   IFS=$as_save_IFS
-  case $as_dir in #(((
-    '') as_dir=./ ;;
-    */) ;;
-    *) as_dir=$as_dir/ ;;
-  esac
+  test -z "$as_dir" && as_dir=.
     for ac_exec_ext in '' $ac_executable_extensions; do
-  if as_fn_executable_p "$as_dir$ac_word$ac_exec_ext"; then
+  if as_fn_executable_p "$as_dir/$ac_word$ac_exec_ext"; then
     ac_cv_prog_AWK="$ac_prog"
-    printf "%s\n" "$as_me:${as_lineno-$LINENO}: found $as_dir$ac_word$ac_exec_ext" >&5
+    $as_echo "$as_me:${as_lineno-$LINENO}: found $as_dir/$ac_word$ac_exec_ext" >&5
     break 2
   fi
 done
@@ -9638,11 +8812,11 @@ fi
 fi
 AWK=$ac_cv_prog_AWK
 if test -n "$AWK"; then
-  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $AWK" >&5
-printf "%s\n" "$AWK" >&6; }
+  { $as_echo "$as_me:${as_lineno-$LINENO}: result: $AWK" >&5
+$as_echo "$AWK" >&6; }
 else
-  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: no" >&5
-printf "%s\n" "no" >&6; }
+  { $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
+$as_echo "no" >&6; }
 fi
 
 
@@ -9678,12 +8852,11 @@ compiler=$CC
 
 
 # Check for command to grab the raw symbol name followed by C symbol from nm.
-{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking command to parse $NM output from $compiler object" >&5
-printf %s "checking command to parse $NM output from $compiler object... " >&6; }
-if test ${lt_cv_sys_global_symbol_pipe+y}
-then :
-  printf %s "(cached) " >&6
-else $as_nop
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking command to parse $NM output from $compiler object" >&5
+$as_echo_n "checking command to parse $NM output from $compiler object... " >&6; }
+if ${lt_cv_sys_global_symbol_pipe+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
 
 # These are sane defaults that work on at least a few old systems.
 # [They come from Ultrix.  What could be older than Ultrix?!! ;)]
@@ -9835,14 +9008,14 @@ _LT_EOF
   if { { eval echo "\"\$as_me\":${as_lineno-$LINENO}: \"$ac_compile\""; } >&5
   (eval $ac_compile) 2>&5
   ac_status=$?
-  printf "%s\n" "$as_me:${as_lineno-$LINENO}: \$? = $ac_status" >&5
+  $as_echo "$as_me:${as_lineno-$LINENO}: \$? = $ac_status" >&5
   test $ac_status = 0; }; then
     # Now try to grab the symbols.
     nlist=conftest.nm
     if { { eval echo "\"\$as_me\":${as_lineno-$LINENO}: \"$NM conftest.$ac_objext \| "$lt_cv_sys_global_symbol_pipe" \> $nlist\""; } >&5
   (eval $NM conftest.$ac_objext \| "$lt_cv_sys_global_symbol_pipe" \> $nlist) 2>&5
   ac_status=$?
-  printf "%s\n" "$as_me:${as_lineno-$LINENO}: \$? = $ac_status" >&5
+  $as_echo "$as_me:${as_lineno-$LINENO}: \$? = $ac_status" >&5
   test $ac_status = 0; } && test -s "$nlist"; then
       # Try sorting and uniquifying the output.
       if sort "$nlist" | uniq > "$nlist"T; then
@@ -9911,7 +9084,7 @@ _LT_EOF
 	  if { { eval echo "\"\$as_me\":${as_lineno-$LINENO}: \"$ac_link\""; } >&5
   (eval $ac_link) 2>&5
   ac_status=$?
-  printf "%s\n" "$as_me:${as_lineno-$LINENO}: \$? = $ac_status" >&5
+  $as_echo "$as_me:${as_lineno-$LINENO}: \$? = $ac_status" >&5
   test $ac_status = 0; } && test -s conftest$ac_exeext; then
 	    pipe_works=yes
 	  fi
@@ -9946,11 +9119,11 @@ if test -z "$lt_cv_sys_global_symbol_pipe"; then
   lt_cv_sys_global_symbol_to_cdecl=
 fi
 if test -z "$lt_cv_sys_global_symbol_pipe$lt_cv_sys_global_symbol_to_cdecl"; then
-  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: failed" >&5
-printf "%s\n" "failed" >&6; }
+  { $as_echo "$as_me:${as_lineno-$LINENO}: result: failed" >&5
+$as_echo "failed" >&6; }
 else
-  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: ok" >&5
-printf "%s\n" "ok" >&6; }
+  { $as_echo "$as_me:${as_lineno-$LINENO}: result: ok" >&5
+$as_echo "ok" >&6; }
 fi
 
 # Response file support.
@@ -9996,14 +9169,13 @@ fi
 
 
 
-{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for sysroot" >&5
-printf %s "checking for sysroot... " >&6; }
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for sysroot" >&5
+$as_echo_n "checking for sysroot... " >&6; }
 
 # Check whether --with-sysroot was given.
-if test ${with_sysroot+y}
-then :
+if test "${with_sysroot+set}" = set; then :
   withval=$with_sysroot;
-else $as_nop
+else
   with_sysroot=no
 fi
 
@@ -10021,25 +9193,24 @@ case $with_sysroot in #(
  no|'')
    ;; #(
  *)
-   { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $with_sysroot" >&5
-printf "%s\n" "$with_sysroot" >&6; }
+   { $as_echo "$as_me:${as_lineno-$LINENO}: result: $with_sysroot" >&5
+$as_echo "$with_sysroot" >&6; }
    as_fn_error $? "The sysroot must be an absolute path." "$LINENO" 5
    ;;
 esac
 
- { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: ${lt_sysroot:-no}" >&5
-printf "%s\n" "${lt_sysroot:-no}" >&6; }
+ { $as_echo "$as_me:${as_lineno-$LINENO}: result: ${lt_sysroot:-no}" >&5
+$as_echo "${lt_sysroot:-no}" >&6; }
 
 
 
 
 
-{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for a working dd" >&5
-printf %s "checking for a working dd... " >&6; }
-if test ${ac_cv_path_lt_DD+y}
-then :
-  printf %s "(cached) " >&6
-else $as_nop
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for a working dd" >&5
+$as_echo_n "checking for a working dd... " >&6; }
+if ${ac_cv_path_lt_DD+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
   printf 0123456789abcdef0123456789abcdef >conftest.i
 cat conftest.i conftest.i >conftest2.i
 : ${lt_DD:=$DD}
@@ -10050,15 +9221,10 @@ if test -z "$lt_DD"; then
 for as_dir in $PATH
 do
   IFS=$as_save_IFS
-  case $as_dir in #(((
-    '') as_dir=./ ;;
-    */) ;;
-    *) as_dir=$as_dir/ ;;
-  esac
-    for ac_prog in dd
-   do
+  test -z "$as_dir" && as_dir=.
+    for ac_prog in dd; do
     for ac_exec_ext in '' $ac_executable_extensions; do
-      ac_path_lt_DD="$as_dir$ac_prog$ac_exec_ext"
+      ac_path_lt_DD="$as_dir/$ac_prog$ac_exec_ext"
       as_fn_executable_p "$ac_path_lt_DD" || continue
 if "$ac_path_lt_DD" bs=32 count=1 <conftest2.i >conftest.out 2>/dev/null; then
   cmp -s conftest.i conftest.out \
@@ -10078,16 +9244,15 @@ fi
 
 rm -f conftest.i conftest2.i conftest.out
 fi
-{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $ac_cv_path_lt_DD" >&5
-printf "%s\n" "$ac_cv_path_lt_DD" >&6; }
+{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_path_lt_DD" >&5
+$as_echo "$ac_cv_path_lt_DD" >&6; }
 
 
-{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking how to truncate binary pipes" >&5
-printf %s "checking how to truncate binary pipes... " >&6; }
-if test ${lt_cv_truncate_bin+y}
-then :
-  printf %s "(cached) " >&6
-else $as_nop
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking how to truncate binary pipes" >&5
+$as_echo_n "checking how to truncate binary pipes... " >&6; }
+if ${lt_cv_truncate_bin+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
   printf 0123456789abcdef0123456789abcdef >conftest.i
 cat conftest.i conftest.i >conftest2.i
 lt_cv_truncate_bin=
@@ -10098,8 +9263,8 @@ fi
 rm -f conftest.i conftest2.i conftest.out
 test -z "$lt_cv_truncate_bin" && lt_cv_truncate_bin="$SED -e 4q"
 fi
-{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $lt_cv_truncate_bin" >&5
-printf "%s\n" "$lt_cv_truncate_bin" >&6; }
+{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $lt_cv_truncate_bin" >&5
+$as_echo "$lt_cv_truncate_bin" >&6; }
 
 
 
@@ -10122,8 +9287,7 @@ func_cc_basename ()
 }
 
 # Check whether --enable-libtool-lock was given.
-if test ${enable_libtool_lock+y}
-then :
+if test "${enable_libtool_lock+set}" = set; then :
   enableval=$enable_libtool_lock;
 fi
 
@@ -10139,7 +9303,7 @@ ia64-*-hpux*)
   if { { eval echo "\"\$as_me\":${as_lineno-$LINENO}: \"$ac_compile\""; } >&5
   (eval $ac_compile) 2>&5
   ac_status=$?
-  printf "%s\n" "$as_me:${as_lineno-$LINENO}: \$? = $ac_status" >&5
+  $as_echo "$as_me:${as_lineno-$LINENO}: \$? = $ac_status" >&5
   test $ac_status = 0; }; then
     case `/usr/bin/file conftest.$ac_objext` in
       *ELF-32*)
@@ -10159,7 +9323,7 @@ ia64-*-hpux*)
   if { { eval echo "\"\$as_me\":${as_lineno-$LINENO}: \"$ac_compile\""; } >&5
   (eval $ac_compile) 2>&5
   ac_status=$?
-  printf "%s\n" "$as_me:${as_lineno-$LINENO}: \$? = $ac_status" >&5
+  $as_echo "$as_me:${as_lineno-$LINENO}: \$? = $ac_status" >&5
   test $ac_status = 0; }; then
     if test yes = "$lt_cv_prog_gnu_ld"; then
       case `/usr/bin/file conftest.$ac_objext` in
@@ -10197,7 +9361,7 @@ mips64*-*linux*)
   if { { eval echo "\"\$as_me\":${as_lineno-$LINENO}: \"$ac_compile\""; } >&5
   (eval $ac_compile) 2>&5
   ac_status=$?
-  printf "%s\n" "$as_me:${as_lineno-$LINENO}: \$? = $ac_status" >&5
+  $as_echo "$as_me:${as_lineno-$LINENO}: \$? = $ac_status" >&5
   test $ac_status = 0; }; then
     emul=elf
     case `/usr/bin/file conftest.$ac_objext` in
@@ -10238,7 +9402,7 @@ s390*-*linux*|s390*-*tpf*|sparc*-*linux*)
   if { { eval echo "\"\$as_me\":${as_lineno-$LINENO}: \"$ac_compile\""; } >&5
   (eval $ac_compile) 2>&5
   ac_status=$?
-  printf "%s\n" "$as_me:${as_lineno-$LINENO}: \$? = $ac_status" >&5
+  $as_echo "$as_me:${as_lineno-$LINENO}: \$? = $ac_status" >&5
   test $ac_status = 0; }; then
     case `/usr/bin/file conftest.o` in
       *32-bit*)
@@ -10301,12 +9465,11 @@ s390*-*linux*|s390*-*tpf*|sparc*-*linux*)
   # On SCO OpenServer 5, we need -belf to get full-featured binaries.
   SAVE_CFLAGS=$CFLAGS
   CFLAGS="$CFLAGS -belf"
-  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking whether the C compiler needs -belf" >&5
-printf %s "checking whether the C compiler needs -belf... " >&6; }
-if test ${lt_cv_cc_needs_belf+y}
-then :
-  printf %s "(cached) " >&6
-else $as_nop
+  { $as_echo "$as_me:${as_lineno-$LINENO}: checking whether the C compiler needs -belf" >&5
+$as_echo_n "checking whether the C compiler needs -belf... " >&6; }
+if ${lt_cv_cc_needs_belf+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
   ac_ext=c
 ac_cpp='$CPP $CPPFLAGS'
 ac_compile='$CC -c $CFLAGS $CPPFLAGS conftest.$ac_ext >&5'
@@ -10317,20 +9480,19 @@ ac_compiler_gnu=$ac_cv_c_compiler_gnu
 /* end confdefs.h.  */
 
 int
-main (void)
+main ()
 {
 
   ;
   return 0;
 }
 _ACEOF
-if ac_fn_c_try_link "$LINENO"
-then :
+if ac_fn_c_try_link "$LINENO"; then :
   lt_cv_cc_needs_belf=yes
-else $as_nop
+else
   lt_cv_cc_needs_belf=no
 fi
-rm -f core conftest.err conftest.$ac_objext conftest.beam \
+rm -f core conftest.err conftest.$ac_objext \
     conftest$ac_exeext conftest.$ac_ext
      ac_ext=c
 ac_cpp='$CPP $CPPFLAGS'
@@ -10339,8 +9501,8 @@ ac_link='$CC -o conftest$ac_exeext $CFLAGS $CPPFLAGS $LDFLAGS conftest.$ac_ext $
 ac_compiler_gnu=$ac_cv_c_compiler_gnu
 
 fi
-{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $lt_cv_cc_needs_belf" >&5
-printf "%s\n" "$lt_cv_cc_needs_belf" >&6; }
+{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $lt_cv_cc_needs_belf" >&5
+$as_echo "$lt_cv_cc_needs_belf" >&6; }
   if test yes != "$lt_cv_cc_needs_belf"; then
     # this is probably gcc 2.8.0, egcs 1.0 or newer; no need for -belf
     CFLAGS=$SAVE_CFLAGS
@@ -10353,7 +9515,7 @@ printf "%s\n" "$lt_cv_cc_needs_belf" >&6; }
   if { { eval echo "\"\$as_me\":${as_lineno-$LINENO}: \"$ac_compile\""; } >&5
   (eval $ac_compile) 2>&5
   ac_status=$?
-  printf "%s\n" "$as_me:${as_lineno-$LINENO}: \$? = $ac_status" >&5
+  $as_echo "$as_me:${as_lineno-$LINENO}: \$? = $ac_status" >&5
   test $ac_status = 0; }; then
     case `/usr/bin/file conftest.o` in
     *64-bit*)
@@ -10390,12 +9552,11 @@ need_locks=$enable_libtool_lock
 if test -n "$ac_tool_prefix"; then
   # Extract the first word of "${ac_tool_prefix}mt", so it can be a program name with args.
 set dummy ${ac_tool_prefix}mt; ac_word=$2
-{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for $ac_word" >&5
-printf %s "checking for $ac_word... " >&6; }
-if test ${ac_cv_prog_MANIFEST_TOOL+y}
-then :
-  printf %s "(cached) " >&6
-else $as_nop
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for $ac_word" >&5
+$as_echo_n "checking for $ac_word... " >&6; }
+if ${ac_cv_prog_MANIFEST_TOOL+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
   if test -n "$MANIFEST_TOOL"; then
   ac_cv_prog_MANIFEST_TOOL="$MANIFEST_TOOL" # Let the user override the test.
 else
@@ -10403,15 +9564,11 @@ as_save_IFS=$IFS; IFS=$PATH_SEPARATOR
 for as_dir in $PATH
 do
   IFS=$as_save_IFS
-  case $as_dir in #(((
-    '') as_dir=./ ;;
-    */) ;;
-    *) as_dir=$as_dir/ ;;
-  esac
+  test -z "$as_dir" && as_dir=.
     for ac_exec_ext in '' $ac_executable_extensions; do
-  if as_fn_executable_p "$as_dir$ac_word$ac_exec_ext"; then
+  if as_fn_executable_p "$as_dir/$ac_word$ac_exec_ext"; then
     ac_cv_prog_MANIFEST_TOOL="${ac_tool_prefix}mt"
-    printf "%s\n" "$as_me:${as_lineno-$LINENO}: found $as_dir$ac_word$ac_exec_ext" >&5
+    $as_echo "$as_me:${as_lineno-$LINENO}: found $as_dir/$ac_word$ac_exec_ext" >&5
     break 2
   fi
 done
@@ -10422,11 +9579,11 @@ fi
 fi
 MANIFEST_TOOL=$ac_cv_prog_MANIFEST_TOOL
 if test -n "$MANIFEST_TOOL"; then
-  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $MANIFEST_TOOL" >&5
-printf "%s\n" "$MANIFEST_TOOL" >&6; }
+  { $as_echo "$as_me:${as_lineno-$LINENO}: result: $MANIFEST_TOOL" >&5
+$as_echo "$MANIFEST_TOOL" >&6; }
 else
-  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: no" >&5
-printf "%s\n" "no" >&6; }
+  { $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
+$as_echo "no" >&6; }
 fi
 
 
@@ -10435,12 +9592,11 @@ if test -z "$ac_cv_prog_MANIFEST_TOOL"; then
   ac_ct_MANIFEST_TOOL=$MANIFEST_TOOL
   # Extract the first word of "mt", so it can be a program name with args.
 set dummy mt; ac_word=$2
-{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for $ac_word" >&5
-printf %s "checking for $ac_word... " >&6; }
-if test ${ac_cv_prog_ac_ct_MANIFEST_TOOL+y}
-then :
-  printf %s "(cached) " >&6
-else $as_nop
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for $ac_word" >&5
+$as_echo_n "checking for $ac_word... " >&6; }
+if ${ac_cv_prog_ac_ct_MANIFEST_TOOL+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
   if test -n "$ac_ct_MANIFEST_TOOL"; then
   ac_cv_prog_ac_ct_MANIFEST_TOOL="$ac_ct_MANIFEST_TOOL" # Let the user override the test.
 else
@@ -10448,15 +9604,11 @@ as_save_IFS=$IFS; IFS=$PATH_SEPARATOR
 for as_dir in $PATH
 do
   IFS=$as_save_IFS
-  case $as_dir in #(((
-    '') as_dir=./ ;;
-    */) ;;
-    *) as_dir=$as_dir/ ;;
-  esac
+  test -z "$as_dir" && as_dir=.
     for ac_exec_ext in '' $ac_executable_extensions; do
-  if as_fn_executable_p "$as_dir$ac_word$ac_exec_ext"; then
+  if as_fn_executable_p "$as_dir/$ac_word$ac_exec_ext"; then
     ac_cv_prog_ac_ct_MANIFEST_TOOL="mt"
-    printf "%s\n" "$as_me:${as_lineno-$LINENO}: found $as_dir$ac_word$ac_exec_ext" >&5
+    $as_echo "$as_me:${as_lineno-$LINENO}: found $as_dir/$ac_word$ac_exec_ext" >&5
     break 2
   fi
 done
@@ -10467,11 +9619,11 @@ fi
 fi
 ac_ct_MANIFEST_TOOL=$ac_cv_prog_ac_ct_MANIFEST_TOOL
 if test -n "$ac_ct_MANIFEST_TOOL"; then
-  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $ac_ct_MANIFEST_TOOL" >&5
-printf "%s\n" "$ac_ct_MANIFEST_TOOL" >&6; }
+  { $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_ct_MANIFEST_TOOL" >&5
+$as_echo "$ac_ct_MANIFEST_TOOL" >&6; }
 else
-  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: no" >&5
-printf "%s\n" "no" >&6; }
+  { $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
+$as_echo "no" >&6; }
 fi
 
   if test "x$ac_ct_MANIFEST_TOOL" = x; then
@@ -10479,8 +9631,8 @@ fi
   else
     case $cross_compiling:$ac_tool_warned in
 yes:)
-{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: WARNING: using cross tools not prefixed with host triplet" >&5
-printf "%s\n" "$as_me: WARNING: using cross tools not prefixed with host triplet" >&2;}
+{ $as_echo "$as_me:${as_lineno-$LINENO}: WARNING: using cross tools not prefixed with host triplet" >&5
+$as_echo "$as_me: WARNING: using cross tools not prefixed with host triplet" >&2;}
 ac_tool_warned=yes ;;
 esac
     MANIFEST_TOOL=$ac_ct_MANIFEST_TOOL
@@ -10490,12 +9642,11 @@ else
 fi
 
 test -z "$MANIFEST_TOOL" && MANIFEST_TOOL=mt
-{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking if $MANIFEST_TOOL is a manifest tool" >&5
-printf %s "checking if $MANIFEST_TOOL is a manifest tool... " >&6; }
-if test ${lt_cv_path_mainfest_tool+y}
-then :
-  printf %s "(cached) " >&6
-else $as_nop
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking if $MANIFEST_TOOL is a manifest tool" >&5
+$as_echo_n "checking if $MANIFEST_TOOL is a manifest tool... " >&6; }
+if ${lt_cv_path_mainfest_tool+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
   lt_cv_path_mainfest_tool=no
   echo "$as_me:$LINENO: $MANIFEST_TOOL '-?'" >&5
   $MANIFEST_TOOL '-?' 2>conftest.err > conftest.out
@@ -10505,8 +9656,8 @@ else $as_nop
   fi
   rm -f conftest*
 fi
-{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $lt_cv_path_mainfest_tool" >&5
-printf "%s\n" "$lt_cv_path_mainfest_tool" >&6; }
+{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $lt_cv_path_mainfest_tool" >&5
+$as_echo "$lt_cv_path_mainfest_tool" >&6; }
 if test yes != "$lt_cv_path_mainfest_tool"; then
   MANIFEST_TOOL=:
 fi
@@ -10521,12 +9672,11 @@ fi
     if test -n "$ac_tool_prefix"; then
   # Extract the first word of "${ac_tool_prefix}dsymutil", so it can be a program name with args.
 set dummy ${ac_tool_prefix}dsymutil; ac_word=$2
-{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for $ac_word" >&5
-printf %s "checking for $ac_word... " >&6; }
-if test ${ac_cv_prog_DSYMUTIL+y}
-then :
-  printf %s "(cached) " >&6
-else $as_nop
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for $ac_word" >&5
+$as_echo_n "checking for $ac_word... " >&6; }
+if ${ac_cv_prog_DSYMUTIL+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
   if test -n "$DSYMUTIL"; then
   ac_cv_prog_DSYMUTIL="$DSYMUTIL" # Let the user override the test.
 else
@@ -10534,15 +9684,11 @@ as_save_IFS=$IFS; IFS=$PATH_SEPARATOR
 for as_dir in $PATH
 do
   IFS=$as_save_IFS
-  case $as_dir in #(((
-    '') as_dir=./ ;;
-    */) ;;
-    *) as_dir=$as_dir/ ;;
-  esac
+  test -z "$as_dir" && as_dir=.
     for ac_exec_ext in '' $ac_executable_extensions; do
-  if as_fn_executable_p "$as_dir$ac_word$ac_exec_ext"; then
+  if as_fn_executable_p "$as_dir/$ac_word$ac_exec_ext"; then
     ac_cv_prog_DSYMUTIL="${ac_tool_prefix}dsymutil"
-    printf "%s\n" "$as_me:${as_lineno-$LINENO}: found $as_dir$ac_word$ac_exec_ext" >&5
+    $as_echo "$as_me:${as_lineno-$LINENO}: found $as_dir/$ac_word$ac_exec_ext" >&5
     break 2
   fi
 done
@@ -10553,11 +9699,11 @@ fi
 fi
 DSYMUTIL=$ac_cv_prog_DSYMUTIL
 if test -n "$DSYMUTIL"; then
-  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $DSYMUTIL" >&5
-printf "%s\n" "$DSYMUTIL" >&6; }
+  { $as_echo "$as_me:${as_lineno-$LINENO}: result: $DSYMUTIL" >&5
+$as_echo "$DSYMUTIL" >&6; }
 else
-  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: no" >&5
-printf "%s\n" "no" >&6; }
+  { $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
+$as_echo "no" >&6; }
 fi
 
 
@@ -10566,12 +9712,11 @@ if test -z "$ac_cv_prog_DSYMUTIL"; then
   ac_ct_DSYMUTIL=$DSYMUTIL
   # Extract the first word of "dsymutil", so it can be a program name with args.
 set dummy dsymutil; ac_word=$2
-{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for $ac_word" >&5
-printf %s "checking for $ac_word... " >&6; }
-if test ${ac_cv_prog_ac_ct_DSYMUTIL+y}
-then :
-  printf %s "(cached) " >&6
-else $as_nop
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for $ac_word" >&5
+$as_echo_n "checking for $ac_word... " >&6; }
+if ${ac_cv_prog_ac_ct_DSYMUTIL+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
   if test -n "$ac_ct_DSYMUTIL"; then
   ac_cv_prog_ac_ct_DSYMUTIL="$ac_ct_DSYMUTIL" # Let the user override the test.
 else
@@ -10579,15 +9724,11 @@ as_save_IFS=$IFS; IFS=$PATH_SEPARATOR
 for as_dir in $PATH
 do
   IFS=$as_save_IFS
-  case $as_dir in #(((
-    '') as_dir=./ ;;
-    */) ;;
-    *) as_dir=$as_dir/ ;;
-  esac
+  test -z "$as_dir" && as_dir=.
     for ac_exec_ext in '' $ac_executable_extensions; do
-  if as_fn_executable_p "$as_dir$ac_word$ac_exec_ext"; then
+  if as_fn_executable_p "$as_dir/$ac_word$ac_exec_ext"; then
     ac_cv_prog_ac_ct_DSYMUTIL="dsymutil"
-    printf "%s\n" "$as_me:${as_lineno-$LINENO}: found $as_dir$ac_word$ac_exec_ext" >&5
+    $as_echo "$as_me:${as_lineno-$LINENO}: found $as_dir/$ac_word$ac_exec_ext" >&5
     break 2
   fi
 done
@@ -10598,11 +9739,11 @@ fi
 fi
 ac_ct_DSYMUTIL=$ac_cv_prog_ac_ct_DSYMUTIL
 if test -n "$ac_ct_DSYMUTIL"; then
-  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $ac_ct_DSYMUTIL" >&5
-printf "%s\n" "$ac_ct_DSYMUTIL" >&6; }
+  { $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_ct_DSYMUTIL" >&5
+$as_echo "$ac_ct_DSYMUTIL" >&6; }
 else
-  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: no" >&5
-printf "%s\n" "no" >&6; }
+  { $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
+$as_echo "no" >&6; }
 fi
 
   if test "x$ac_ct_DSYMUTIL" = x; then
@@ -10610,8 +9751,8 @@ fi
   else
     case $cross_compiling:$ac_tool_warned in
 yes:)
-{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: WARNING: using cross tools not prefixed with host triplet" >&5
-printf "%s\n" "$as_me: WARNING: using cross tools not prefixed with host triplet" >&2;}
+{ $as_echo "$as_me:${as_lineno-$LINENO}: WARNING: using cross tools not prefixed with host triplet" >&5
+$as_echo "$as_me: WARNING: using cross tools not prefixed with host triplet" >&2;}
 ac_tool_warned=yes ;;
 esac
     DSYMUTIL=$ac_ct_DSYMUTIL
@@ -10623,12 +9764,11 @@ fi
     if test -n "$ac_tool_prefix"; then
   # Extract the first word of "${ac_tool_prefix}nmedit", so it can be a program name with args.
 set dummy ${ac_tool_prefix}nmedit; ac_word=$2
-{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for $ac_word" >&5
-printf %s "checking for $ac_word... " >&6; }
-if test ${ac_cv_prog_NMEDIT+y}
-then :
-  printf %s "(cached) " >&6
-else $as_nop
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for $ac_word" >&5
+$as_echo_n "checking for $ac_word... " >&6; }
+if ${ac_cv_prog_NMEDIT+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
   if test -n "$NMEDIT"; then
   ac_cv_prog_NMEDIT="$NMEDIT" # Let the user override the test.
 else
@@ -10636,15 +9776,11 @@ as_save_IFS=$IFS; IFS=$PATH_SEPARATOR
 for as_dir in $PATH
 do
   IFS=$as_save_IFS
-  case $as_dir in #(((
-    '') as_dir=./ ;;
-    */) ;;
-    *) as_dir=$as_dir/ ;;
-  esac
+  test -z "$as_dir" && as_dir=.
     for ac_exec_ext in '' $ac_executable_extensions; do
-  if as_fn_executable_p "$as_dir$ac_word$ac_exec_ext"; then
+  if as_fn_executable_p "$as_dir/$ac_word$ac_exec_ext"; then
     ac_cv_prog_NMEDIT="${ac_tool_prefix}nmedit"
-    printf "%s\n" "$as_me:${as_lineno-$LINENO}: found $as_dir$ac_word$ac_exec_ext" >&5
+    $as_echo "$as_me:${as_lineno-$LINENO}: found $as_dir/$ac_word$ac_exec_ext" >&5
     break 2
   fi
 done
@@ -10655,11 +9791,11 @@ fi
 fi
 NMEDIT=$ac_cv_prog_NMEDIT
 if test -n "$NMEDIT"; then
-  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $NMEDIT" >&5
-printf "%s\n" "$NMEDIT" >&6; }
+  { $as_echo "$as_me:${as_lineno-$LINENO}: result: $NMEDIT" >&5
+$as_echo "$NMEDIT" >&6; }
 else
-  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: no" >&5
-printf "%s\n" "no" >&6; }
+  { $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
+$as_echo "no" >&6; }
 fi
 
 
@@ -10668,12 +9804,11 @@ if test -z "$ac_cv_prog_NMEDIT"; then
   ac_ct_NMEDIT=$NMEDIT
   # Extract the first word of "nmedit", so it can be a program name with args.
 set dummy nmedit; ac_word=$2
-{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for $ac_word" >&5
-printf %s "checking for $ac_word... " >&6; }
-if test ${ac_cv_prog_ac_ct_NMEDIT+y}
-then :
-  printf %s "(cached) " >&6
-else $as_nop
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for $ac_word" >&5
+$as_echo_n "checking for $ac_word... " >&6; }
+if ${ac_cv_prog_ac_ct_NMEDIT+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
   if test -n "$ac_ct_NMEDIT"; then
   ac_cv_prog_ac_ct_NMEDIT="$ac_ct_NMEDIT" # Let the user override the test.
 else
@@ -10681,15 +9816,11 @@ as_save_IFS=$IFS; IFS=$PATH_SEPARATOR
 for as_dir in $PATH
 do
   IFS=$as_save_IFS
-  case $as_dir in #(((
-    '') as_dir=./ ;;
-    */) ;;
-    *) as_dir=$as_dir/ ;;
-  esac
+  test -z "$as_dir" && as_dir=.
     for ac_exec_ext in '' $ac_executable_extensions; do
-  if as_fn_executable_p "$as_dir$ac_word$ac_exec_ext"; then
+  if as_fn_executable_p "$as_dir/$ac_word$ac_exec_ext"; then
     ac_cv_prog_ac_ct_NMEDIT="nmedit"
-    printf "%s\n" "$as_me:${as_lineno-$LINENO}: found $as_dir$ac_word$ac_exec_ext" >&5
+    $as_echo "$as_me:${as_lineno-$LINENO}: found $as_dir/$ac_word$ac_exec_ext" >&5
     break 2
   fi
 done
@@ -10700,11 +9831,11 @@ fi
 fi
 ac_ct_NMEDIT=$ac_cv_prog_ac_ct_NMEDIT
 if test -n "$ac_ct_NMEDIT"; then
-  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $ac_ct_NMEDIT" >&5
-printf "%s\n" "$ac_ct_NMEDIT" >&6; }
+  { $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_ct_NMEDIT" >&5
+$as_echo "$ac_ct_NMEDIT" >&6; }
 else
-  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: no" >&5
-printf "%s\n" "no" >&6; }
+  { $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
+$as_echo "no" >&6; }
 fi
 
   if test "x$ac_ct_NMEDIT" = x; then
@@ -10712,8 +9843,8 @@ fi
   else
     case $cross_compiling:$ac_tool_warned in
 yes:)
-{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: WARNING: using cross tools not prefixed with host triplet" >&5
-printf "%s\n" "$as_me: WARNING: using cross tools not prefixed with host triplet" >&2;}
+{ $as_echo "$as_me:${as_lineno-$LINENO}: WARNING: using cross tools not prefixed with host triplet" >&5
+$as_echo "$as_me: WARNING: using cross tools not prefixed with host triplet" >&2;}
 ac_tool_warned=yes ;;
 esac
     NMEDIT=$ac_ct_NMEDIT
@@ -10725,12 +9856,11 @@ fi
     if test -n "$ac_tool_prefix"; then
   # Extract the first word of "${ac_tool_prefix}lipo", so it can be a program name with args.
 set dummy ${ac_tool_prefix}lipo; ac_word=$2
-{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for $ac_word" >&5
-printf %s "checking for $ac_word... " >&6; }
-if test ${ac_cv_prog_LIPO+y}
-then :
-  printf %s "(cached) " >&6
-else $as_nop
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for $ac_word" >&5
+$as_echo_n "checking for $ac_word... " >&6; }
+if ${ac_cv_prog_LIPO+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
   if test -n "$LIPO"; then
   ac_cv_prog_LIPO="$LIPO" # Let the user override the test.
 else
@@ -10738,15 +9868,11 @@ as_save_IFS=$IFS; IFS=$PATH_SEPARATOR
 for as_dir in $PATH
 do
   IFS=$as_save_IFS
-  case $as_dir in #(((
-    '') as_dir=./ ;;
-    */) ;;
-    *) as_dir=$as_dir/ ;;
-  esac
+  test -z "$as_dir" && as_dir=.
     for ac_exec_ext in '' $ac_executable_extensions; do
-  if as_fn_executable_p "$as_dir$ac_word$ac_exec_ext"; then
+  if as_fn_executable_p "$as_dir/$ac_word$ac_exec_ext"; then
     ac_cv_prog_LIPO="${ac_tool_prefix}lipo"
-    printf "%s\n" "$as_me:${as_lineno-$LINENO}: found $as_dir$ac_word$ac_exec_ext" >&5
+    $as_echo "$as_me:${as_lineno-$LINENO}: found $as_dir/$ac_word$ac_exec_ext" >&5
     break 2
   fi
 done
@@ -10757,11 +9883,11 @@ fi
 fi
 LIPO=$ac_cv_prog_LIPO
 if test -n "$LIPO"; then
-  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $LIPO" >&5
-printf "%s\n" "$LIPO" >&6; }
+  { $as_echo "$as_me:${as_lineno-$LINENO}: result: $LIPO" >&5
+$as_echo "$LIPO" >&6; }
 else
-  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: no" >&5
-printf "%s\n" "no" >&6; }
+  { $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
+$as_echo "no" >&6; }
 fi
 
 
@@ -10770,12 +9896,11 @@ if test -z "$ac_cv_prog_LIPO"; then
   ac_ct_LIPO=$LIPO
   # Extract the first word of "lipo", so it can be a program name with args.
 set dummy lipo; ac_word=$2
-{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for $ac_word" >&5
-printf %s "checking for $ac_word... " >&6; }
-if test ${ac_cv_prog_ac_ct_LIPO+y}
-then :
-  printf %s "(cached) " >&6
-else $as_nop
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for $ac_word" >&5
+$as_echo_n "checking for $ac_word... " >&6; }
+if ${ac_cv_prog_ac_ct_LIPO+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
   if test -n "$ac_ct_LIPO"; then
   ac_cv_prog_ac_ct_LIPO="$ac_ct_LIPO" # Let the user override the test.
 else
@@ -10783,15 +9908,11 @@ as_save_IFS=$IFS; IFS=$PATH_SEPARATOR
 for as_dir in $PATH
 do
   IFS=$as_save_IFS
-  case $as_dir in #(((
-    '') as_dir=./ ;;
-    */) ;;
-    *) as_dir=$as_dir/ ;;
-  esac
+  test -z "$as_dir" && as_dir=.
     for ac_exec_ext in '' $ac_executable_extensions; do
-  if as_fn_executable_p "$as_dir$ac_word$ac_exec_ext"; then
+  if as_fn_executable_p "$as_dir/$ac_word$ac_exec_ext"; then
     ac_cv_prog_ac_ct_LIPO="lipo"
-    printf "%s\n" "$as_me:${as_lineno-$LINENO}: found $as_dir$ac_word$ac_exec_ext" >&5
+    $as_echo "$as_me:${as_lineno-$LINENO}: found $as_dir/$ac_word$ac_exec_ext" >&5
     break 2
   fi
 done
@@ -10802,11 +9923,11 @@ fi
 fi
 ac_ct_LIPO=$ac_cv_prog_ac_ct_LIPO
 if test -n "$ac_ct_LIPO"; then
-  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $ac_ct_LIPO" >&5
-printf "%s\n" "$ac_ct_LIPO" >&6; }
+  { $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_ct_LIPO" >&5
+$as_echo "$ac_ct_LIPO" >&6; }
 else
-  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: no" >&5
-printf "%s\n" "no" >&6; }
+  { $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
+$as_echo "no" >&6; }
 fi
 
   if test "x$ac_ct_LIPO" = x; then
@@ -10814,8 +9935,8 @@ fi
   else
     case $cross_compiling:$ac_tool_warned in
 yes:)
-{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: WARNING: using cross tools not prefixed with host triplet" >&5
-printf "%s\n" "$as_me: WARNING: using cross tools not prefixed with host triplet" >&2;}
+{ $as_echo "$as_me:${as_lineno-$LINENO}: WARNING: using cross tools not prefixed with host triplet" >&5
+$as_echo "$as_me: WARNING: using cross tools not prefixed with host triplet" >&2;}
 ac_tool_warned=yes ;;
 esac
     LIPO=$ac_ct_LIPO
@@ -10827,12 +9948,11 @@ fi
     if test -n "$ac_tool_prefix"; then
   # Extract the first word of "${ac_tool_prefix}otool", so it can be a program name with args.
 set dummy ${ac_tool_prefix}otool; ac_word=$2
-{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for $ac_word" >&5
-printf %s "checking for $ac_word... " >&6; }
-if test ${ac_cv_prog_OTOOL+y}
-then :
-  printf %s "(cached) " >&6
-else $as_nop
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for $ac_word" >&5
+$as_echo_n "checking for $ac_word... " >&6; }
+if ${ac_cv_prog_OTOOL+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
   if test -n "$OTOOL"; then
   ac_cv_prog_OTOOL="$OTOOL" # Let the user override the test.
 else
@@ -10840,15 +9960,11 @@ as_save_IFS=$IFS; IFS=$PATH_SEPARATOR
 for as_dir in $PATH
 do
   IFS=$as_save_IFS
-  case $as_dir in #(((
-    '') as_dir=./ ;;
-    */) ;;
-    *) as_dir=$as_dir/ ;;
-  esac
+  test -z "$as_dir" && as_dir=.
     for ac_exec_ext in '' $ac_executable_extensions; do
-  if as_fn_executable_p "$as_dir$ac_word$ac_exec_ext"; then
+  if as_fn_executable_p "$as_dir/$ac_word$ac_exec_ext"; then
     ac_cv_prog_OTOOL="${ac_tool_prefix}otool"
-    printf "%s\n" "$as_me:${as_lineno-$LINENO}: found $as_dir$ac_word$ac_exec_ext" >&5
+    $as_echo "$as_me:${as_lineno-$LINENO}: found $as_dir/$ac_word$ac_exec_ext" >&5
     break 2
   fi
 done
@@ -10859,11 +9975,11 @@ fi
 fi
 OTOOL=$ac_cv_prog_OTOOL
 if test -n "$OTOOL"; then
-  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $OTOOL" >&5
-printf "%s\n" "$OTOOL" >&6; }
+  { $as_echo "$as_me:${as_lineno-$LINENO}: result: $OTOOL" >&5
+$as_echo "$OTOOL" >&6; }
 else
-  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: no" >&5
-printf "%s\n" "no" >&6; }
+  { $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
+$as_echo "no" >&6; }
 fi
 
 
@@ -10872,12 +9988,11 @@ if test -z "$ac_cv_prog_OTOOL"; then
   ac_ct_OTOOL=$OTOOL
   # Extract the first word of "otool", so it can be a program name with args.
 set dummy otool; ac_word=$2
-{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for $ac_word" >&5
-printf %s "checking for $ac_word... " >&6; }
-if test ${ac_cv_prog_ac_ct_OTOOL+y}
-then :
-  printf %s "(cached) " >&6
-else $as_nop
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for $ac_word" >&5
+$as_echo_n "checking for $ac_word... " >&6; }
+if ${ac_cv_prog_ac_ct_OTOOL+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
   if test -n "$ac_ct_OTOOL"; then
   ac_cv_prog_ac_ct_OTOOL="$ac_ct_OTOOL" # Let the user override the test.
 else
@@ -10885,15 +10000,11 @@ as_save_IFS=$IFS; IFS=$PATH_SEPARATOR
 for as_dir in $PATH
 do
   IFS=$as_save_IFS
-  case $as_dir in #(((
-    '') as_dir=./ ;;
-    */) ;;
-    *) as_dir=$as_dir/ ;;
-  esac
+  test -z "$as_dir" && as_dir=.
     for ac_exec_ext in '' $ac_executable_extensions; do
-  if as_fn_executable_p "$as_dir$ac_word$ac_exec_ext"; then
+  if as_fn_executable_p "$as_dir/$ac_word$ac_exec_ext"; then
     ac_cv_prog_ac_ct_OTOOL="otool"
-    printf "%s\n" "$as_me:${as_lineno-$LINENO}: found $as_dir$ac_word$ac_exec_ext" >&5
+    $as_echo "$as_me:${as_lineno-$LINENO}: found $as_dir/$ac_word$ac_exec_ext" >&5
     break 2
   fi
 done
@@ -10904,11 +10015,11 @@ fi
 fi
 ac_ct_OTOOL=$ac_cv_prog_ac_ct_OTOOL
 if test -n "$ac_ct_OTOOL"; then
-  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $ac_ct_OTOOL" >&5
-printf "%s\n" "$ac_ct_OTOOL" >&6; }
+  { $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_ct_OTOOL" >&5
+$as_echo "$ac_ct_OTOOL" >&6; }
 else
-  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: no" >&5
-printf "%s\n" "no" >&6; }
+  { $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
+$as_echo "no" >&6; }
 fi
 
   if test "x$ac_ct_OTOOL" = x; then
@@ -10916,8 +10027,8 @@ fi
   else
     case $cross_compiling:$ac_tool_warned in
 yes:)
-{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: WARNING: using cross tools not prefixed with host triplet" >&5
-printf "%s\n" "$as_me: WARNING: using cross tools not prefixed with host triplet" >&2;}
+{ $as_echo "$as_me:${as_lineno-$LINENO}: WARNING: using cross tools not prefixed with host triplet" >&5
+$as_echo "$as_me: WARNING: using cross tools not prefixed with host triplet" >&2;}
 ac_tool_warned=yes ;;
 esac
     OTOOL=$ac_ct_OTOOL
@@ -10929,12 +10040,11 @@ fi
     if test -n "$ac_tool_prefix"; then
   # Extract the first word of "${ac_tool_prefix}otool64", so it can be a program name with args.
 set dummy ${ac_tool_prefix}otool64; ac_word=$2
-{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for $ac_word" >&5
-printf %s "checking for $ac_word... " >&6; }
-if test ${ac_cv_prog_OTOOL64+y}
-then :
-  printf %s "(cached) " >&6
-else $as_nop
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for $ac_word" >&5
+$as_echo_n "checking for $ac_word... " >&6; }
+if ${ac_cv_prog_OTOOL64+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
   if test -n "$OTOOL64"; then
   ac_cv_prog_OTOOL64="$OTOOL64" # Let the user override the test.
 else
@@ -10942,15 +10052,11 @@ as_save_IFS=$IFS; IFS=$PATH_SEPARATOR
 for as_dir in $PATH
 do
   IFS=$as_save_IFS
-  case $as_dir in #(((
-    '') as_dir=./ ;;
-    */) ;;
-    *) as_dir=$as_dir/ ;;
-  esac
+  test -z "$as_dir" && as_dir=.
     for ac_exec_ext in '' $ac_executable_extensions; do
-  if as_fn_executable_p "$as_dir$ac_word$ac_exec_ext"; then
+  if as_fn_executable_p "$as_dir/$ac_word$ac_exec_ext"; then
     ac_cv_prog_OTOOL64="${ac_tool_prefix}otool64"
-    printf "%s\n" "$as_me:${as_lineno-$LINENO}: found $as_dir$ac_word$ac_exec_ext" >&5
+    $as_echo "$as_me:${as_lineno-$LINENO}: found $as_dir/$ac_word$ac_exec_ext" >&5
     break 2
   fi
 done
@@ -10961,11 +10067,11 @@ fi
 fi
 OTOOL64=$ac_cv_prog_OTOOL64
 if test -n "$OTOOL64"; then
-  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $OTOOL64" >&5
-printf "%s\n" "$OTOOL64" >&6; }
+  { $as_echo "$as_me:${as_lineno-$LINENO}: result: $OTOOL64" >&5
+$as_echo "$OTOOL64" >&6; }
 else
-  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: no" >&5
-printf "%s\n" "no" >&6; }
+  { $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
+$as_echo "no" >&6; }
 fi
 
 
@@ -10974,12 +10080,11 @@ if test -z "$ac_cv_prog_OTOOL64"; then
   ac_ct_OTOOL64=$OTOOL64
   # Extract the first word of "otool64", so it can be a program name with args.
 set dummy otool64; ac_word=$2
-{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for $ac_word" >&5
-printf %s "checking for $ac_word... " >&6; }
-if test ${ac_cv_prog_ac_ct_OTOOL64+y}
-then :
-  printf %s "(cached) " >&6
-else $as_nop
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for $ac_word" >&5
+$as_echo_n "checking for $ac_word... " >&6; }
+if ${ac_cv_prog_ac_ct_OTOOL64+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
   if test -n "$ac_ct_OTOOL64"; then
   ac_cv_prog_ac_ct_OTOOL64="$ac_ct_OTOOL64" # Let the user override the test.
 else
@@ -10987,15 +10092,11 @@ as_save_IFS=$IFS; IFS=$PATH_SEPARATOR
 for as_dir in $PATH
 do
   IFS=$as_save_IFS
-  case $as_dir in #(((
-    '') as_dir=./ ;;
-    */) ;;
-    *) as_dir=$as_dir/ ;;
-  esac
+  test -z "$as_dir" && as_dir=.
     for ac_exec_ext in '' $ac_executable_extensions; do
-  if as_fn_executable_p "$as_dir$ac_word$ac_exec_ext"; then
+  if as_fn_executable_p "$as_dir/$ac_word$ac_exec_ext"; then
     ac_cv_prog_ac_ct_OTOOL64="otool64"
-    printf "%s\n" "$as_me:${as_lineno-$LINENO}: found $as_dir$ac_word$ac_exec_ext" >&5
+    $as_echo "$as_me:${as_lineno-$LINENO}: found $as_dir/$ac_word$ac_exec_ext" >&5
     break 2
   fi
 done
@@ -11006,11 +10107,11 @@ fi
 fi
 ac_ct_OTOOL64=$ac_cv_prog_ac_ct_OTOOL64
 if test -n "$ac_ct_OTOOL64"; then
-  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $ac_ct_OTOOL64" >&5
-printf "%s\n" "$ac_ct_OTOOL64" >&6; }
+  { $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_ct_OTOOL64" >&5
+$as_echo "$ac_ct_OTOOL64" >&6; }
 else
-  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: no" >&5
-printf "%s\n" "no" >&6; }
+  { $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
+$as_echo "no" >&6; }
 fi
 
   if test "x$ac_ct_OTOOL64" = x; then
@@ -11018,8 +10119,8 @@ fi
   else
     case $cross_compiling:$ac_tool_warned in
 yes:)
-{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: WARNING: using cross tools not prefixed with host triplet" >&5
-printf "%s\n" "$as_me: WARNING: using cross tools not prefixed with host triplet" >&2;}
+{ $as_echo "$as_me:${as_lineno-$LINENO}: WARNING: using cross tools not prefixed with host triplet" >&5
+$as_echo "$as_me: WARNING: using cross tools not prefixed with host triplet" >&2;}
 ac_tool_warned=yes ;;
 esac
     OTOOL64=$ac_ct_OTOOL64
@@ -11054,12 +10155,11 @@ fi
 
 
 
-    { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for -single_module linker flag" >&5
-printf %s "checking for -single_module linker flag... " >&6; }
-if test ${lt_cv_apple_cc_single_mod+y}
-then :
-  printf %s "(cached) " >&6
-else $as_nop
+    { $as_echo "$as_me:${as_lineno-$LINENO}: checking for -single_module linker flag" >&5
+$as_echo_n "checking for -single_module linker flag... " >&6; }
+if ${lt_cv_apple_cc_single_mod+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
   lt_cv_apple_cc_single_mod=no
       if test -z "$LT_MULTI_MODULE"; then
 	# By default we will add the -single_module flag. You can override
@@ -11088,15 +10188,14 @@ else $as_nop
 	rm -f conftest.*
       fi
 fi
-{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $lt_cv_apple_cc_single_mod" >&5
-printf "%s\n" "$lt_cv_apple_cc_single_mod" >&6; }
+{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $lt_cv_apple_cc_single_mod" >&5
+$as_echo "$lt_cv_apple_cc_single_mod" >&6; }
 
-    { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for -exported_symbols_list linker flag" >&5
-printf %s "checking for -exported_symbols_list linker flag... " >&6; }
-if test ${lt_cv_ld_exported_symbols_list+y}
-then :
-  printf %s "(cached) " >&6
-else $as_nop
+    { $as_echo "$as_me:${as_lineno-$LINENO}: checking for -exported_symbols_list linker flag" >&5
+$as_echo_n "checking for -exported_symbols_list linker flag... " >&6; }
+if ${lt_cv_ld_exported_symbols_list+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
   lt_cv_ld_exported_symbols_list=no
       save_LDFLAGS=$LDFLAGS
       echo "_main" > conftest.sym
@@ -11105,33 +10204,31 @@ else $as_nop
 /* end confdefs.h.  */
 
 int
-main (void)
+main ()
 {
 
   ;
   return 0;
 }
 _ACEOF
-if ac_fn_c_try_link "$LINENO"
-then :
+if ac_fn_c_try_link "$LINENO"; then :
   lt_cv_ld_exported_symbols_list=yes
-else $as_nop
+else
   lt_cv_ld_exported_symbols_list=no
 fi
-rm -f core conftest.err conftest.$ac_objext conftest.beam \
+rm -f core conftest.err conftest.$ac_objext \
     conftest$ac_exeext conftest.$ac_ext
 	LDFLAGS=$save_LDFLAGS
 
 fi
-{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $lt_cv_ld_exported_symbols_list" >&5
-printf "%s\n" "$lt_cv_ld_exported_symbols_list" >&6; }
+{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $lt_cv_ld_exported_symbols_list" >&5
+$as_echo "$lt_cv_ld_exported_symbols_list" >&6; }
 
-    { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for -force_load linker flag" >&5
-printf %s "checking for -force_load linker flag... " >&6; }
-if test ${lt_cv_ld_force_load+y}
-then :
-  printf %s "(cached) " >&6
-else $as_nop
+    { $as_echo "$as_me:${as_lineno-$LINENO}: checking for -force_load linker flag" >&5
+$as_echo_n "checking for -force_load linker flag... " >&6; }
+if ${lt_cv_ld_force_load+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
   lt_cv_ld_force_load=no
       cat > conftest.c << _LT_EOF
 int forced_loaded() { return 2;}
@@ -11159,8 +10256,8 @@ _LT_EOF
         rm -rf conftest.dSYM
 
 fi
-{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $lt_cv_ld_force_load" >&5
-printf "%s\n" "$lt_cv_ld_force_load" >&6; }
+{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $lt_cv_ld_force_load" >&5
+$as_echo "$lt_cv_ld_force_load" >&6; }
     case $host_os in
     rhapsody* | darwin1.[012])
       _lt_dar_allow_undefined='$wl-undefined ${wl}suppress' ;;
@@ -11231,13 +10328,18 @@ func_munge_path_list ()
     esac
 }
 
-ac_fn_c_check_header_compile "$LINENO" "dlfcn.h" "ac_cv_header_dlfcn_h" "$ac_includes_default
+for ac_header in dlfcn.h
+do :
+  ac_fn_c_check_header_compile "$LINENO" "dlfcn.h" "ac_cv_header_dlfcn_h" "$ac_includes_default
 "
-if test "x$ac_cv_header_dlfcn_h" = xyes
-then :
-  printf "%s\n" "#define HAVE_DLFCN_H 1" >>confdefs.h
+if test "x$ac_cv_header_dlfcn_h" = xyes; then :
+  cat >>confdefs.h <<_ACEOF
+#define HAVE_DLFCN_H 1
+_ACEOF
 
 fi
+
+done
 
 
 
@@ -11256,8 +10358,7 @@ fi
 
 
             # Check whether --enable-shared was given.
-if test ${enable_shared+y}
-then :
+if test "${enable_shared+set}" = set; then :
   enableval=$enable_shared; p=${PACKAGE-default}
     case $enableval in
     yes) enable_shared=yes ;;
@@ -11275,7 +10376,7 @@ then :
       IFS=$lt_save_ifs
       ;;
     esac
-else $as_nop
+else
   enable_shared=yes
 fi
 
@@ -11288,8 +10389,7 @@ fi
 
 
   # Check whether --enable-static was given.
-if test ${enable_static+y}
-then :
+if test "${enable_static+set}" = set; then :
   enableval=$enable_static; p=${PACKAGE-default}
     case $enableval in
     yes) enable_static=yes ;;
@@ -11307,7 +10407,7 @@ then :
       IFS=$lt_save_ifs
       ;;
     esac
-else $as_nop
+else
   enable_static=yes
 fi
 
@@ -11321,8 +10421,7 @@ fi
 
 
 # Check whether --with-pic was given.
-if test ${with_pic+y}
-then :
+if test "${with_pic+set}" = set; then :
   withval=$with_pic; lt_p=${PACKAGE-default}
     case $withval in
     yes|no) pic_mode=$withval ;;
@@ -11339,7 +10438,7 @@ then :
       IFS=$lt_save_ifs
       ;;
     esac
-else $as_nop
+else
   pic_mode=default
 fi
 
@@ -11351,8 +10450,7 @@ fi
 
 
   # Check whether --enable-fast-install was given.
-if test ${enable_fast_install+y}
-then :
+if test "${enable_fast_install+set}" = set; then :
   enableval=$enable_fast_install; p=${PACKAGE-default}
     case $enableval in
     yes) enable_fast_install=yes ;;
@@ -11370,7 +10468,7 @@ then :
       IFS=$lt_save_ifs
       ;;
     esac
-else $as_nop
+else
   enable_fast_install=yes
 fi
 
@@ -11384,12 +10482,11 @@ fi
   shared_archive_member_spec=
 case $host,$enable_shared in
 power*-*-aix[5-9]*,yes)
-  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking which variant of shared library versioning to provide" >&5
-printf %s "checking which variant of shared library versioning to provide... " >&6; }
+  { $as_echo "$as_me:${as_lineno-$LINENO}: checking which variant of shared library versioning to provide" >&5
+$as_echo_n "checking which variant of shared library versioning to provide... " >&6; }
 
 # Check whether --with-aix-soname was given.
-if test ${with_aix_soname+y}
-then :
+if test "${with_aix_soname+set}" = set; then :
   withval=$with_aix_soname; case $withval in
     aix|svr4|both)
       ;;
@@ -11398,19 +10495,18 @@ then :
       ;;
     esac
     lt_cv_with_aix_soname=$with_aix_soname
-else $as_nop
-  if test ${lt_cv_with_aix_soname+y}
-then :
-  printf %s "(cached) " >&6
-else $as_nop
+else
+  if ${lt_cv_with_aix_soname+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
   lt_cv_with_aix_soname=aix
 fi
 
     with_aix_soname=$lt_cv_with_aix_soname
 fi
 
-  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $with_aix_soname" >&5
-printf "%s\n" "$with_aix_soname" >&6; }
+  { $as_echo "$as_me:${as_lineno-$LINENO}: result: $with_aix_soname" >&5
+$as_echo "$with_aix_soname" >&6; }
   if test aix != "$with_aix_soname"; then
     # For the AIX way of multilib, we name the shared archive member
     # based on the bitwidth used, traditionally 'shr.o' or 'shr_64.o',
@@ -11492,12 +10588,11 @@ if test -n "${ZSH_VERSION+set}"; then
    setopt NO_GLOB_SUBST
 fi
 
-{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for objdir" >&5
-printf %s "checking for objdir... " >&6; }
-if test ${lt_cv_objdir+y}
-then :
-  printf %s "(cached) " >&6
-else $as_nop
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for objdir" >&5
+$as_echo_n "checking for objdir... " >&6; }
+if ${lt_cv_objdir+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
   rm -f .libs 2>/dev/null
 mkdir .libs 2>/dev/null
 if test -d .libs; then
@@ -11508,15 +10603,17 @@ else
 fi
 rmdir .libs 2>/dev/null
 fi
-{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $lt_cv_objdir" >&5
-printf "%s\n" "$lt_cv_objdir" >&6; }
+{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $lt_cv_objdir" >&5
+$as_echo "$lt_cv_objdir" >&6; }
 objdir=$lt_cv_objdir
 
 
 
 
 
-printf "%s\n" "#define LT_OBJDIR \"$lt_cv_objdir/\"" >>confdefs.h
+cat >>confdefs.h <<_ACEOF
+#define LT_OBJDIR "$lt_cv_objdir/"
+_ACEOF
 
 
 
@@ -11562,12 +10659,11 @@ test -z "$MAGIC_CMD" && MAGIC_CMD=file
 case $deplibs_check_method in
 file_magic*)
   if test "$file_magic_cmd" = '$MAGIC_CMD'; then
-    { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for ${ac_tool_prefix}file" >&5
-printf %s "checking for ${ac_tool_prefix}file... " >&6; }
-if test ${lt_cv_path_MAGIC_CMD+y}
-then :
-  printf %s "(cached) " >&6
-else $as_nop
+    { $as_echo "$as_me:${as_lineno-$LINENO}: checking for ${ac_tool_prefix}file" >&5
+$as_echo_n "checking for ${ac_tool_prefix}file... " >&6; }
+if ${lt_cv_path_MAGIC_CMD+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
   case $MAGIC_CMD in
 [\\/*] |  ?:[\\/]*)
   lt_cv_path_MAGIC_CMD=$MAGIC_CMD # Let the user override the test with a path.
@@ -11616,11 +10712,11 @@ fi
 
 MAGIC_CMD=$lt_cv_path_MAGIC_CMD
 if test -n "$MAGIC_CMD"; then
-  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $MAGIC_CMD" >&5
-printf "%s\n" "$MAGIC_CMD" >&6; }
+  { $as_echo "$as_me:${as_lineno-$LINENO}: result: $MAGIC_CMD" >&5
+$as_echo "$MAGIC_CMD" >&6; }
 else
-  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: no" >&5
-printf "%s\n" "no" >&6; }
+  { $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
+$as_echo "no" >&6; }
 fi
 
 
@@ -11629,12 +10725,11 @@ fi
 
 if test -z "$lt_cv_path_MAGIC_CMD"; then
   if test -n "$ac_tool_prefix"; then
-    { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for file" >&5
-printf %s "checking for file... " >&6; }
-if test ${lt_cv_path_MAGIC_CMD+y}
-then :
-  printf %s "(cached) " >&6
-else $as_nop
+    { $as_echo "$as_me:${as_lineno-$LINENO}: checking for file" >&5
+$as_echo_n "checking for file... " >&6; }
+if ${lt_cv_path_MAGIC_CMD+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
   case $MAGIC_CMD in
 [\\/*] |  ?:[\\/]*)
   lt_cv_path_MAGIC_CMD=$MAGIC_CMD # Let the user override the test with a path.
@@ -11683,11 +10778,11 @@ fi
 
 MAGIC_CMD=$lt_cv_path_MAGIC_CMD
 if test -n "$MAGIC_CMD"; then
-  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $MAGIC_CMD" >&5
-printf "%s\n" "$MAGIC_CMD" >&6; }
+  { $as_echo "$as_me:${as_lineno-$LINENO}: result: $MAGIC_CMD" >&5
+$as_echo "$MAGIC_CMD" >&6; }
 else
-  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: no" >&5
-printf "%s\n" "no" >&6; }
+  { $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
+$as_echo "no" >&6; }
 fi
 
 
@@ -11768,12 +10863,11 @@ if test yes = "$GCC"; then
     lt_prog_compiler_no_builtin_flag=' -fno-builtin' ;;
   esac
 
-  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking if $compiler supports -fno-rtti -fno-exceptions" >&5
-printf %s "checking if $compiler supports -fno-rtti -fno-exceptions... " >&6; }
-if test ${lt_cv_prog_compiler_rtti_exceptions+y}
-then :
-  printf %s "(cached) " >&6
-else $as_nop
+  { $as_echo "$as_me:${as_lineno-$LINENO}: checking if $compiler supports -fno-rtti -fno-exceptions" >&5
+$as_echo_n "checking if $compiler supports -fno-rtti -fno-exceptions... " >&6; }
+if ${lt_cv_prog_compiler_rtti_exceptions+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
   lt_cv_prog_compiler_rtti_exceptions=no
    ac_outfile=conftest.$ac_objext
    echo "$lt_simple_compile_test_code" > conftest.$ac_ext
@@ -11804,8 +10898,8 @@ else $as_nop
    $RM conftest*
 
 fi
-{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $lt_cv_prog_compiler_rtti_exceptions" >&5
-printf "%s\n" "$lt_cv_prog_compiler_rtti_exceptions" >&6; }
+{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $lt_cv_prog_compiler_rtti_exceptions" >&5
+$as_echo "$lt_cv_prog_compiler_rtti_exceptions" >&6; }
 
 if test yes = "$lt_cv_prog_compiler_rtti_exceptions"; then
     lt_prog_compiler_no_builtin_flag="$lt_prog_compiler_no_builtin_flag -fno-rtti -fno-exceptions"
@@ -12162,28 +11256,26 @@ case $host_os in
     ;;
 esac
 
-{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for $compiler option to produce PIC" >&5
-printf %s "checking for $compiler option to produce PIC... " >&6; }
-if test ${lt_cv_prog_compiler_pic+y}
-then :
-  printf %s "(cached) " >&6
-else $as_nop
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for $compiler option to produce PIC" >&5
+$as_echo_n "checking for $compiler option to produce PIC... " >&6; }
+if ${lt_cv_prog_compiler_pic+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
   lt_cv_prog_compiler_pic=$lt_prog_compiler_pic
 fi
-{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $lt_cv_prog_compiler_pic" >&5
-printf "%s\n" "$lt_cv_prog_compiler_pic" >&6; }
+{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $lt_cv_prog_compiler_pic" >&5
+$as_echo "$lt_cv_prog_compiler_pic" >&6; }
 lt_prog_compiler_pic=$lt_cv_prog_compiler_pic
 
 #
 # Check to make sure the PIC flag actually works.
 #
 if test -n "$lt_prog_compiler_pic"; then
-  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking if $compiler PIC flag $lt_prog_compiler_pic works" >&5
-printf %s "checking if $compiler PIC flag $lt_prog_compiler_pic works... " >&6; }
-if test ${lt_cv_prog_compiler_pic_works+y}
-then :
-  printf %s "(cached) " >&6
-else $as_nop
+  { $as_echo "$as_me:${as_lineno-$LINENO}: checking if $compiler PIC flag $lt_prog_compiler_pic works" >&5
+$as_echo_n "checking if $compiler PIC flag $lt_prog_compiler_pic works... " >&6; }
+if ${lt_cv_prog_compiler_pic_works+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
   lt_cv_prog_compiler_pic_works=no
    ac_outfile=conftest.$ac_objext
    echo "$lt_simple_compile_test_code" > conftest.$ac_ext
@@ -12214,8 +11306,8 @@ else $as_nop
    $RM conftest*
 
 fi
-{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $lt_cv_prog_compiler_pic_works" >&5
-printf "%s\n" "$lt_cv_prog_compiler_pic_works" >&6; }
+{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $lt_cv_prog_compiler_pic_works" >&5
+$as_echo "$lt_cv_prog_compiler_pic_works" >&6; }
 
 if test yes = "$lt_cv_prog_compiler_pic_works"; then
     case $lt_prog_compiler_pic in
@@ -12243,12 +11335,11 @@ fi
 # Check to make sure the static flag actually works.
 #
 wl=$lt_prog_compiler_wl eval lt_tmp_static_flag=\"$lt_prog_compiler_static\"
-{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking if $compiler static flag $lt_tmp_static_flag works" >&5
-printf %s "checking if $compiler static flag $lt_tmp_static_flag works... " >&6; }
-if test ${lt_cv_prog_compiler_static_works+y}
-then :
-  printf %s "(cached) " >&6
-else $as_nop
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking if $compiler static flag $lt_tmp_static_flag works" >&5
+$as_echo_n "checking if $compiler static flag $lt_tmp_static_flag works... " >&6; }
+if ${lt_cv_prog_compiler_static_works+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
   lt_cv_prog_compiler_static_works=no
    save_LDFLAGS=$LDFLAGS
    LDFLAGS="$LDFLAGS $lt_tmp_static_flag"
@@ -12272,8 +11363,8 @@ else $as_nop
    LDFLAGS=$save_LDFLAGS
 
 fi
-{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $lt_cv_prog_compiler_static_works" >&5
-printf "%s\n" "$lt_cv_prog_compiler_static_works" >&6; }
+{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $lt_cv_prog_compiler_static_works" >&5
+$as_echo "$lt_cv_prog_compiler_static_works" >&6; }
 
 if test yes = "$lt_cv_prog_compiler_static_works"; then
     :
@@ -12287,12 +11378,11 @@ fi
 
 
 
-  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking if $compiler supports -c -o file.$ac_objext" >&5
-printf %s "checking if $compiler supports -c -o file.$ac_objext... " >&6; }
-if test ${lt_cv_prog_compiler_c_o+y}
-then :
-  printf %s "(cached) " >&6
-else $as_nop
+  { $as_echo "$as_me:${as_lineno-$LINENO}: checking if $compiler supports -c -o file.$ac_objext" >&5
+$as_echo_n "checking if $compiler supports -c -o file.$ac_objext... " >&6; }
+if ${lt_cv_prog_compiler_c_o+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
   lt_cv_prog_compiler_c_o=no
    $RM -r conftest 2>/dev/null
    mkdir conftest
@@ -12335,20 +11425,19 @@ else $as_nop
    $RM conftest*
 
 fi
-{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $lt_cv_prog_compiler_c_o" >&5
-printf "%s\n" "$lt_cv_prog_compiler_c_o" >&6; }
+{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $lt_cv_prog_compiler_c_o" >&5
+$as_echo "$lt_cv_prog_compiler_c_o" >&6; }
 
 
 
 
 
 
-  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking if $compiler supports -c -o file.$ac_objext" >&5
-printf %s "checking if $compiler supports -c -o file.$ac_objext... " >&6; }
-if test ${lt_cv_prog_compiler_c_o+y}
-then :
-  printf %s "(cached) " >&6
-else $as_nop
+  { $as_echo "$as_me:${as_lineno-$LINENO}: checking if $compiler supports -c -o file.$ac_objext" >&5
+$as_echo_n "checking if $compiler supports -c -o file.$ac_objext... " >&6; }
+if ${lt_cv_prog_compiler_c_o+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
   lt_cv_prog_compiler_c_o=no
    $RM -r conftest 2>/dev/null
    mkdir conftest
@@ -12391,8 +11480,8 @@ else $as_nop
    $RM conftest*
 
 fi
-{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $lt_cv_prog_compiler_c_o" >&5
-printf "%s\n" "$lt_cv_prog_compiler_c_o" >&6; }
+{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $lt_cv_prog_compiler_c_o" >&5
+$as_echo "$lt_cv_prog_compiler_c_o" >&6; }
 
 
 
@@ -12400,19 +11489,19 @@ printf "%s\n" "$lt_cv_prog_compiler_c_o" >&6; }
 hard_links=nottested
 if test no = "$lt_cv_prog_compiler_c_o" && test no != "$need_locks"; then
   # do not overwrite the value of need_locks provided by the user
-  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking if we can lock with hard links" >&5
-printf %s "checking if we can lock with hard links... " >&6; }
+  { $as_echo "$as_me:${as_lineno-$LINENO}: checking if we can lock with hard links" >&5
+$as_echo_n "checking if we can lock with hard links... " >&6; }
   hard_links=yes
   $RM conftest*
   ln conftest.a conftest.b 2>/dev/null && hard_links=no
   touch conftest.a
   ln conftest.a conftest.b 2>&5 || hard_links=no
   ln conftest.a conftest.b 2>/dev/null && hard_links=no
-  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $hard_links" >&5
-printf "%s\n" "$hard_links" >&6; }
+  { $as_echo "$as_me:${as_lineno-$LINENO}: result: $hard_links" >&5
+$as_echo "$hard_links" >&6; }
   if test no = "$hard_links"; then
-    { printf "%s\n" "$as_me:${as_lineno-$LINENO}: WARNING: '$CC' does not support '-c -o', so 'make -j' may be unsafe" >&5
-printf "%s\n" "$as_me: WARNING: '$CC' does not support '-c -o', so 'make -j' may be unsafe" >&2;}
+    { $as_echo "$as_me:${as_lineno-$LINENO}: WARNING: '$CC' does not support '-c -o', so 'make -j' may be unsafe" >&5
+$as_echo "$as_me: WARNING: '$CC' does not support '-c -o', so 'make -j' may be unsafe" >&2;}
     need_locks=warn
   fi
 else
@@ -12424,8 +11513,8 @@ fi
 
 
 
-  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking whether the $compiler linker ($LD) supports shared libraries" >&5
-printf %s "checking whether the $compiler linker ($LD) supports shared libraries... " >&6; }
+  { $as_echo "$as_me:${as_lineno-$LINENO}: checking whether the $compiler linker ($LD) supports shared libraries" >&5
+$as_echo_n "checking whether the $compiler linker ($LD) supports shared libraries... " >&6; }
 
   runpath_var=
   allow_undefined_flag=
@@ -12980,23 +12069,21 @@ _LT_EOF
         if test set = "${lt_cv_aix_libpath+set}"; then
   aix_libpath=$lt_cv_aix_libpath
 else
-  if test ${lt_cv_aix_libpath_+y}
-then :
-  printf %s "(cached) " >&6
-else $as_nop
+  if ${lt_cv_aix_libpath_+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
   cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 /* end confdefs.h.  */
 
 int
-main (void)
+main ()
 {
 
   ;
   return 0;
 }
 _ACEOF
-if ac_fn_c_try_link "$LINENO"
-then :
+if ac_fn_c_try_link "$LINENO"; then :
 
   lt_aix_libpath_sed='
       /Import File Strings/,/^$/ {
@@ -13011,7 +12098,7 @@ then :
     lt_cv_aix_libpath_=`dump -HX64 conftest$ac_exeext 2>/dev/null | $SED -n -e "$lt_aix_libpath_sed"`
   fi
 fi
-rm -f core conftest.err conftest.$ac_objext conftest.beam \
+rm -f core conftest.err conftest.$ac_objext \
     conftest$ac_exeext conftest.$ac_ext
   if test -z "$lt_cv_aix_libpath_"; then
     lt_cv_aix_libpath_=/usr/lib:/lib
@@ -13035,23 +12122,21 @@ fi
 	 if test set = "${lt_cv_aix_libpath+set}"; then
   aix_libpath=$lt_cv_aix_libpath
 else
-  if test ${lt_cv_aix_libpath_+y}
-then :
-  printf %s "(cached) " >&6
-else $as_nop
+  if ${lt_cv_aix_libpath_+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
   cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 /* end confdefs.h.  */
 
 int
-main (void)
+main ()
 {
 
   ;
   return 0;
 }
 _ACEOF
-if ac_fn_c_try_link "$LINENO"
-then :
+if ac_fn_c_try_link "$LINENO"; then :
 
   lt_aix_libpath_sed='
       /Import File Strings/,/^$/ {
@@ -13066,7 +12151,7 @@ then :
     lt_cv_aix_libpath_=`dump -HX64 conftest$ac_exeext 2>/dev/null | $SED -n -e "$lt_aix_libpath_sed"`
   fi
 fi
-rm -f core conftest.err conftest.$ac_objext conftest.beam \
+rm -f core conftest.err conftest.$ac_objext \
     conftest$ac_exeext conftest.$ac_ext
   if test -z "$lt_cv_aix_libpath_"; then
     lt_cv_aix_libpath_=/usr/lib:/lib
@@ -13317,12 +12402,11 @@ fi
 
 	  # Older versions of the 11.00 compiler do not understand -b yet
 	  # (HP92453-01 A.11.01.20 doesn't, HP92453-01 B.11.X.35175-35176.GP does)
-	  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking if $CC understands -b" >&5
-printf %s "checking if $CC understands -b... " >&6; }
-if test ${lt_cv_prog_compiler__b+y}
-then :
-  printf %s "(cached) " >&6
-else $as_nop
+	  { $as_echo "$as_me:${as_lineno-$LINENO}: checking if $CC understands -b" >&5
+$as_echo_n "checking if $CC understands -b... " >&6; }
+if ${lt_cv_prog_compiler__b+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
   lt_cv_prog_compiler__b=no
    save_LDFLAGS=$LDFLAGS
    LDFLAGS="$LDFLAGS -b"
@@ -13346,8 +12430,8 @@ else $as_nop
    LDFLAGS=$save_LDFLAGS
 
 fi
-{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $lt_cv_prog_compiler__b" >&5
-printf "%s\n" "$lt_cv_prog_compiler__b" >&6; }
+{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $lt_cv_prog_compiler__b" >&5
+$as_echo "$lt_cv_prog_compiler__b" >&6; }
 
 if test yes = "$lt_cv_prog_compiler__b"; then
     archive_cmds='$CC -b $wl+h $wl$soname $wl+b $wl$install_libdir -o $lib $libobjs $deplibs $compiler_flags'
@@ -13387,30 +12471,28 @@ fi
 	# work, assume that -exports_file does not work either and
 	# implicitly export all symbols.
 	# This should be the same for all languages, so no per-tag cache variable.
-	{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking whether the $host_os linker accepts -exported_symbol" >&5
-printf %s "checking whether the $host_os linker accepts -exported_symbol... " >&6; }
-if test ${lt_cv_irix_exported_symbol+y}
-then :
-  printf %s "(cached) " >&6
-else $as_nop
+	{ $as_echo "$as_me:${as_lineno-$LINENO}: checking whether the $host_os linker accepts -exported_symbol" >&5
+$as_echo_n "checking whether the $host_os linker accepts -exported_symbol... " >&6; }
+if ${lt_cv_irix_exported_symbol+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
   save_LDFLAGS=$LDFLAGS
 	   LDFLAGS="$LDFLAGS -shared $wl-exported_symbol ${wl}foo $wl-update_registry $wl/dev/null"
 	   cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 /* end confdefs.h.  */
 int foo (void) { return 0; }
 _ACEOF
-if ac_fn_c_try_link "$LINENO"
-then :
+if ac_fn_c_try_link "$LINENO"; then :
   lt_cv_irix_exported_symbol=yes
-else $as_nop
+else
   lt_cv_irix_exported_symbol=no
 fi
-rm -f core conftest.err conftest.$ac_objext conftest.beam \
+rm -f core conftest.err conftest.$ac_objext \
     conftest$ac_exeext conftest.$ac_ext
            LDFLAGS=$save_LDFLAGS
 fi
-{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $lt_cv_irix_exported_symbol" >&5
-printf "%s\n" "$lt_cv_irix_exported_symbol" >&6; }
+{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $lt_cv_irix_exported_symbol" >&5
+$as_echo "$lt_cv_irix_exported_symbol" >&6; }
 	if test yes = "$lt_cv_irix_exported_symbol"; then
           archive_expsym_cmds='$CC -shared $pic_flag $libobjs $deplibs $compiler_flags $wl-soname $wl$soname `test -n "$verstring" && func_echo_all "$wl-set_version $wl$verstring"` $wl-update_registry $wl$output_objdir/so_locations $wl-exports_file $wl$export_symbols -o $lib'
 	fi
@@ -13690,8 +12772,8 @@ printf "%s\n" "$lt_cv_irix_exported_symbol" >&6; }
     fi
   fi
 
-{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $ld_shlibs" >&5
-printf "%s\n" "$ld_shlibs" >&6; }
+{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $ld_shlibs" >&5
+$as_echo "$ld_shlibs" >&6; }
 test no = "$ld_shlibs" && can_build_shared=no
 
 with_gnu_ld=$with_gnu_ld
@@ -13727,19 +12809,18 @@ x|xyes)
       # Test whether the compiler implicitly links with -lc since on some
       # systems, -lgcc has to come before -lc. If gcc already passes -lc
       # to ld, don't add -lc before -lgcc.
-      { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking whether -lc should be explicitly linked in" >&5
-printf %s "checking whether -lc should be explicitly linked in... " >&6; }
-if test ${lt_cv_archive_cmds_need_lc+y}
-then :
-  printf %s "(cached) " >&6
-else $as_nop
+      { $as_echo "$as_me:${as_lineno-$LINENO}: checking whether -lc should be explicitly linked in" >&5
+$as_echo_n "checking whether -lc should be explicitly linked in... " >&6; }
+if ${lt_cv_archive_cmds_need_lc+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
   $RM conftest*
 	echo "$lt_simple_compile_test_code" > conftest.$ac_ext
 
 	if { { eval echo "\"\$as_me\":${as_lineno-$LINENO}: \"$ac_compile\""; } >&5
   (eval $ac_compile) 2>&5
   ac_status=$?
-  printf "%s\n" "$as_me:${as_lineno-$LINENO}: \$? = $ac_status" >&5
+  $as_echo "$as_me:${as_lineno-$LINENO}: \$? = $ac_status" >&5
   test $ac_status = 0; } 2>conftest.err; then
 	  soname=conftest
 	  lib=conftest
@@ -13757,7 +12838,7 @@ else $as_nop
 	  if { { eval echo "\"\$as_me\":${as_lineno-$LINENO}: \"$archive_cmds 2\>\&1 \| $GREP \" -lc \" \>/dev/null 2\>\&1\""; } >&5
   (eval $archive_cmds 2\>\&1 \| $GREP \" -lc \" \>/dev/null 2\>\&1) 2>&5
   ac_status=$?
-  printf "%s\n" "$as_me:${as_lineno-$LINENO}: \$? = $ac_status" >&5
+  $as_echo "$as_me:${as_lineno-$LINENO}: \$? = $ac_status" >&5
   test $ac_status = 0; }
 	  then
 	    lt_cv_archive_cmds_need_lc=no
@@ -13771,8 +12852,8 @@ else $as_nop
 	$RM conftest*
 
 fi
-{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $lt_cv_archive_cmds_need_lc" >&5
-printf "%s\n" "$lt_cv_archive_cmds_need_lc" >&6; }
+{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $lt_cv_archive_cmds_need_lc" >&5
+$as_echo "$lt_cv_archive_cmds_need_lc" >&6; }
       archive_cmds_need_lc=$lt_cv_archive_cmds_need_lc
       ;;
     esac
@@ -13931,8 +13012,8 @@ esac
 
 
 
-  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking dynamic linker characteristics" >&5
-printf %s "checking dynamic linker characteristics... " >&6; }
+  { $as_echo "$as_me:${as_lineno-$LINENO}: checking dynamic linker characteristics" >&5
+$as_echo_n "checking dynamic linker characteristics... " >&6; }
 
 if test yes = "$GCC"; then
   case $host_os in
@@ -14493,10 +13574,9 @@ linux* | k*bsd*-gnu | kopensolaris*-gnu | gnu*)
   shlibpath_overrides_runpath=no
 
   # Some binutils ld are patched to set DT_RUNPATH
-  if test ${lt_cv_shlibpath_overrides_runpath+y}
-then :
-  printf %s "(cached) " >&6
-else $as_nop
+  if ${lt_cv_shlibpath_overrides_runpath+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
   lt_cv_shlibpath_overrides_runpath=no
     save_LDFLAGS=$LDFLAGS
     save_libdir=$libdir
@@ -14506,21 +13586,19 @@ else $as_nop
 /* end confdefs.h.  */
 
 int
-main (void)
+main ()
 {
 
   ;
   return 0;
 }
 _ACEOF
-if ac_fn_c_try_link "$LINENO"
-then :
-  if  ($OBJDUMP -p conftest$ac_exeext) 2>/dev/null | grep "RUNPATH.*$libdir" >/dev/null
-then :
+if ac_fn_c_try_link "$LINENO"; then :
+  if  ($OBJDUMP -p conftest$ac_exeext) 2>/dev/null | grep "RUNPATH.*$libdir" >/dev/null; then :
   lt_cv_shlibpath_overrides_runpath=yes
 fi
 fi
-rm -f core conftest.err conftest.$ac_objext conftest.beam \
+rm -f core conftest.err conftest.$ac_objext \
     conftest$ac_exeext conftest.$ac_ext
     LDFLAGS=$save_LDFLAGS
     libdir=$save_libdir
@@ -14755,8 +13833,8 @@ uts4*)
   dynamic_linker=no
   ;;
 esac
-{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $dynamic_linker" >&5
-printf "%s\n" "$dynamic_linker" >&6; }
+{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $dynamic_linker" >&5
+$as_echo "$dynamic_linker" >&6; }
 test no = "$dynamic_linker" && can_build_shared=no
 
 variables_saved_for_relink="PATH $shlibpath_var $runpath_var"
@@ -14877,8 +13955,8 @@ configure_time_lt_sys_library_path=$LT_SYS_LIBRARY_PATH
 
 
 
-  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking how to hardcode library paths into programs" >&5
-printf %s "checking how to hardcode library paths into programs... " >&6; }
+  { $as_echo "$as_me:${as_lineno-$LINENO}: checking how to hardcode library paths into programs" >&5
+$as_echo_n "checking how to hardcode library paths into programs... " >&6; }
 hardcode_action=
 if test -n "$hardcode_libdir_flag_spec" ||
    test -n "$runpath_var" ||
@@ -14902,8 +13980,8 @@ else
   # directories.
   hardcode_action=unsupported
 fi
-{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $hardcode_action" >&5
-printf "%s\n" "$hardcode_action" >&6; }
+{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $hardcode_action" >&5
+$as_echo "$hardcode_action" >&6; }
 
 if test relink = "$hardcode_action" ||
    test yes = "$inherit_rpath"; then
@@ -14947,12 +14025,11 @@ else
 
   darwin*)
     # if libdl is installed we need to link against it
-    { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for dlopen in -ldl" >&5
-printf %s "checking for dlopen in -ldl... " >&6; }
-if test ${ac_cv_lib_dl_dlopen+y}
-then :
-  printf %s "(cached) " >&6
-else $as_nop
+    { $as_echo "$as_me:${as_lineno-$LINENO}: checking for dlopen in -ldl" >&5
+$as_echo_n "checking for dlopen in -ldl... " >&6; }
+if ${ac_cv_lib_dl_dlopen+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
   ac_check_lib_save_LIBS=$LIBS
 LIBS="-ldl  $LIBS"
 cat confdefs.h - <<_ACEOF >conftest.$ac_ext
@@ -14961,31 +14038,32 @@ cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 /* Override any GCC internal prototype to avoid an error.
    Use char because int might match the return type of a GCC
    builtin and then its argument prototype would still apply.  */
+#ifdef __cplusplus
+extern "C"
+#endif
 char dlopen ();
 int
-main (void)
+main ()
 {
 return dlopen ();
   ;
   return 0;
 }
 _ACEOF
-if ac_fn_c_try_link "$LINENO"
-then :
+if ac_fn_c_try_link "$LINENO"; then :
   ac_cv_lib_dl_dlopen=yes
-else $as_nop
+else
   ac_cv_lib_dl_dlopen=no
 fi
-rm -f core conftest.err conftest.$ac_objext conftest.beam \
+rm -f core conftest.err conftest.$ac_objext \
     conftest$ac_exeext conftest.$ac_ext
 LIBS=$ac_check_lib_save_LIBS
 fi
-{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $ac_cv_lib_dl_dlopen" >&5
-printf "%s\n" "$ac_cv_lib_dl_dlopen" >&6; }
-if test "x$ac_cv_lib_dl_dlopen" = xyes
-then :
+{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_lib_dl_dlopen" >&5
+$as_echo "$ac_cv_lib_dl_dlopen" >&6; }
+if test "x$ac_cv_lib_dl_dlopen" = xyes; then :
   lt_cv_dlopen=dlopen lt_cv_dlopen_libs=-ldl
-else $as_nop
+else
 
     lt_cv_dlopen=dyld
     lt_cv_dlopen_libs=
@@ -15005,16 +14083,14 @@ fi
 
   *)
     ac_fn_c_check_func "$LINENO" "shl_load" "ac_cv_func_shl_load"
-if test "x$ac_cv_func_shl_load" = xyes
-then :
+if test "x$ac_cv_func_shl_load" = xyes; then :
   lt_cv_dlopen=shl_load
-else $as_nop
-  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for shl_load in -ldld" >&5
-printf %s "checking for shl_load in -ldld... " >&6; }
-if test ${ac_cv_lib_dld_shl_load+y}
-then :
-  printf %s "(cached) " >&6
-else $as_nop
+else
+  { $as_echo "$as_me:${as_lineno-$LINENO}: checking for shl_load in -ldld" >&5
+$as_echo_n "checking for shl_load in -ldld... " >&6; }
+if ${ac_cv_lib_dld_shl_load+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
   ac_check_lib_save_LIBS=$LIBS
 LIBS="-ldld  $LIBS"
 cat confdefs.h - <<_ACEOF >conftest.$ac_ext
@@ -15023,42 +14099,41 @@ cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 /* Override any GCC internal prototype to avoid an error.
    Use char because int might match the return type of a GCC
    builtin and then its argument prototype would still apply.  */
+#ifdef __cplusplus
+extern "C"
+#endif
 char shl_load ();
 int
-main (void)
+main ()
 {
 return shl_load ();
   ;
   return 0;
 }
 _ACEOF
-if ac_fn_c_try_link "$LINENO"
-then :
+if ac_fn_c_try_link "$LINENO"; then :
   ac_cv_lib_dld_shl_load=yes
-else $as_nop
+else
   ac_cv_lib_dld_shl_load=no
 fi
-rm -f core conftest.err conftest.$ac_objext conftest.beam \
+rm -f core conftest.err conftest.$ac_objext \
     conftest$ac_exeext conftest.$ac_ext
 LIBS=$ac_check_lib_save_LIBS
 fi
-{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $ac_cv_lib_dld_shl_load" >&5
-printf "%s\n" "$ac_cv_lib_dld_shl_load" >&6; }
-if test "x$ac_cv_lib_dld_shl_load" = xyes
-then :
+{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_lib_dld_shl_load" >&5
+$as_echo "$ac_cv_lib_dld_shl_load" >&6; }
+if test "x$ac_cv_lib_dld_shl_load" = xyes; then :
   lt_cv_dlopen=shl_load lt_cv_dlopen_libs=-ldld
-else $as_nop
+else
   ac_fn_c_check_func "$LINENO" "dlopen" "ac_cv_func_dlopen"
-if test "x$ac_cv_func_dlopen" = xyes
-then :
+if test "x$ac_cv_func_dlopen" = xyes; then :
   lt_cv_dlopen=dlopen
-else $as_nop
-  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for dlopen in -ldl" >&5
-printf %s "checking for dlopen in -ldl... " >&6; }
-if test ${ac_cv_lib_dl_dlopen+y}
-then :
-  printf %s "(cached) " >&6
-else $as_nop
+else
+  { $as_echo "$as_me:${as_lineno-$LINENO}: checking for dlopen in -ldl" >&5
+$as_echo_n "checking for dlopen in -ldl... " >&6; }
+if ${ac_cv_lib_dl_dlopen+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
   ac_check_lib_save_LIBS=$LIBS
 LIBS="-ldl  $LIBS"
 cat confdefs.h - <<_ACEOF >conftest.$ac_ext
@@ -15067,37 +14142,37 @@ cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 /* Override any GCC internal prototype to avoid an error.
    Use char because int might match the return type of a GCC
    builtin and then its argument prototype would still apply.  */
+#ifdef __cplusplus
+extern "C"
+#endif
 char dlopen ();
 int
-main (void)
+main ()
 {
 return dlopen ();
   ;
   return 0;
 }
 _ACEOF
-if ac_fn_c_try_link "$LINENO"
-then :
+if ac_fn_c_try_link "$LINENO"; then :
   ac_cv_lib_dl_dlopen=yes
-else $as_nop
+else
   ac_cv_lib_dl_dlopen=no
 fi
-rm -f core conftest.err conftest.$ac_objext conftest.beam \
+rm -f core conftest.err conftest.$ac_objext \
     conftest$ac_exeext conftest.$ac_ext
 LIBS=$ac_check_lib_save_LIBS
 fi
-{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $ac_cv_lib_dl_dlopen" >&5
-printf "%s\n" "$ac_cv_lib_dl_dlopen" >&6; }
-if test "x$ac_cv_lib_dl_dlopen" = xyes
-then :
+{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_lib_dl_dlopen" >&5
+$as_echo "$ac_cv_lib_dl_dlopen" >&6; }
+if test "x$ac_cv_lib_dl_dlopen" = xyes; then :
   lt_cv_dlopen=dlopen lt_cv_dlopen_libs=-ldl
-else $as_nop
-  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for dlopen in -lsvld" >&5
-printf %s "checking for dlopen in -lsvld... " >&6; }
-if test ${ac_cv_lib_svld_dlopen+y}
-then :
-  printf %s "(cached) " >&6
-else $as_nop
+else
+  { $as_echo "$as_me:${as_lineno-$LINENO}: checking for dlopen in -lsvld" >&5
+$as_echo_n "checking for dlopen in -lsvld... " >&6; }
+if ${ac_cv_lib_svld_dlopen+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
   ac_check_lib_save_LIBS=$LIBS
 LIBS="-lsvld  $LIBS"
 cat confdefs.h - <<_ACEOF >conftest.$ac_ext
@@ -15106,37 +14181,37 @@ cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 /* Override any GCC internal prototype to avoid an error.
    Use char because int might match the return type of a GCC
    builtin and then its argument prototype would still apply.  */
+#ifdef __cplusplus
+extern "C"
+#endif
 char dlopen ();
 int
-main (void)
+main ()
 {
 return dlopen ();
   ;
   return 0;
 }
 _ACEOF
-if ac_fn_c_try_link "$LINENO"
-then :
+if ac_fn_c_try_link "$LINENO"; then :
   ac_cv_lib_svld_dlopen=yes
-else $as_nop
+else
   ac_cv_lib_svld_dlopen=no
 fi
-rm -f core conftest.err conftest.$ac_objext conftest.beam \
+rm -f core conftest.err conftest.$ac_objext \
     conftest$ac_exeext conftest.$ac_ext
 LIBS=$ac_check_lib_save_LIBS
 fi
-{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $ac_cv_lib_svld_dlopen" >&5
-printf "%s\n" "$ac_cv_lib_svld_dlopen" >&6; }
-if test "x$ac_cv_lib_svld_dlopen" = xyes
-then :
+{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_lib_svld_dlopen" >&5
+$as_echo "$ac_cv_lib_svld_dlopen" >&6; }
+if test "x$ac_cv_lib_svld_dlopen" = xyes; then :
   lt_cv_dlopen=dlopen lt_cv_dlopen_libs=-lsvld
-else $as_nop
-  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for dld_link in -ldld" >&5
-printf %s "checking for dld_link in -ldld... " >&6; }
-if test ${ac_cv_lib_dld_dld_link+y}
-then :
-  printf %s "(cached) " >&6
-else $as_nop
+else
+  { $as_echo "$as_me:${as_lineno-$LINENO}: checking for dld_link in -ldld" >&5
+$as_echo_n "checking for dld_link in -ldld... " >&6; }
+if ${ac_cv_lib_dld_dld_link+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
   ac_check_lib_save_LIBS=$LIBS
 LIBS="-ldld  $LIBS"
 cat confdefs.h - <<_ACEOF >conftest.$ac_ext
@@ -15145,29 +14220,30 @@ cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 /* Override any GCC internal prototype to avoid an error.
    Use char because int might match the return type of a GCC
    builtin and then its argument prototype would still apply.  */
+#ifdef __cplusplus
+extern "C"
+#endif
 char dld_link ();
 int
-main (void)
+main ()
 {
 return dld_link ();
   ;
   return 0;
 }
 _ACEOF
-if ac_fn_c_try_link "$LINENO"
-then :
+if ac_fn_c_try_link "$LINENO"; then :
   ac_cv_lib_dld_dld_link=yes
-else $as_nop
+else
   ac_cv_lib_dld_dld_link=no
 fi
-rm -f core conftest.err conftest.$ac_objext conftest.beam \
+rm -f core conftest.err conftest.$ac_objext \
     conftest$ac_exeext conftest.$ac_ext
 LIBS=$ac_check_lib_save_LIBS
 fi
-{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $ac_cv_lib_dld_dld_link" >&5
-printf "%s\n" "$ac_cv_lib_dld_dld_link" >&6; }
-if test "x$ac_cv_lib_dld_dld_link" = xyes
-then :
+{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_lib_dld_dld_link" >&5
+$as_echo "$ac_cv_lib_dld_dld_link" >&6; }
+if test "x$ac_cv_lib_dld_dld_link" = xyes; then :
   lt_cv_dlopen=dld_link lt_cv_dlopen_libs=-ldld
 fi
 
@@ -15206,12 +14282,11 @@ fi
     save_LIBS=$LIBS
     LIBS="$lt_cv_dlopen_libs $LIBS"
 
-    { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking whether a program can dlopen itself" >&5
-printf %s "checking whether a program can dlopen itself... " >&6; }
-if test ${lt_cv_dlopen_self+y}
-then :
-  printf %s "(cached) " >&6
-else $as_nop
+    { $as_echo "$as_me:${as_lineno-$LINENO}: checking whether a program can dlopen itself" >&5
+$as_echo_n "checking whether a program can dlopen itself... " >&6; }
+if ${lt_cv_dlopen_self+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
   	  if test yes = "$cross_compiling"; then :
   lt_cv_dlopen_self=cross
 else
@@ -15290,7 +14365,7 @@ _LT_EOF
   if { { eval echo "\"\$as_me\":${as_lineno-$LINENO}: \"$ac_link\""; } >&5
   (eval $ac_link) 2>&5
   ac_status=$?
-  printf "%s\n" "$as_me:${as_lineno-$LINENO}: \$? = $ac_status" >&5
+  $as_echo "$as_me:${as_lineno-$LINENO}: \$? = $ac_status" >&5
   test $ac_status = 0; } && test -s "conftest$ac_exeext" 2>/dev/null; then
     (./conftest; exit; ) >&5 2>/dev/null
     lt_status=$?
@@ -15308,17 +14383,16 @@ rm -fr conftest*
 
 
 fi
-{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $lt_cv_dlopen_self" >&5
-printf "%s\n" "$lt_cv_dlopen_self" >&6; }
+{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $lt_cv_dlopen_self" >&5
+$as_echo "$lt_cv_dlopen_self" >&6; }
 
     if test yes = "$lt_cv_dlopen_self"; then
       wl=$lt_prog_compiler_wl eval LDFLAGS=\"\$LDFLAGS $lt_prog_compiler_static\"
-      { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking whether a statically linked program can dlopen itself" >&5
-printf %s "checking whether a statically linked program can dlopen itself... " >&6; }
-if test ${lt_cv_dlopen_self_static+y}
-then :
-  printf %s "(cached) " >&6
-else $as_nop
+      { $as_echo "$as_me:${as_lineno-$LINENO}: checking whether a statically linked program can dlopen itself" >&5
+$as_echo_n "checking whether a statically linked program can dlopen itself... " >&6; }
+if ${lt_cv_dlopen_self_static+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
   	  if test yes = "$cross_compiling"; then :
   lt_cv_dlopen_self_static=cross
 else
@@ -15397,7 +14471,7 @@ _LT_EOF
   if { { eval echo "\"\$as_me\":${as_lineno-$LINENO}: \"$ac_link\""; } >&5
   (eval $ac_link) 2>&5
   ac_status=$?
-  printf "%s\n" "$as_me:${as_lineno-$LINENO}: \$? = $ac_status" >&5
+  $as_echo "$as_me:${as_lineno-$LINENO}: \$? = $ac_status" >&5
   test $ac_status = 0; } && test -s "conftest$ac_exeext" 2>/dev/null; then
     (./conftest; exit; ) >&5 2>/dev/null
     lt_status=$?
@@ -15415,8 +14489,8 @@ rm -fr conftest*
 
 
 fi
-{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $lt_cv_dlopen_self_static" >&5
-printf "%s\n" "$lt_cv_dlopen_self_static" >&6; }
+{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $lt_cv_dlopen_self_static" >&5
+$as_echo "$lt_cv_dlopen_self_static" >&6; }
     fi
 
     CPPFLAGS=$save_CPPFLAGS
@@ -15454,13 +14528,13 @@ fi
 
 striplib=
 old_striplib=
-{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking whether stripping libraries is possible" >&5
-printf %s "checking whether stripping libraries is possible... " >&6; }
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking whether stripping libraries is possible" >&5
+$as_echo_n "checking whether stripping libraries is possible... " >&6; }
 if test -n "$STRIP" && $STRIP -V 2>&1 | $GREP "GNU strip" >/dev/null; then
   test -z "$old_striplib" && old_striplib="$STRIP --strip-debug"
   test -z "$striplib" && striplib="$STRIP --strip-unneeded"
-  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: yes" >&5
-printf "%s\n" "yes" >&6; }
+  { $as_echo "$as_me:${as_lineno-$LINENO}: result: yes" >&5
+$as_echo "yes" >&6; }
 else
 # FIXME - insert some real tests, host_os isn't really good enough
   case $host_os in
@@ -15468,16 +14542,16 @@ else
     if test -n "$STRIP"; then
       striplib="$STRIP -x"
       old_striplib="$STRIP -S"
-      { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: yes" >&5
-printf "%s\n" "yes" >&6; }
+      { $as_echo "$as_me:${as_lineno-$LINENO}: result: yes" >&5
+$as_echo "yes" >&6; }
     else
-      { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: no" >&5
-printf "%s\n" "no" >&6; }
+      { $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
+$as_echo "no" >&6; }
     fi
     ;;
   *)
-    { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: no" >&5
-printf "%s\n" "no" >&6; }
+    { $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
+$as_echo "no" >&6; }
     ;;
   esac
 fi
@@ -15494,13 +14568,13 @@ fi
 
 
   # Report what library types will actually be built
-  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking if libtool supports shared libraries" >&5
-printf %s "checking if libtool supports shared libraries... " >&6; }
-  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $can_build_shared" >&5
-printf "%s\n" "$can_build_shared" >&6; }
+  { $as_echo "$as_me:${as_lineno-$LINENO}: checking if libtool supports shared libraries" >&5
+$as_echo_n "checking if libtool supports shared libraries... " >&6; }
+  { $as_echo "$as_me:${as_lineno-$LINENO}: result: $can_build_shared" >&5
+$as_echo "$can_build_shared" >&6; }
 
-  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking whether to build shared libraries" >&5
-printf %s "checking whether to build shared libraries... " >&6; }
+  { $as_echo "$as_me:${as_lineno-$LINENO}: checking whether to build shared libraries" >&5
+$as_echo_n "checking whether to build shared libraries... " >&6; }
   test no = "$can_build_shared" && enable_shared=no
 
   # On AIX, shared libraries and static libraries use the same namespace, and
@@ -15524,15 +14598,15 @@ printf %s "checking whether to build shared libraries... " >&6; }
     fi
     ;;
   esac
-  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $enable_shared" >&5
-printf "%s\n" "$enable_shared" >&6; }
+  { $as_echo "$as_me:${as_lineno-$LINENO}: result: $enable_shared" >&5
+$as_echo "$enable_shared" >&6; }
 
-  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking whether to build static libraries" >&5
-printf %s "checking whether to build static libraries... " >&6; }
+  { $as_echo "$as_me:${as_lineno-$LINENO}: checking whether to build static libraries" >&5
+$as_echo_n "checking whether to build static libraries... " >&6; }
   # Make sure either enable_shared or enable_static is yes.
   test yes = "$enable_shared" || enable_static=yes
-  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $enable_static" >&5
-printf "%s\n" "$enable_static" >&6; }
+  { $as_echo "$as_me:${as_lineno-$LINENO}: result: $enable_static" >&5
+$as_echo "$enable_static" >&6; }
 
 
 
@@ -15583,12 +14657,11 @@ if test "x$ac_cv_env_PKG_CONFIG_set" != "xset"; then
 	if test -n "$ac_tool_prefix"; then
   # Extract the first word of "${ac_tool_prefix}pkg-config", so it can be a program name with args.
 set dummy ${ac_tool_prefix}pkg-config; ac_word=$2
-{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for $ac_word" >&5
-printf %s "checking for $ac_word... " >&6; }
-if test ${ac_cv_path_PKG_CONFIG+y}
-then :
-  printf %s "(cached) " >&6
-else $as_nop
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for $ac_word" >&5
+$as_echo_n "checking for $ac_word... " >&6; }
+if ${ac_cv_path_PKG_CONFIG+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
   case $PKG_CONFIG in
   [\\/]* | ?:[\\/]*)
   ac_cv_path_PKG_CONFIG="$PKG_CONFIG" # Let the user override the test with a path.
@@ -15598,15 +14671,11 @@ else $as_nop
 for as_dir in $PATH
 do
   IFS=$as_save_IFS
-  case $as_dir in #(((
-    '') as_dir=./ ;;
-    */) ;;
-    *) as_dir=$as_dir/ ;;
-  esac
+  test -z "$as_dir" && as_dir=.
     for ac_exec_ext in '' $ac_executable_extensions; do
-  if as_fn_executable_p "$as_dir$ac_word$ac_exec_ext"; then
-    ac_cv_path_PKG_CONFIG="$as_dir$ac_word$ac_exec_ext"
-    printf "%s\n" "$as_me:${as_lineno-$LINENO}: found $as_dir$ac_word$ac_exec_ext" >&5
+  if as_fn_executable_p "$as_dir/$ac_word$ac_exec_ext"; then
+    ac_cv_path_PKG_CONFIG="$as_dir/$ac_word$ac_exec_ext"
+    $as_echo "$as_me:${as_lineno-$LINENO}: found $as_dir/$ac_word$ac_exec_ext" >&5
     break 2
   fi
 done
@@ -15618,11 +14687,11 @@ esac
 fi
 PKG_CONFIG=$ac_cv_path_PKG_CONFIG
 if test -n "$PKG_CONFIG"; then
-  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $PKG_CONFIG" >&5
-printf "%s\n" "$PKG_CONFIG" >&6; }
+  { $as_echo "$as_me:${as_lineno-$LINENO}: result: $PKG_CONFIG" >&5
+$as_echo "$PKG_CONFIG" >&6; }
 else
-  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: no" >&5
-printf "%s\n" "no" >&6; }
+  { $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
+$as_echo "no" >&6; }
 fi
 
 
@@ -15631,12 +14700,11 @@ if test -z "$ac_cv_path_PKG_CONFIG"; then
   ac_pt_PKG_CONFIG=$PKG_CONFIG
   # Extract the first word of "pkg-config", so it can be a program name with args.
 set dummy pkg-config; ac_word=$2
-{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for $ac_word" >&5
-printf %s "checking for $ac_word... " >&6; }
-if test ${ac_cv_path_ac_pt_PKG_CONFIG+y}
-then :
-  printf %s "(cached) " >&6
-else $as_nop
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for $ac_word" >&5
+$as_echo_n "checking for $ac_word... " >&6; }
+if ${ac_cv_path_ac_pt_PKG_CONFIG+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
   case $ac_pt_PKG_CONFIG in
   [\\/]* | ?:[\\/]*)
   ac_cv_path_ac_pt_PKG_CONFIG="$ac_pt_PKG_CONFIG" # Let the user override the test with a path.
@@ -15646,15 +14714,11 @@ else $as_nop
 for as_dir in $PATH
 do
   IFS=$as_save_IFS
-  case $as_dir in #(((
-    '') as_dir=./ ;;
-    */) ;;
-    *) as_dir=$as_dir/ ;;
-  esac
+  test -z "$as_dir" && as_dir=.
     for ac_exec_ext in '' $ac_executable_extensions; do
-  if as_fn_executable_p "$as_dir$ac_word$ac_exec_ext"; then
-    ac_cv_path_ac_pt_PKG_CONFIG="$as_dir$ac_word$ac_exec_ext"
-    printf "%s\n" "$as_me:${as_lineno-$LINENO}: found $as_dir$ac_word$ac_exec_ext" >&5
+  if as_fn_executable_p "$as_dir/$ac_word$ac_exec_ext"; then
+    ac_cv_path_ac_pt_PKG_CONFIG="$as_dir/$ac_word$ac_exec_ext"
+    $as_echo "$as_me:${as_lineno-$LINENO}: found $as_dir/$ac_word$ac_exec_ext" >&5
     break 2
   fi
 done
@@ -15666,11 +14730,11 @@ esac
 fi
 ac_pt_PKG_CONFIG=$ac_cv_path_ac_pt_PKG_CONFIG
 if test -n "$ac_pt_PKG_CONFIG"; then
-  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $ac_pt_PKG_CONFIG" >&5
-printf "%s\n" "$ac_pt_PKG_CONFIG" >&6; }
+  { $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_pt_PKG_CONFIG" >&5
+$as_echo "$ac_pt_PKG_CONFIG" >&6; }
 else
-  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: no" >&5
-printf "%s\n" "no" >&6; }
+  { $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
+$as_echo "no" >&6; }
 fi
 
   if test "x$ac_pt_PKG_CONFIG" = x; then
@@ -15678,8 +14742,8 @@ fi
   else
     case $cross_compiling:$ac_tool_warned in
 yes:)
-{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: WARNING: using cross tools not prefixed with host triplet" >&5
-printf "%s\n" "$as_me: WARNING: using cross tools not prefixed with host triplet" >&2;}
+{ $as_echo "$as_me:${as_lineno-$LINENO}: WARNING: using cross tools not prefixed with host triplet" >&5
+$as_echo "$as_me: WARNING: using cross tools not prefixed with host triplet" >&2;}
 ac_tool_warned=yes ;;
 esac
     PKG_CONFIG=$ac_pt_PKG_CONFIG
@@ -15691,206 +14755,39 @@ fi
 fi
 if test -n "$PKG_CONFIG"; then
 	_pkg_min_version=0.9.0
-	{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking pkg-config is at least version $_pkg_min_version" >&5
-printf %s "checking pkg-config is at least version $_pkg_min_version... " >&6; }
+	{ $as_echo "$as_me:${as_lineno-$LINENO}: checking pkg-config is at least version $_pkg_min_version" >&5
+$as_echo_n "checking pkg-config is at least version $_pkg_min_version... " >&6; }
 	if $PKG_CONFIG --atleast-pkgconfig-version $_pkg_min_version; then
-		{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: yes" >&5
-printf "%s\n" "yes" >&6; }
+		{ $as_echo "$as_me:${as_lineno-$LINENO}: result: yes" >&5
+$as_echo "yes" >&6; }
 	else
-		{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: no" >&5
-printf "%s\n" "no" >&6; }
+		{ $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
+$as_echo "no" >&6; }
 		PKG_CONFIG=""
 	fi
 fi
 fi
 
 # Checks for header files.
-ac_fn_c_check_header_compile "$LINENO" "stdarg.h" "ac_cv_header_stdarg_h" "$ac_includes_default
+for ac_header in stdarg.h stdbool.h netinet/in.h netinet/tcp.h sys/param.h sys/select.h sys/socket.h sys/un.h sys/uio.h sys/resource.h arpa/inet.h syslog.h netdb.h sys/wait.h pwd.h glob.h grp.h login_cap.h winsock2.h ws2tcpip.h endian.h sys/endian.h libkern/OSByteOrder.h sys/ipc.h sys/shm.h ifaddrs.h
+do :
+  as_ac_Header=`$as_echo "ac_cv_header_$ac_header" | $as_tr_sh`
+ac_fn_c_check_header_compile "$LINENO" "$ac_header" "$as_ac_Header" "$ac_includes_default
 "
-if test "x$ac_cv_header_stdarg_h" = xyes
-then :
-  printf "%s\n" "#define HAVE_STDARG_H 1" >>confdefs.h
+if eval test \"x\$"$as_ac_Header"\" = x"yes"; then :
+  cat >>confdefs.h <<_ACEOF
+#define `$as_echo "HAVE_$ac_header" | $as_tr_cpp` 1
+_ACEOF
 
 fi
-ac_fn_c_check_header_compile "$LINENO" "stdbool.h" "ac_cv_header_stdbool_h" "$ac_includes_default
-"
-if test "x$ac_cv_header_stdbool_h" = xyes
-then :
-  printf "%s\n" "#define HAVE_STDBOOL_H 1" >>confdefs.h
 
-fi
-ac_fn_c_check_header_compile "$LINENO" "netinet/in.h" "ac_cv_header_netinet_in_h" "$ac_includes_default
-"
-if test "x$ac_cv_header_netinet_in_h" = xyes
-then :
-  printf "%s\n" "#define HAVE_NETINET_IN_H 1" >>confdefs.h
-
-fi
-ac_fn_c_check_header_compile "$LINENO" "netinet/tcp.h" "ac_cv_header_netinet_tcp_h" "$ac_includes_default
-"
-if test "x$ac_cv_header_netinet_tcp_h" = xyes
-then :
-  printf "%s\n" "#define HAVE_NETINET_TCP_H 1" >>confdefs.h
-
-fi
-ac_fn_c_check_header_compile "$LINENO" "sys/param.h" "ac_cv_header_sys_param_h" "$ac_includes_default
-"
-if test "x$ac_cv_header_sys_param_h" = xyes
-then :
-  printf "%s\n" "#define HAVE_SYS_PARAM_H 1" >>confdefs.h
-
-fi
-ac_fn_c_check_header_compile "$LINENO" "sys/select.h" "ac_cv_header_sys_select_h" "$ac_includes_default
-"
-if test "x$ac_cv_header_sys_select_h" = xyes
-then :
-  printf "%s\n" "#define HAVE_SYS_SELECT_H 1" >>confdefs.h
-
-fi
-ac_fn_c_check_header_compile "$LINENO" "sys/socket.h" "ac_cv_header_sys_socket_h" "$ac_includes_default
-"
-if test "x$ac_cv_header_sys_socket_h" = xyes
-then :
-  printf "%s\n" "#define HAVE_SYS_SOCKET_H 1" >>confdefs.h
-
-fi
-ac_fn_c_check_header_compile "$LINENO" "sys/un.h" "ac_cv_header_sys_un_h" "$ac_includes_default
-"
-if test "x$ac_cv_header_sys_un_h" = xyes
-then :
-  printf "%s\n" "#define HAVE_SYS_UN_H 1" >>confdefs.h
-
-fi
-ac_fn_c_check_header_compile "$LINENO" "sys/uio.h" "ac_cv_header_sys_uio_h" "$ac_includes_default
-"
-if test "x$ac_cv_header_sys_uio_h" = xyes
-then :
-  printf "%s\n" "#define HAVE_SYS_UIO_H 1" >>confdefs.h
-
-fi
-ac_fn_c_check_header_compile "$LINENO" "sys/resource.h" "ac_cv_header_sys_resource_h" "$ac_includes_default
-"
-if test "x$ac_cv_header_sys_resource_h" = xyes
-then :
-  printf "%s\n" "#define HAVE_SYS_RESOURCE_H 1" >>confdefs.h
-
-fi
-ac_fn_c_check_header_compile "$LINENO" "arpa/inet.h" "ac_cv_header_arpa_inet_h" "$ac_includes_default
-"
-if test "x$ac_cv_header_arpa_inet_h" = xyes
-then :
-  printf "%s\n" "#define HAVE_ARPA_INET_H 1" >>confdefs.h
-
-fi
-ac_fn_c_check_header_compile "$LINENO" "syslog.h" "ac_cv_header_syslog_h" "$ac_includes_default
-"
-if test "x$ac_cv_header_syslog_h" = xyes
-then :
-  printf "%s\n" "#define HAVE_SYSLOG_H 1" >>confdefs.h
-
-fi
-ac_fn_c_check_header_compile "$LINENO" "netdb.h" "ac_cv_header_netdb_h" "$ac_includes_default
-"
-if test "x$ac_cv_header_netdb_h" = xyes
-then :
-  printf "%s\n" "#define HAVE_NETDB_H 1" >>confdefs.h
-
-fi
-ac_fn_c_check_header_compile "$LINENO" "sys/wait.h" "ac_cv_header_sys_wait_h" "$ac_includes_default
-"
-if test "x$ac_cv_header_sys_wait_h" = xyes
-then :
-  printf "%s\n" "#define HAVE_SYS_WAIT_H 1" >>confdefs.h
-
-fi
-ac_fn_c_check_header_compile "$LINENO" "pwd.h" "ac_cv_header_pwd_h" "$ac_includes_default
-"
-if test "x$ac_cv_header_pwd_h" = xyes
-then :
-  printf "%s\n" "#define HAVE_PWD_H 1" >>confdefs.h
-
-fi
-ac_fn_c_check_header_compile "$LINENO" "glob.h" "ac_cv_header_glob_h" "$ac_includes_default
-"
-if test "x$ac_cv_header_glob_h" = xyes
-then :
-  printf "%s\n" "#define HAVE_GLOB_H 1" >>confdefs.h
-
-fi
-ac_fn_c_check_header_compile "$LINENO" "grp.h" "ac_cv_header_grp_h" "$ac_includes_default
-"
-if test "x$ac_cv_header_grp_h" = xyes
-then :
-  printf "%s\n" "#define HAVE_GRP_H 1" >>confdefs.h
-
-fi
-ac_fn_c_check_header_compile "$LINENO" "login_cap.h" "ac_cv_header_login_cap_h" "$ac_includes_default
-"
-if test "x$ac_cv_header_login_cap_h" = xyes
-then :
-  printf "%s\n" "#define HAVE_LOGIN_CAP_H 1" >>confdefs.h
-
-fi
-ac_fn_c_check_header_compile "$LINENO" "winsock2.h" "ac_cv_header_winsock2_h" "$ac_includes_default
-"
-if test "x$ac_cv_header_winsock2_h" = xyes
-then :
-  printf "%s\n" "#define HAVE_WINSOCK2_H 1" >>confdefs.h
-
-fi
-ac_fn_c_check_header_compile "$LINENO" "ws2tcpip.h" "ac_cv_header_ws2tcpip_h" "$ac_includes_default
-"
-if test "x$ac_cv_header_ws2tcpip_h" = xyes
-then :
-  printf "%s\n" "#define HAVE_WS2TCPIP_H 1" >>confdefs.h
-
-fi
-ac_fn_c_check_header_compile "$LINENO" "endian.h" "ac_cv_header_endian_h" "$ac_includes_default
-"
-if test "x$ac_cv_header_endian_h" = xyes
-then :
-  printf "%s\n" "#define HAVE_ENDIAN_H 1" >>confdefs.h
-
-fi
-ac_fn_c_check_header_compile "$LINENO" "sys/endian.h" "ac_cv_header_sys_endian_h" "$ac_includes_default
-"
-if test "x$ac_cv_header_sys_endian_h" = xyes
-then :
-  printf "%s\n" "#define HAVE_SYS_ENDIAN_H 1" >>confdefs.h
-
-fi
-ac_fn_c_check_header_compile "$LINENO" "libkern/OSByteOrder.h" "ac_cv_header_libkern_OSByteOrder_h" "$ac_includes_default
-"
-if test "x$ac_cv_header_libkern_OSByteOrder_h" = xyes
-then :
-  printf "%s\n" "#define HAVE_LIBKERN_OSBYTEORDER_H 1" >>confdefs.h
-
-fi
-ac_fn_c_check_header_compile "$LINENO" "sys/ipc.h" "ac_cv_header_sys_ipc_h" "$ac_includes_default
-"
-if test "x$ac_cv_header_sys_ipc_h" = xyes
-then :
-  printf "%s\n" "#define HAVE_SYS_IPC_H 1" >>confdefs.h
-
-fi
-ac_fn_c_check_header_compile "$LINENO" "sys/shm.h" "ac_cv_header_sys_shm_h" "$ac_includes_default
-"
-if test "x$ac_cv_header_sys_shm_h" = xyes
-then :
-  printf "%s\n" "#define HAVE_SYS_SHM_H 1" >>confdefs.h
-
-fi
-ac_fn_c_check_header_compile "$LINENO" "ifaddrs.h" "ac_cv_header_ifaddrs_h" "$ac_includes_default
-"
-if test "x$ac_cv_header_ifaddrs_h" = xyes
-then :
-  printf "%s\n" "#define HAVE_IFADDRS_H 1" >>confdefs.h
-
-fi
+done
 
 # net/if.h portability for Darwin see:
 # https://www.gnu.org/software/autoconf/manual/autoconf-2.69/html_node/Header-Portability.html
-ac_fn_c_check_header_compile "$LINENO" "net/if.h" "ac_cv_header_net_if_h" "
+for ac_header in net/if.h
+do :
+  ac_fn_c_check_header_compile "$LINENO" "net/if.h" "ac_cv_header_net_if_h" "
 #include <stdio.h>
 #ifdef STDC_HEADERS
 # include <stdlib.h>
@@ -15905,23 +14802,33 @@ ac_fn_c_check_header_compile "$LINENO" "net/if.h" "ac_cv_header_net_if_h" "
 #endif
 
 "
-if test "x$ac_cv_header_net_if_h" = xyes
-then :
-  printf "%s\n" "#define HAVE_NET_IF_H 1" >>confdefs.h
+if test "x$ac_cv_header_net_if_h" = xyes; then :
+  cat >>confdefs.h <<_ACEOF
+#define HAVE_NET_IF_H 1
+_ACEOF
 
 fi
+
+done
 
 
 # Check for Apple header. This uncovers TARGET_OS_IPHONE, TARGET_OS_TV or TARGET_OS_WATCH
-ac_fn_c_check_header_compile "$LINENO" "TargetConditionals.h" "ac_cv_header_TargetConditionals_h" "$ac_includes_default
+for ac_header in TargetConditionals.h
+do :
+  ac_fn_c_check_header_compile "$LINENO" "TargetConditionals.h" "ac_cv_header_TargetConditionals_h" "$ac_includes_default
 "
-if test "x$ac_cv_header_TargetConditionals_h" = xyes
-then :
-  printf "%s\n" "#define HAVE_TARGETCONDITIONALS_H 1" >>confdefs.h
+if test "x$ac_cv_header_TargetConditionals_h" = xyes; then :
+  cat >>confdefs.h <<_ACEOF
+#define HAVE_TARGETCONDITIONALS_H 1
+_ACEOF
 
 fi
 
-ac_fn_c_check_header_compile "$LINENO" "netioapi.h" "ac_cv_header_netioapi_h" "$ac_includes_default
+done
+
+for ac_header in netioapi.h
+do :
+  ac_fn_c_check_header_compile "$LINENO" "netioapi.h" "ac_cv_header_netioapi_h" "$ac_includes_default
 #if HAVE_SYS_PARAM_H
 #include <sys/param.h>
 #endif
@@ -15955,324 +14862,177 @@ ac_fn_c_check_header_compile "$LINENO" "netioapi.h" "ac_cv_header_netioapi_h" "$
 #endif
 
 "
-if test "x$ac_cv_header_netioapi_h" = xyes
-then :
-  printf "%s\n" "#define HAVE_NETIOAPI_H 1" >>confdefs.h
+if test "x$ac_cv_header_netioapi_h" = xyes; then :
+  cat >>confdefs.h <<_ACEOF
+#define HAVE_NETIOAPI_H 1
+_ACEOF
 
 fi
+
+done
 
 
 # check for types.
 # Using own tests for int64* because autoconf builtin only give 32bit.
 ac_fn_c_check_type "$LINENO" "int8_t" "ac_cv_type_int8_t" "$ac_includes_default"
-if test "x$ac_cv_type_int8_t" = xyes
-then :
+if test "x$ac_cv_type_int8_t" = xyes; then :
 
-else $as_nop
+else
 
-printf "%s\n" "#define int8_t signed char" >>confdefs.h
+cat >>confdefs.h <<_ACEOF
+#define int8_t signed char
+_ACEOF
 
 fi
 
 ac_fn_c_check_type "$LINENO" "int16_t" "ac_cv_type_int16_t" "$ac_includes_default"
-if test "x$ac_cv_type_int16_t" = xyes
-then :
+if test "x$ac_cv_type_int16_t" = xyes; then :
 
-else $as_nop
+else
 
-printf "%s\n" "#define int16_t short" >>confdefs.h
+cat >>confdefs.h <<_ACEOF
+#define int16_t short
+_ACEOF
 
 fi
 
 ac_fn_c_check_type "$LINENO" "int32_t" "ac_cv_type_int32_t" "$ac_includes_default"
-if test "x$ac_cv_type_int32_t" = xyes
-then :
+if test "x$ac_cv_type_int32_t" = xyes; then :
 
-else $as_nop
+else
 
-printf "%s\n" "#define int32_t int" >>confdefs.h
+cat >>confdefs.h <<_ACEOF
+#define int32_t int
+_ACEOF
 
 fi
 
 ac_fn_c_check_type "$LINENO" "int64_t" "ac_cv_type_int64_t" "$ac_includes_default"
-if test "x$ac_cv_type_int64_t" = xyes
-then :
+if test "x$ac_cv_type_int64_t" = xyes; then :
 
-else $as_nop
+else
 
-printf "%s\n" "#define int64_t long long" >>confdefs.h
+cat >>confdefs.h <<_ACEOF
+#define int64_t long long
+_ACEOF
 
 fi
 
 ac_fn_c_check_type "$LINENO" "uint8_t" "ac_cv_type_uint8_t" "$ac_includes_default"
-if test "x$ac_cv_type_uint8_t" = xyes
-then :
+if test "x$ac_cv_type_uint8_t" = xyes; then :
 
-else $as_nop
+else
 
-printf "%s\n" "#define uint8_t unsigned char" >>confdefs.h
+cat >>confdefs.h <<_ACEOF
+#define uint8_t unsigned char
+_ACEOF
 
 fi
 
 ac_fn_c_check_type "$LINENO" "uint16_t" "ac_cv_type_uint16_t" "$ac_includes_default"
-if test "x$ac_cv_type_uint16_t" = xyes
-then :
+if test "x$ac_cv_type_uint16_t" = xyes; then :
 
-else $as_nop
+else
 
-printf "%s\n" "#define uint16_t unsigned short" >>confdefs.h
+cat >>confdefs.h <<_ACEOF
+#define uint16_t unsigned short
+_ACEOF
 
 fi
 
 ac_fn_c_check_type "$LINENO" "uint32_t" "ac_cv_type_uint32_t" "$ac_includes_default"
-if test "x$ac_cv_type_uint32_t" = xyes
-then :
+if test "x$ac_cv_type_uint32_t" = xyes; then :
 
-else $as_nop
+else
 
-printf "%s\n" "#define uint32_t unsigned int" >>confdefs.h
+cat >>confdefs.h <<_ACEOF
+#define uint32_t unsigned int
+_ACEOF
 
 fi
 
 ac_fn_c_check_type "$LINENO" "uint64_t" "ac_cv_type_uint64_t" "$ac_includes_default"
-if test "x$ac_cv_type_uint64_t" = xyes
-then :
+if test "x$ac_cv_type_uint64_t" = xyes; then :
 
-else $as_nop
+else
 
-printf "%s\n" "#define uint64_t unsigned long long" >>confdefs.h
+cat >>confdefs.h <<_ACEOF
+#define uint64_t unsigned long long
+_ACEOF
 
 fi
 
 ac_fn_c_check_type "$LINENO" "size_t" "ac_cv_type_size_t" "$ac_includes_default"
-if test "x$ac_cv_type_size_t" = xyes
-then :
+if test "x$ac_cv_type_size_t" = xyes; then :
 
-else $as_nop
+else
 
-printf "%s\n" "#define size_t unsigned int" >>confdefs.h
+cat >>confdefs.h <<_ACEOF
+#define size_t unsigned int
+_ACEOF
 
 fi
 
 ac_fn_c_check_type "$LINENO" "ssize_t" "ac_cv_type_ssize_t" "$ac_includes_default"
-if test "x$ac_cv_type_ssize_t" = xyes
-then :
+if test "x$ac_cv_type_ssize_t" = xyes; then :
 
-else $as_nop
-
-printf "%s\n" "#define ssize_t int" >>confdefs.h
-
-fi
-
-ac_ext=c
-ac_cpp='$CPP $CPPFLAGS'
-ac_compile='$CC -c $CFLAGS $CPPFLAGS conftest.$ac_ext >&5'
-ac_link='$CC -o conftest$ac_exeext $CFLAGS $CPPFLAGS $LDFLAGS conftest.$ac_ext $LIBS >&5'
-ac_compiler_gnu=$ac_cv_c_compiler_gnu
-{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking how to run the C preprocessor" >&5
-printf %s "checking how to run the C preprocessor... " >&6; }
-# On Suns, sometimes $CPP names a directory.
-if test -n "$CPP" && test -d "$CPP"; then
-  CPP=
-fi
-if test -z "$CPP"; then
-  if test ${ac_cv_prog_CPP+y}
-then :
-  printf %s "(cached) " >&6
-else $as_nop
-      # Double quotes because $CC needs to be expanded
-    for CPP in "$CC -E" "$CC -E -traditional-cpp" cpp /lib/cpp
-    do
-      ac_preproc_ok=false
-for ac_c_preproc_warn_flag in '' yes
-do
-  # Use a header file that comes with gcc, so configuring glibc
-  # with a fresh cross-compiler works.
-  # On the NeXT, cc -E runs the code through the compiler's parser,
-  # not just through cpp. "Syntax error" is here to catch this case.
-  cat confdefs.h - <<_ACEOF >conftest.$ac_ext
-/* end confdefs.h.  */
-#include <limits.h>
-		     Syntax error
-_ACEOF
-if ac_fn_c_try_cpp "$LINENO"
-then :
-
-else $as_nop
-  # Broken: fails on valid input.
-continue
-fi
-rm -f conftest.err conftest.i conftest.$ac_ext
-
-  # OK, works on sane cases.  Now check whether nonexistent headers
-  # can be detected and how.
-  cat confdefs.h - <<_ACEOF >conftest.$ac_ext
-/* end confdefs.h.  */
-#include <ac_nonexistent.h>
-_ACEOF
-if ac_fn_c_try_cpp "$LINENO"
-then :
-  # Broken: success on invalid input.
-continue
-else $as_nop
-  # Passes both tests.
-ac_preproc_ok=:
-break
-fi
-rm -f conftest.err conftest.i conftest.$ac_ext
-
-done
-# Because of `break', _AC_PREPROC_IFELSE's cleaning code was skipped.
-rm -f conftest.i conftest.err conftest.$ac_ext
-if $ac_preproc_ok
-then :
-  break
-fi
-
-    done
-    ac_cv_prog_CPP=$CPP
-
-fi
-  CPP=$ac_cv_prog_CPP
 else
-  ac_cv_prog_CPP=$CPP
-fi
-{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $CPP" >&5
-printf "%s\n" "$CPP" >&6; }
-ac_preproc_ok=false
-for ac_c_preproc_warn_flag in '' yes
-do
-  # Use a header file that comes with gcc, so configuring glibc
-  # with a fresh cross-compiler works.
-  # On the NeXT, cc -E runs the code through the compiler's parser,
-  # not just through cpp. "Syntax error" is here to catch this case.
-  cat confdefs.h - <<_ACEOF >conftest.$ac_ext
-/* end confdefs.h.  */
-#include <limits.h>
-		     Syntax error
+
+cat >>confdefs.h <<_ACEOF
+#define ssize_t int
 _ACEOF
-if ac_fn_c_try_cpp "$LINENO"
-then :
 
-else $as_nop
-  # Broken: fails on valid input.
-continue
-fi
-rm -f conftest.err conftest.i conftest.$ac_ext
-
-  # OK, works on sane cases.  Now check whether nonexistent headers
-  # can be detected and how.
-  cat confdefs.h - <<_ACEOF >conftest.$ac_ext
-/* end confdefs.h.  */
-#include <ac_nonexistent.h>
-_ACEOF
-if ac_fn_c_try_cpp "$LINENO"
-then :
-  # Broken: success on invalid input.
-continue
-else $as_nop
-  # Passes both tests.
-ac_preproc_ok=:
-break
-fi
-rm -f conftest.err conftest.i conftest.$ac_ext
-
-done
-# Because of `break', _AC_PREPROC_IFELSE's cleaning code was skipped.
-rm -f conftest.i conftest.err conftest.$ac_ext
-if $ac_preproc_ok
-then :
-
-else $as_nop
-  { { printf "%s\n" "$as_me:${as_lineno-$LINENO}: error: in \`$ac_pwd':" >&5
-printf "%s\n" "$as_me: error: in \`$ac_pwd':" >&2;}
-as_fn_error $? "C preprocessor \"$CPP\" fails sanity check
-See \`config.log' for more details" "$LINENO" 5; }
 fi
 
-ac_ext=c
-ac_cpp='$CPP $CPPFLAGS'
-ac_compile='$CC -c $CFLAGS $CPPFLAGS conftest.$ac_ext >&5'
-ac_link='$CC -o conftest$ac_exeext $CFLAGS $CPPFLAGS $LDFLAGS conftest.$ac_ext $LIBS >&5'
-ac_compiler_gnu=$ac_cv_c_compiler_gnu
-
-
-{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for uid_t in sys/types.h" >&5
-printf %s "checking for uid_t in sys/types.h... " >&6; }
-if test ${ac_cv_type_uid_t+y}
-then :
-  printf %s "(cached) " >&6
-else $as_nop
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for uid_t in sys/types.h" >&5
+$as_echo_n "checking for uid_t in sys/types.h... " >&6; }
+if ${ac_cv_type_uid_t+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
   cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 /* end confdefs.h.  */
 #include <sys/types.h>
 
 _ACEOF
 if (eval "$ac_cpp conftest.$ac_ext") 2>&5 |
-  $EGREP "uid_t" >/dev/null 2>&1
-then :
+  $EGREP "uid_t" >/dev/null 2>&1; then :
   ac_cv_type_uid_t=yes
-else $as_nop
+else
   ac_cv_type_uid_t=no
 fi
-rm -rf conftest*
+rm -f conftest*
 
 fi
-{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $ac_cv_type_uid_t" >&5
-printf "%s\n" "$ac_cv_type_uid_t" >&6; }
+{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_type_uid_t" >&5
+$as_echo "$ac_cv_type_uid_t" >&6; }
 if test $ac_cv_type_uid_t = no; then
 
-printf "%s\n" "#define uid_t int" >>confdefs.h
+$as_echo "#define uid_t int" >>confdefs.h
 
 
-printf "%s\n" "#define gid_t int" >>confdefs.h
+$as_echo "#define gid_t int" >>confdefs.h
 
 fi
 
+ac_fn_c_check_type "$LINENO" "pid_t" "ac_cv_type_pid_t" "$ac_includes_default"
+if test "x$ac_cv_type_pid_t" = xyes; then :
 
-  ac_fn_c_check_type "$LINENO" "pid_t" "ac_cv_type_pid_t" "$ac_includes_default
-"
-if test "x$ac_cv_type_pid_t" = xyes
-then :
+else
 
-else $as_nop
-                                          cat confdefs.h - <<_ACEOF >conftest.$ac_ext
-/* end confdefs.h.  */
-
-          #if defined _WIN64 && !defined __CYGWIN__
-          LLP64
-          #endif
-
-int
-main (void)
-{
-
-  ;
-  return 0;
-}
-
+cat >>confdefs.h <<_ACEOF
+#define pid_t int
 _ACEOF
-if ac_fn_c_try_compile "$LINENO"
-then :
-  ac_pid_type='int'
-else $as_nop
-  ac_pid_type='__int64'
-fi
-rm -f core conftest.err conftest.$ac_objext conftest.beam conftest.$ac_ext
-
-printf "%s\n" "#define pid_t $ac_pid_type" >>confdefs.h
-
 
 fi
-
 
 ac_fn_c_check_type "$LINENO" "off_t" "ac_cv_type_off_t" "$ac_includes_default"
-if test "x$ac_cv_type_off_t" = xyes
-then :
+if test "x$ac_cv_type_off_t" = xyes; then :
 
-else $as_nop
+else
 
-printf "%s\n" "#define off_t long int" >>confdefs.h
+cat >>confdefs.h <<_ACEOF
+#define off_t long int
+_ACEOF
 
 fi
 
@@ -16283,12 +15043,11 @@ $ac_includes_default
 #endif
 
 "
-if test "x$ac_cv_type_u_char" = xyes
-then :
+if test "x$ac_cv_type_u_char" = xyes; then :
 
-else $as_nop
+else
 
-printf "%s\n" "#define u_char unsigned char" >>confdefs.h
+$as_echo "#define u_char unsigned char" >>confdefs.h
 
 fi
 
@@ -16299,12 +15058,11 @@ $ac_includes_default
 #endif
 
 "
-if test "x$ac_cv_type_rlim_t" = xyes
-then :
+if test "x$ac_cv_type_rlim_t" = xyes; then :
 
-else $as_nop
+else
 
-printf "%s\n" "#define rlim_t unsigned long" >>confdefs.h
+$as_echo "#define rlim_t unsigned long" >>confdefs.h
 
 fi
 
@@ -16319,12 +15077,11 @@ $ac_includes_default
 #endif
 
 "
-if test "x$ac_cv_type_socklen_t" = xyes
-then :
+if test "x$ac_cv_type_socklen_t" = xyes; then :
 
-else $as_nop
+else
 
-printf "%s\n" "#define socklen_t int" >>confdefs.h
+$as_echo "#define socklen_t int" >>confdefs.h
 
 fi
 
@@ -16338,12 +15095,11 @@ $ac_includes_default
 #endif
 
 "
-if test "x$ac_cv_type_in_addr_t" = xyes
-then :
+if test "x$ac_cv_type_in_addr_t" = xyes; then :
 
-else $as_nop
+else
 
-printf "%s\n" "#define in_addr_t uint32_t" >>confdefs.h
+$as_echo "#define in_addr_t uint32_t" >>confdefs.h
 
 fi
 
@@ -16357,23 +15113,21 @@ $ac_includes_default
 #endif
 
 "
-if test "x$ac_cv_type_in_port_t" = xyes
-then :
+if test "x$ac_cv_type_in_port_t" = xyes; then :
 
-else $as_nop
+else
 
-printf "%s\n" "#define in_port_t uint16_t" >>confdefs.h
+$as_echo "#define in_port_t uint16_t" >>confdefs.h
 
 fi
 
-{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking if memcmp compares unsigned" >&5
-printf %s "checking if memcmp compares unsigned... " >&6; }
-if test "$cross_compiling" = yes
-then :
-   { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: cross-compile no" >&5
-printf "%s\n" "cross-compile no" >&6; }
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking if memcmp compares unsigned" >&5
+$as_echo_n "checking if memcmp compares unsigned... " >&6; }
+if test "$cross_compiling" = yes; then :
+   { $as_echo "$as_me:${as_lineno-$LINENO}: result: cross-compile no" >&5
+$as_echo "cross-compile no" >&6; }
 
-printf "%s\n" "#define MEMCMP_IS_BROKEN 1" >>confdefs.h
+$as_echo "#define MEMCMP_IS_BROKEN 1" >>confdefs.h
 
   case " $LIBOBJS " in
   *" memcmp.$ac_objext "* ) ;;
@@ -16382,7 +15136,7 @@ printf "%s\n" "#define MEMCMP_IS_BROKEN 1" >>confdefs.h
 esac
 
 
-else $as_nop
+else
   cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 /* end confdefs.h.  */
 
@@ -16398,15 +15152,14 @@ int main(void)
 }
 
 _ACEOF
-if ac_fn_c_try_run "$LINENO"
-then :
-  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: yes" >&5
-printf "%s\n" "yes" >&6; }
-else $as_nop
-   { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: no" >&5
-printf "%s\n" "no" >&6; }
+if ac_fn_c_try_run "$LINENO"; then :
+  { $as_echo "$as_me:${as_lineno-$LINENO}: result: yes" >&5
+$as_echo "yes" >&6; }
+else
+   { $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
+$as_echo "no" >&6; }
 
-printf "%s\n" "#define MEMCMP_IS_BROKEN 1" >>confdefs.h
+$as_echo "#define MEMCMP_IS_BROKEN 1" >>confdefs.h
 
   case " $LIBOBJS " in
   *" memcmp.$ac_objext "* ) ;;
@@ -16425,12 +15178,11 @@ fi
 # version HP92453-01 B.11.11.23709.GP, which incorrectly rejects
 # declarations like `int a3[[(sizeof (unsigned char)) >= 0]];'.
 # This bug is HP SR number 8606223364.
-{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking size of time_t" >&5
-printf %s "checking size of time_t... " >&6; }
-if test ${ac_cv_sizeof_time_t+y}
-then :
-  printf %s "(cached) " >&6
-else $as_nop
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking size of time_t" >&5
+$as_echo_n "checking size of time_t... " >&6; }
+if ${ac_cv_sizeof_time_t+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
   if ac_fn_c_compute_int "$LINENO" "(long int) (sizeof (time_t))" "ac_cv_sizeof_time_t"        "
 $ac_includes_default
 #ifdef TIME_WITH_SYS_TIME
@@ -16444,13 +15196,12 @@ $ac_includes_default
 # endif
 #endif
 
-"
-then :
+"; then :
 
-else $as_nop
+else
   if test "$ac_cv_type_time_t" = yes; then
-     { { printf "%s\n" "$as_me:${as_lineno-$LINENO}: error: in \`$ac_pwd':" >&5
-printf "%s\n" "$as_me: error: in \`$ac_pwd':" >&2;}
+     { { $as_echo "$as_me:${as_lineno-$LINENO}: error: in \`$ac_pwd':" >&5
+$as_echo "$as_me: error: in \`$ac_pwd':" >&2;}
 as_fn_error 77 "cannot compute sizeof (time_t)
 See \`config.log' for more details" "$LINENO" 5; }
    else
@@ -16459,31 +15210,31 @@ See \`config.log' for more details" "$LINENO" 5; }
 fi
 
 fi
-{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $ac_cv_sizeof_time_t" >&5
-printf "%s\n" "$ac_cv_sizeof_time_t" >&6; }
+{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_sizeof_time_t" >&5
+$as_echo "$ac_cv_sizeof_time_t" >&6; }
 
 
 
-printf "%s\n" "#define SIZEOF_TIME_T $ac_cv_sizeof_time_t" >>confdefs.h
+cat >>confdefs.h <<_ACEOF
+#define SIZEOF_TIME_T $ac_cv_sizeof_time_t
+_ACEOF
 
 
 # The cast to long int works around a bug in the HP C Compiler
 # version HP92453-01 B.11.11.23709.GP, which incorrectly rejects
 # declarations like `int a3[[(sizeof (unsigned char)) >= 0]];'.
 # This bug is HP SR number 8606223364.
-{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking size of size_t" >&5
-printf %s "checking size of size_t... " >&6; }
-if test ${ac_cv_sizeof_size_t+y}
-then :
-  printf %s "(cached) " >&6
-else $as_nop
-  if ac_fn_c_compute_int "$LINENO" "(long int) (sizeof (size_t))" "ac_cv_sizeof_size_t"        "$ac_includes_default"
-then :
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking size of size_t" >&5
+$as_echo_n "checking size of size_t... " >&6; }
+if ${ac_cv_sizeof_size_t+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
+  if ac_fn_c_compute_int "$LINENO" "(long int) (sizeof (size_t))" "ac_cv_sizeof_size_t"        "$ac_includes_default"; then :
 
-else $as_nop
+else
   if test "$ac_cv_type_size_t" = yes; then
-     { { printf "%s\n" "$as_me:${as_lineno-$LINENO}: error: in \`$ac_pwd':" >&5
-printf "%s\n" "$as_me: error: in \`$ac_pwd':" >&2;}
+     { { $as_echo "$as_me:${as_lineno-$LINENO}: error: in \`$ac_pwd':" >&5
+$as_echo "$as_me: error: in \`$ac_pwd':" >&2;}
 as_fn_error 77 "cannot compute sizeof (size_t)
 See \`config.log' for more details" "$LINENO" 5; }
    else
@@ -16492,22 +15243,23 @@ See \`config.log' for more details" "$LINENO" 5; }
 fi
 
 fi
-{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $ac_cv_sizeof_size_t" >&5
-printf "%s\n" "$ac_cv_sizeof_size_t" >&6; }
+{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_sizeof_size_t" >&5
+$as_echo "$ac_cv_sizeof_size_t" >&6; }
 
 
 
-printf "%s\n" "#define SIZEOF_SIZE_T $ac_cv_sizeof_size_t" >>confdefs.h
+cat >>confdefs.h <<_ACEOF
+#define SIZEOF_SIZE_T $ac_cv_sizeof_size_t
+_ACEOF
 
 
 
 # add option to disable the evil rpath
 
 # Check whether --enable-rpath was given.
-if test ${enable_rpath+y}
-then :
+if test "${enable_rpath+set}" = set; then :
   enableval=$enable_rpath; enable_rpath=$enableval
-else $as_nop
+else
   enable_rpath=yes
 fi
 
@@ -16519,12 +15271,11 @@ fi
 
 
 # check to see if libraries are needed for these functions.
-{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for library containing inet_pton" >&5
-printf %s "checking for library containing inet_pton... " >&6; }
-if test ${ac_cv_search_inet_pton+y}
-then :
-  printf %s "(cached) " >&6
-else $as_nop
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for library containing inet_pton" >&5
+$as_echo_n "checking for library containing inet_pton... " >&6; }
+if ${ac_cv_search_inet_pton+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
   ac_func_search_save_LIBS=$LIBS
 cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 /* end confdefs.h.  */
@@ -16532,58 +15283,55 @@ cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 /* Override any GCC internal prototype to avoid an error.
    Use char because int might match the return type of a GCC
    builtin and then its argument prototype would still apply.  */
+#ifdef __cplusplus
+extern "C"
+#endif
 char inet_pton ();
 int
-main (void)
+main ()
 {
 return inet_pton ();
   ;
   return 0;
 }
 _ACEOF
-for ac_lib in '' nsl
-do
+for ac_lib in '' nsl; do
   if test -z "$ac_lib"; then
     ac_res="none required"
   else
     ac_res=-l$ac_lib
     LIBS="-l$ac_lib  $ac_func_search_save_LIBS"
   fi
-  if ac_fn_c_try_link "$LINENO"
-then :
+  if ac_fn_c_try_link "$LINENO"; then :
   ac_cv_search_inet_pton=$ac_res
 fi
-rm -f core conftest.err conftest.$ac_objext conftest.beam \
+rm -f core conftest.err conftest.$ac_objext \
     conftest$ac_exeext
-  if test ${ac_cv_search_inet_pton+y}
-then :
+  if ${ac_cv_search_inet_pton+:} false; then :
   break
 fi
 done
-if test ${ac_cv_search_inet_pton+y}
-then :
+if ${ac_cv_search_inet_pton+:} false; then :
 
-else $as_nop
+else
   ac_cv_search_inet_pton=no
 fi
 rm conftest.$ac_ext
 LIBS=$ac_func_search_save_LIBS
 fi
-{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $ac_cv_search_inet_pton" >&5
-printf "%s\n" "$ac_cv_search_inet_pton" >&6; }
+{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_search_inet_pton" >&5
+$as_echo "$ac_cv_search_inet_pton" >&6; }
 ac_res=$ac_cv_search_inet_pton
-if test "$ac_res" != no
-then :
+if test "$ac_res" != no; then :
   test "$ac_res" = "none required" || LIBS="$ac_res $LIBS"
 
 fi
 
-{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for library containing socket" >&5
-printf %s "checking for library containing socket... " >&6; }
-if test ${ac_cv_search_socket+y}
-then :
-  printf %s "(cached) " >&6
-else $as_nop
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for library containing socket" >&5
+$as_echo_n "checking for library containing socket... " >&6; }
+if ${ac_cv_search_socket+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
   ac_func_search_save_LIBS=$LIBS
 cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 /* end confdefs.h.  */
@@ -16591,48 +15339,46 @@ cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 /* Override any GCC internal prototype to avoid an error.
    Use char because int might match the return type of a GCC
    builtin and then its argument prototype would still apply.  */
+#ifdef __cplusplus
+extern "C"
+#endif
 char socket ();
 int
-main (void)
+main ()
 {
 return socket ();
   ;
   return 0;
 }
 _ACEOF
-for ac_lib in '' socket
-do
+for ac_lib in '' socket; do
   if test -z "$ac_lib"; then
     ac_res="none required"
   else
     ac_res=-l$ac_lib
     LIBS="-l$ac_lib  $ac_func_search_save_LIBS"
   fi
-  if ac_fn_c_try_link "$LINENO"
-then :
+  if ac_fn_c_try_link "$LINENO"; then :
   ac_cv_search_socket=$ac_res
 fi
-rm -f core conftest.err conftest.$ac_objext conftest.beam \
+rm -f core conftest.err conftest.$ac_objext \
     conftest$ac_exeext
-  if test ${ac_cv_search_socket+y}
-then :
+  if ${ac_cv_search_socket+:} false; then :
   break
 fi
 done
-if test ${ac_cv_search_socket+y}
-then :
+if ${ac_cv_search_socket+:} false; then :
 
-else $as_nop
+else
   ac_cv_search_socket=no
 fi
 rm conftest.$ac_ext
 LIBS=$ac_func_search_save_LIBS
 fi
-{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $ac_cv_search_socket" >&5
-printf "%s\n" "$ac_cv_search_socket" >&6; }
+{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_search_socket" >&5
+$as_echo "$ac_cv_search_socket" >&6; }
 ac_res=$ac_cv_search_socket
-if test "$ac_res" != no
-then :
+if test "$ac_res" != no; then :
   test "$ac_res" = "none required" || LIBS="$ac_res $LIBS"
 
 fi
@@ -16641,28 +15387,33 @@ fi
 # check whether strptime also works
 
 # check some functions of the OS before linking libs (while still runnable).
-{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for working chown" >&5
-printf %s "checking for working chown... " >&6; }
-if test ${ac_cv_func_chown_works+y}
-then :
-  printf %s "(cached) " >&6
-else $as_nop
-  if test "$cross_compiling" = yes
-then :
-  case "$host_os" in # ((
-			  # Guess yes on glibc systems.
-		  *-gnu*) ac_cv_func_chown_works=yes ;;
-			  # If we don't know, assume the worst.
-		  *)      ac_cv_func_chown_works=no ;;
-		esac
-else $as_nop
+for ac_header in unistd.h
+do :
+  ac_fn_c_check_header_mongrel "$LINENO" "unistd.h" "ac_cv_header_unistd_h" "$ac_includes_default"
+if test "x$ac_cv_header_unistd_h" = xyes; then :
+  cat >>confdefs.h <<_ACEOF
+#define HAVE_UNISTD_H 1
+_ACEOF
+
+fi
+
+done
+
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for working chown" >&5
+$as_echo_n "checking for working chown... " >&6; }
+if ${ac_cv_func_chown_works+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
+  if test "$cross_compiling" = yes; then :
+  ac_cv_func_chown_works=no
+else
   cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 /* end confdefs.h.  */
 $ac_includes_default
 #include <fcntl.h>
 
 int
-main (void)
+main ()
 {
   char *f = "conftest.chown";
   struct stat before, after;
@@ -16681,10 +15432,9 @@ main (void)
   return 0;
 }
 _ACEOF
-if ac_fn_c_try_run "$LINENO"
-then :
+if ac_fn_c_try_run "$LINENO"; then :
   ac_cv_func_chown_works=yes
-else $as_nop
+else
   ac_cv_func_chown_works=no
 fi
 rm -f core *.core core.conftest.* gmon.out bb.out conftest$ac_exeext \
@@ -16694,47 +15444,52 @@ fi
 rm -f conftest.chown
 
 fi
-{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $ac_cv_func_chown_works" >&5
-printf "%s\n" "$ac_cv_func_chown_works" >&6; }
+{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_func_chown_works" >&5
+$as_echo "$ac_cv_func_chown_works" >&6; }
 if test $ac_cv_func_chown_works = yes; then
 
-printf "%s\n" "#define HAVE_CHOWN 1" >>confdefs.h
+$as_echo "#define HAVE_CHOWN 1" >>confdefs.h
 
 fi
 
+for ac_header in vfork.h
+do :
+  ac_fn_c_check_header_mongrel "$LINENO" "vfork.h" "ac_cv_header_vfork_h" "$ac_includes_default"
+if test "x$ac_cv_header_vfork_h" = xyes; then :
+  cat >>confdefs.h <<_ACEOF
+#define HAVE_VFORK_H 1
+_ACEOF
 
-ac_func=
-for ac_item in $ac_func_c_list
-do
-  if test $ac_func; then
-    ac_fn_c_check_func "$LINENO" $ac_func ac_cv_func_$ac_func
-    if eval test \"x\$ac_cv_func_$ac_func\" = xyes; then
-      echo "#define $ac_item 1" >> confdefs.h
-    fi
-    ac_func=
-  else
-    ac_func=$ac_item
-  fi
+fi
+
 done
 
+for ac_func in fork vfork
+do :
+  as_ac_var=`$as_echo "ac_cv_func_$ac_func" | $as_tr_sh`
+ac_fn_c_check_func "$LINENO" "$ac_func" "$as_ac_var"
+if eval test \"x\$"$as_ac_var"\" = x"yes"; then :
+  cat >>confdefs.h <<_ACEOF
+#define `$as_echo "HAVE_$ac_func" | $as_tr_cpp` 1
+_ACEOF
 
+fi
+done
 
 if test "x$ac_cv_func_fork" = xyes; then
-  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for working fork" >&5
-printf %s "checking for working fork... " >&6; }
-if test ${ac_cv_func_fork_works+y}
-then :
-  printf %s "(cached) " >&6
-else $as_nop
-  if test "$cross_compiling" = yes
-then :
+  { $as_echo "$as_me:${as_lineno-$LINENO}: checking for working fork" >&5
+$as_echo_n "checking for working fork... " >&6; }
+if ${ac_cv_func_fork_works+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
+  if test "$cross_compiling" = yes; then :
   ac_cv_func_fork_works=cross
-else $as_nop
+else
   cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 /* end confdefs.h.  */
 $ac_includes_default
 int
-main (void)
+main ()
 {
 
 	  /* By Ruediger Kuhlmann. */
@@ -16744,10 +15499,9 @@ main (void)
   return 0;
 }
 _ACEOF
-if ac_fn_c_try_run "$LINENO"
-then :
+if ac_fn_c_try_run "$LINENO"; then :
   ac_cv_func_fork_works=yes
-else $as_nop
+else
   ac_cv_func_fork_works=no
 fi
 rm -f core *.core core.conftest.* gmon.out bb.out conftest$ac_exeext \
@@ -16755,8 +15509,8 @@ rm -f core *.core core.conftest.* gmon.out bb.out conftest$ac_exeext \
 fi
 
 fi
-{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $ac_cv_func_fork_works" >&5
-printf "%s\n" "$ac_cv_func_fork_works" >&6; }
+{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_func_fork_works" >&5
+$as_echo "$ac_cv_func_fork_works" >&6; }
 
 else
   ac_cv_func_fork_works=$ac_cv_func_fork
@@ -16771,37 +15525,27 @@ if test "x$ac_cv_func_fork_works" = xcross; then
       ac_cv_func_fork_works=yes
       ;;
   esac
-  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: WARNING: result $ac_cv_func_fork_works guessed because of cross compilation" >&5
-printf "%s\n" "$as_me: WARNING: result $ac_cv_func_fork_works guessed because of cross compilation" >&2;}
+  { $as_echo "$as_me:${as_lineno-$LINENO}: WARNING: result $ac_cv_func_fork_works guessed because of cross compilation" >&5
+$as_echo "$as_me: WARNING: result $ac_cv_func_fork_works guessed because of cross compilation" >&2;}
 fi
 ac_cv_func_vfork_works=$ac_cv_func_vfork
 if test "x$ac_cv_func_vfork" = xyes; then
-  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for working vfork" >&5
-printf %s "checking for working vfork... " >&6; }
-if test ${ac_cv_func_vfork_works+y}
-then :
-  printf %s "(cached) " >&6
-else $as_nop
-  if test "$cross_compiling" = yes
-then :
+  { $as_echo "$as_me:${as_lineno-$LINENO}: checking for working vfork" >&5
+$as_echo_n "checking for working vfork... " >&6; }
+if ${ac_cv_func_vfork_works+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
+  if test "$cross_compiling" = yes; then :
   ac_cv_func_vfork_works=cross
-else $as_nop
+else
   cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 /* end confdefs.h.  */
 /* Thanks to Paul Eggert for this test.  */
 $ac_includes_default
-#include <signal.h>
 #include <sys/wait.h>
 #ifdef HAVE_VFORK_H
 # include <vfork.h>
 #endif
-
-static void
-do_nothing (int sig)
-{
-  (void) sig;
-}
-
 /* On some sparc systems, changes by the child to local and incoming
    argument registers are propagated back to the parent.  The compiler
    is told about this with #include <vfork.h>, but some compilers
@@ -16809,7 +15553,11 @@ do_nothing (int sig)
    static variable whose address is put into a register that is
    clobbered by the vfork.  */
 static void
+#ifdef __cplusplus
 sparc_address_test (int arg)
+# else
+sparc_address_test (arg) int arg;
+#endif
 {
   static pid_t child;
   if (!child) {
@@ -16827,17 +15575,12 @@ sparc_address_test (int arg)
 }
 
 int
-main (void)
+main ()
 {
   pid_t parent = getpid ();
   pid_t child;
 
   sparc_address_test (0);
-
-  /* On Solaris 2.4, changes by the child to the signal handler
-     also munge signal handlers in the parent.  To detect this,
-     start by putting the parent's handler in a known state.  */
-  signal (SIGTERM, SIG_DFL);
 
   child = vfork ();
 
@@ -16860,10 +15603,6 @@ main (void)
 	|| p != p5 || p != p6 || p != p7)
       _exit(1);
 
-    /* Alter the child's signal handler.  */
-    if (signal (SIGTERM, do_nothing) != SIG_DFL)
-      _exit(1);
-
     /* On some systems (e.g. IRIX 3.3), vfork doesn't separate parent
        from child file descriptors.  If the child closes a descriptor
        before it execs or exits, this munges the parent's descriptor
@@ -16879,9 +15618,6 @@ main (void)
 	 /* Was there some problem with vforking?  */
 	 child < 0
 
-	 /* Did the child munge the parent's signal handler?  */
-	 || signal (SIGTERM, SIG_DFL) != SIG_DFL
-
 	 /* Did the child fail?  (This shouldn't happen.)  */
 	 || status
 
@@ -16894,10 +15630,9 @@ main (void)
   }
 }
 _ACEOF
-if ac_fn_c_try_run "$LINENO"
-then :
+if ac_fn_c_try_run "$LINENO"; then :
   ac_cv_func_vfork_works=yes
-else $as_nop
+else
   ac_cv_func_vfork_works=no
 fi
 rm -f core *.core core.conftest.* gmon.out bb.out conftest$ac_exeext \
@@ -16905,47 +15640,46 @@ rm -f core *.core core.conftest.* gmon.out bb.out conftest$ac_exeext \
 fi
 
 fi
-{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $ac_cv_func_vfork_works" >&5
-printf "%s\n" "$ac_cv_func_vfork_works" >&6; }
+{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_func_vfork_works" >&5
+$as_echo "$ac_cv_func_vfork_works" >&6; }
 
 fi;
 if test "x$ac_cv_func_fork_works" = xcross; then
   ac_cv_func_vfork_works=$ac_cv_func_vfork
-  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: WARNING: result $ac_cv_func_vfork_works guessed because of cross compilation" >&5
-printf "%s\n" "$as_me: WARNING: result $ac_cv_func_vfork_works guessed because of cross compilation" >&2;}
+  { $as_echo "$as_me:${as_lineno-$LINENO}: WARNING: result $ac_cv_func_vfork_works guessed because of cross compilation" >&5
+$as_echo "$as_me: WARNING: result $ac_cv_func_vfork_works guessed because of cross compilation" >&2;}
 fi
 
 if test "x$ac_cv_func_vfork_works" = xyes; then
 
-printf "%s\n" "#define HAVE_WORKING_VFORK 1" >>confdefs.h
+$as_echo "#define HAVE_WORKING_VFORK 1" >>confdefs.h
 
 else
 
-printf "%s\n" "#define vfork fork" >>confdefs.h
+$as_echo "#define vfork fork" >>confdefs.h
 
 fi
 if test "x$ac_cv_func_fork_works" = xyes; then
 
-printf "%s\n" "#define HAVE_WORKING_FORK 1" >>confdefs.h
+$as_echo "#define HAVE_WORKING_FORK 1" >>confdefs.h
 
 fi
 
 
-printf "%s\n" "#define RETSIGTYPE void" >>confdefs.h
+$as_echo "#define RETSIGTYPE void" >>confdefs.h
 
-{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for _LARGEFILE_SOURCE value needed for large files" >&5
-printf %s "checking for _LARGEFILE_SOURCE value needed for large files... " >&6; }
-if test ${ac_cv_sys_largefile_source+y}
-then :
-  printf %s "(cached) " >&6
-else $as_nop
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for _LARGEFILE_SOURCE value needed for large files" >&5
+$as_echo_n "checking for _LARGEFILE_SOURCE value needed for large files... " >&6; }
+if ${ac_cv_sys_largefile_source+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
   while :; do
   cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 /* end confdefs.h.  */
 #include <sys/types.h> /* for off_t */
      #include <stdio.h>
 int
-main (void)
+main ()
 {
 int (*fp) (FILE *, off_t, int) = fseeko;
      return fseeko (stdin, 0, 0) && fp (stdin, 0, 0);
@@ -16953,11 +15687,10 @@ int (*fp) (FILE *, off_t, int) = fseeko;
   return 0;
 }
 _ACEOF
-if ac_fn_c_try_link "$LINENO"
-then :
+if ac_fn_c_try_link "$LINENO"; then :
   ac_cv_sys_largefile_source=no; break
 fi
-rm -f core conftest.err conftest.$ac_objext conftest.beam \
+rm -f core conftest.err conftest.$ac_objext \
     conftest$ac_exeext conftest.$ac_ext
   cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 /* end confdefs.h.  */
@@ -16965,7 +15698,7 @@ rm -f core conftest.err conftest.$ac_objext conftest.beam \
 #include <sys/types.h> /* for off_t */
      #include <stdio.h>
 int
-main (void)
+main ()
 {
 int (*fp) (FILE *, off_t, int) = fseeko;
      return fseeko (stdin, 0, 0) && fp (stdin, 0, 0);
@@ -16973,22 +15706,23 @@ int (*fp) (FILE *, off_t, int) = fseeko;
   return 0;
 }
 _ACEOF
-if ac_fn_c_try_link "$LINENO"
-then :
+if ac_fn_c_try_link "$LINENO"; then :
   ac_cv_sys_largefile_source=1; break
 fi
-rm -f core conftest.err conftest.$ac_objext conftest.beam \
+rm -f core conftest.err conftest.$ac_objext \
     conftest$ac_exeext conftest.$ac_ext
   ac_cv_sys_largefile_source=unknown
   break
 done
 fi
-{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $ac_cv_sys_largefile_source" >&5
-printf "%s\n" "$ac_cv_sys_largefile_source" >&6; }
+{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_sys_largefile_source" >&5
+$as_echo "$ac_cv_sys_largefile_source" >&6; }
 case $ac_cv_sys_largefile_source in #(
   no | unknown) ;;
   *)
-printf "%s\n" "#define _LARGEFILE_SOURCE $ac_cv_sys_largefile_source" >>confdefs.h
+cat >>confdefs.h <<_ACEOF
+#define _LARGEFILE_SOURCE $ac_cv_sys_largefile_source
+_ACEOF
 ;;
 esac
 rm -rf conftest*
@@ -16998,25 +15732,23 @@ rm -rf conftest*
 # If you want fseeko and ftello with glibc, upgrade to a fixed glibc.
 if test $ac_cv_sys_largefile_source != unknown; then
 
-printf "%s\n" "#define HAVE_FSEEKO 1" >>confdefs.h
+$as_echo "#define HAVE_FSEEKO 1" >>confdefs.h
 
 fi
 
 
 # Check whether --enable-largefile was given.
-if test ${enable_largefile+y}
-then :
+if test "${enable_largefile+set}" = set; then :
   enableval=$enable_largefile;
 fi
 
 if test "$enable_largefile" != no; then
 
-  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for special C compiler options needed for large files" >&5
-printf %s "checking for special C compiler options needed for large files... " >&6; }
-if test ${ac_cv_sys_largefile_CC+y}
-then :
-  printf %s "(cached) " >&6
-else $as_nop
+  { $as_echo "$as_me:${as_lineno-$LINENO}: checking for special C compiler options needed for large files" >&5
+$as_echo_n "checking for special C compiler options needed for large files... " >&6; }
+if ${ac_cv_sys_largefile_CC+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
   ac_cv_sys_largefile_CC=no
      if test "$GCC" != yes; then
        ac_save_CC=$CC
@@ -17030,47 +15762,44 @@ else $as_nop
     We can't simply define LARGE_OFF_T to be 9223372036854775807,
     since some C++ compilers masquerading as C compilers
     incorrectly reject 9223372036854775807.  */
-#define LARGE_OFF_T (((off_t) 1 << 31 << 31) - 1 + ((off_t) 1 << 31 << 31))
+#define LARGE_OFF_T (((off_t) 1 << 62) - 1 + ((off_t) 1 << 62))
   int off_t_is_large[(LARGE_OFF_T % 2147483629 == 721
 		       && LARGE_OFF_T % 2147483647 == 1)
 		      ? 1 : -1];
 int
-main (void)
+main ()
 {
 
   ;
   return 0;
 }
 _ACEOF
-	 if ac_fn_c_try_compile "$LINENO"
-then :
+	 if ac_fn_c_try_compile "$LINENO"; then :
   break
 fi
-rm -f core conftest.err conftest.$ac_objext conftest.beam
+rm -f core conftest.err conftest.$ac_objext
 	 CC="$CC -n32"
-	 if ac_fn_c_try_compile "$LINENO"
-then :
+	 if ac_fn_c_try_compile "$LINENO"; then :
   ac_cv_sys_largefile_CC=' -n32'; break
 fi
-rm -f core conftest.err conftest.$ac_objext conftest.beam
+rm -f core conftest.err conftest.$ac_objext
 	 break
        done
        CC=$ac_save_CC
        rm -f conftest.$ac_ext
     fi
 fi
-{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $ac_cv_sys_largefile_CC" >&5
-printf "%s\n" "$ac_cv_sys_largefile_CC" >&6; }
+{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_sys_largefile_CC" >&5
+$as_echo "$ac_cv_sys_largefile_CC" >&6; }
   if test "$ac_cv_sys_largefile_CC" != no; then
     CC=$CC$ac_cv_sys_largefile_CC
   fi
 
-  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for _FILE_OFFSET_BITS value needed for large files" >&5
-printf %s "checking for _FILE_OFFSET_BITS value needed for large files... " >&6; }
-if test ${ac_cv_sys_file_offset_bits+y}
-then :
-  printf %s "(cached) " >&6
-else $as_nop
+  { $as_echo "$as_me:${as_lineno-$LINENO}: checking for _FILE_OFFSET_BITS value needed for large files" >&5
+$as_echo_n "checking for _FILE_OFFSET_BITS value needed for large files... " >&6; }
+if ${ac_cv_sys_file_offset_bits+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
   while :; do
   cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 /* end confdefs.h.  */
@@ -17079,23 +15808,22 @@ else $as_nop
     We can't simply define LARGE_OFF_T to be 9223372036854775807,
     since some C++ compilers masquerading as C compilers
     incorrectly reject 9223372036854775807.  */
-#define LARGE_OFF_T (((off_t) 1 << 31 << 31) - 1 + ((off_t) 1 << 31 << 31))
+#define LARGE_OFF_T (((off_t) 1 << 62) - 1 + ((off_t) 1 << 62))
   int off_t_is_large[(LARGE_OFF_T % 2147483629 == 721
 		       && LARGE_OFF_T % 2147483647 == 1)
 		      ? 1 : -1];
 int
-main (void)
+main ()
 {
 
   ;
   return 0;
 }
 _ACEOF
-if ac_fn_c_try_compile "$LINENO"
-then :
+if ac_fn_c_try_compile "$LINENO"; then :
   ac_cv_sys_file_offset_bits=no; break
 fi
-rm -f core conftest.err conftest.$ac_objext conftest.beam conftest.$ac_ext
+rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
   cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 /* end confdefs.h.  */
 #define _FILE_OFFSET_BITS 64
@@ -17104,43 +15832,43 @@ rm -f core conftest.err conftest.$ac_objext conftest.beam conftest.$ac_ext
     We can't simply define LARGE_OFF_T to be 9223372036854775807,
     since some C++ compilers masquerading as C compilers
     incorrectly reject 9223372036854775807.  */
-#define LARGE_OFF_T (((off_t) 1 << 31 << 31) - 1 + ((off_t) 1 << 31 << 31))
+#define LARGE_OFF_T (((off_t) 1 << 62) - 1 + ((off_t) 1 << 62))
   int off_t_is_large[(LARGE_OFF_T % 2147483629 == 721
 		       && LARGE_OFF_T % 2147483647 == 1)
 		      ? 1 : -1];
 int
-main (void)
+main ()
 {
 
   ;
   return 0;
 }
 _ACEOF
-if ac_fn_c_try_compile "$LINENO"
-then :
+if ac_fn_c_try_compile "$LINENO"; then :
   ac_cv_sys_file_offset_bits=64; break
 fi
-rm -f core conftest.err conftest.$ac_objext conftest.beam conftest.$ac_ext
+rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
   ac_cv_sys_file_offset_bits=unknown
   break
 done
 fi
-{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $ac_cv_sys_file_offset_bits" >&5
-printf "%s\n" "$ac_cv_sys_file_offset_bits" >&6; }
+{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_sys_file_offset_bits" >&5
+$as_echo "$ac_cv_sys_file_offset_bits" >&6; }
 case $ac_cv_sys_file_offset_bits in #(
   no | unknown) ;;
   *)
-printf "%s\n" "#define _FILE_OFFSET_BITS $ac_cv_sys_file_offset_bits" >>confdefs.h
+cat >>confdefs.h <<_ACEOF
+#define _FILE_OFFSET_BITS $ac_cv_sys_file_offset_bits
+_ACEOF
 ;;
 esac
 rm -rf conftest*
   if test $ac_cv_sys_file_offset_bits = unknown; then
-    { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for _LARGE_FILES value needed for large files" >&5
-printf %s "checking for _LARGE_FILES value needed for large files... " >&6; }
-if test ${ac_cv_sys_large_files+y}
-then :
-  printf %s "(cached) " >&6
-else $as_nop
+    { $as_echo "$as_me:${as_lineno-$LINENO}: checking for _LARGE_FILES value needed for large files" >&5
+$as_echo_n "checking for _LARGE_FILES value needed for large files... " >&6; }
+if ${ac_cv_sys_large_files+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
   while :; do
   cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 /* end confdefs.h.  */
@@ -17149,23 +15877,22 @@ else $as_nop
     We can't simply define LARGE_OFF_T to be 9223372036854775807,
     since some C++ compilers masquerading as C compilers
     incorrectly reject 9223372036854775807.  */
-#define LARGE_OFF_T (((off_t) 1 << 31 << 31) - 1 + ((off_t) 1 << 31 << 31))
+#define LARGE_OFF_T (((off_t) 1 << 62) - 1 + ((off_t) 1 << 62))
   int off_t_is_large[(LARGE_OFF_T % 2147483629 == 721
 		       && LARGE_OFF_T % 2147483647 == 1)
 		      ? 1 : -1];
 int
-main (void)
+main ()
 {
 
   ;
   return 0;
 }
 _ACEOF
-if ac_fn_c_try_compile "$LINENO"
-then :
+if ac_fn_c_try_compile "$LINENO"; then :
   ac_cv_sys_large_files=no; break
 fi
-rm -f core conftest.err conftest.$ac_objext conftest.beam conftest.$ac_ext
+rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
   cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 /* end confdefs.h.  */
 #define _LARGE_FILES 1
@@ -17174,49 +15901,51 @@ rm -f core conftest.err conftest.$ac_objext conftest.beam conftest.$ac_ext
     We can't simply define LARGE_OFF_T to be 9223372036854775807,
     since some C++ compilers masquerading as C compilers
     incorrectly reject 9223372036854775807.  */
-#define LARGE_OFF_T (((off_t) 1 << 31 << 31) - 1 + ((off_t) 1 << 31 << 31))
+#define LARGE_OFF_T (((off_t) 1 << 62) - 1 + ((off_t) 1 << 62))
   int off_t_is_large[(LARGE_OFF_T % 2147483629 == 721
 		       && LARGE_OFF_T % 2147483647 == 1)
 		      ? 1 : -1];
 int
-main (void)
+main ()
 {
 
   ;
   return 0;
 }
 _ACEOF
-if ac_fn_c_try_compile "$LINENO"
-then :
+if ac_fn_c_try_compile "$LINENO"; then :
   ac_cv_sys_large_files=1; break
 fi
-rm -f core conftest.err conftest.$ac_objext conftest.beam conftest.$ac_ext
+rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
   ac_cv_sys_large_files=unknown
   break
 done
 fi
-{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $ac_cv_sys_large_files" >&5
-printf "%s\n" "$ac_cv_sys_large_files" >&6; }
+{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_sys_large_files" >&5
+$as_echo "$ac_cv_sys_large_files" >&6; }
 case $ac_cv_sys_large_files in #(
   no | unknown) ;;
   *)
-printf "%s\n" "#define _LARGE_FILES $ac_cv_sys_large_files" >>confdefs.h
+cat >>confdefs.h <<_ACEOF
+#define _LARGE_FILES $ac_cv_sys_large_files
+_ACEOF
 ;;
 esac
 rm -rf conftest*
   fi
+
+
 fi
 
 
 
 
-{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking whether we need -D_LARGEFILE_SOURCE=1 as a flag for $CC" >&5
-printf %s "checking whether we need -D_LARGEFILE_SOURCE=1 as a flag for $CC... " >&6; }
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking whether we need -D_LARGEFILE_SOURCE=1 as a flag for $CC" >&5
+$as_echo_n "checking whether we need -D_LARGEFILE_SOURCE=1 as a flag for $CC... " >&6; }
 cache=_D_LARGEFILE_SOURCE_1
-if eval test \${cv_prog_cc_flag_needed_$cache+y}
-then :
-  printf %s "(cached) " >&6
-else $as_nop
+if eval \${cv_prog_cc_flag_needed_$cache+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
 
 echo '
 #include <stdio.h>
@@ -17247,14 +15976,14 @@ rm -f conftest conftest.c conftest.o
 fi
 
 if eval "test \"`echo '$cv_prog_cc_flag_needed_'$cache`\" = yes"; then
-{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: yes" >&5
-printf "%s\n" "yes" >&6; }
+{ $as_echo "$as_me:${as_lineno-$LINENO}: result: yes" >&5
+$as_echo "yes" >&6; }
 :
 CFLAGS="$CFLAGS -D_LARGEFILE_SOURCE=1"
 else
 if eval "test \"`echo '$cv_prog_cc_flag_needed_'$cache`\" = no"; then
-{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: no" >&5
-printf "%s\n" "no" >&6; }
+{ $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
+$as_echo "no" >&6; }
 #echo 'Test with flag is no!'
 #cat conftest.c
 #echo "$CC $CPPFLAGS $CFLAGS -D_LARGEFILE_SOURCE=1 $ERRFLAG -c conftest.c 2>&1"
@@ -17263,8 +15992,8 @@ printf "%s\n" "no" >&6; }
 :
 
 else
-{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: failed" >&5
-printf "%s\n" "failed" >&6; }
+{ $as_echo "$as_me:${as_lineno-$LINENO}: result: failed" >&5
+$as_echo "failed" >&6; }
 :
 
 fi
@@ -17272,22 +16001,21 @@ fi
 
 
 
-{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking if nonblocking sockets work" >&5
-printf %s "checking if nonblocking sockets work... " >&6; }
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking if nonblocking sockets work" >&5
+$as_echo_n "checking if nonblocking sockets work... " >&6; }
 if echo $host | grep mingw >/dev/null; then
-	{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: no (windows)" >&5
-printf "%s\n" "no (windows)" >&6; }
+	{ $as_echo "$as_me:${as_lineno-$LINENO}: result: no (windows)" >&5
+$as_echo "no (windows)" >&6; }
 
-printf "%s\n" "#define NONBLOCKING_IS_BROKEN 1" >>confdefs.h
+$as_echo "#define NONBLOCKING_IS_BROKEN 1" >>confdefs.h
 
 else
-if test "$cross_compiling" = yes
-then :
+if test "$cross_compiling" = yes; then :
 
-	{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: crosscompile(yes)" >&5
-printf "%s\n" "crosscompile(yes)" >&6; }
+	{ $as_echo "$as_me:${as_lineno-$LINENO}: result: crosscompile(yes)" >&5
+$as_echo "crosscompile(yes)" >&6; }
 
-else $as_nop
+else
   cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 /* end confdefs.h.  */
 
@@ -17414,18 +16142,17 @@ int main(void)
 }
 
 _ACEOF
-if ac_fn_c_try_run "$LINENO"
-then :
+if ac_fn_c_try_run "$LINENO"; then :
 
-	{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: yes" >&5
-printf "%s\n" "yes" >&6; }
+	{ $as_echo "$as_me:${as_lineno-$LINENO}: result: yes" >&5
+$as_echo "yes" >&6; }
 
-else $as_nop
+else
 
-	{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: no" >&5
-printf "%s\n" "no" >&6; }
+	{ $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
+$as_echo "no" >&6; }
 
-printf "%s\n" "#define NONBLOCKING_IS_BROKEN 1" >>confdefs.h
+$as_echo "#define NONBLOCKING_IS_BROKEN 1" >>confdefs.h
 
 
 fi
@@ -17436,8 +16163,8 @@ fi
 fi
 
 
-{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking whether mkdir has one arg" >&5
-printf %s "checking whether mkdir has one arg... " >&6; }
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking whether mkdir has one arg" >&5
+$as_echo_n "checking whether mkdir has one arg... " >&6; }
 cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 /* end confdefs.h.  */
 
@@ -17451,7 +16178,7 @@ cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 #endif
 
 int
-main (void)
+main ()
 {
 
 	(void)mkdir("directory");
@@ -17460,39 +16187,37 @@ main (void)
   return 0;
 }
 _ACEOF
-if ac_fn_c_try_compile "$LINENO"
-then :
-  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: yes" >&5
-printf "%s\n" "yes" >&6; }
+if ac_fn_c_try_compile "$LINENO"; then :
+  { $as_echo "$as_me:${as_lineno-$LINENO}: result: yes" >&5
+$as_echo "yes" >&6; }
 
-printf "%s\n" "#define MKDIR_HAS_ONE_ARG 1" >>confdefs.h
+$as_echo "#define MKDIR_HAS_ONE_ARG 1" >>confdefs.h
 
 
-else $as_nop
-  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: no" >&5
-printf "%s\n" "no" >&6; }
+else
+  { $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
+$as_echo "no" >&6; }
 
 fi
-rm -f core conftest.err conftest.$ac_objext conftest.beam conftest.$ac_ext
+rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
 
-
-  for ac_func in strptime
+for ac_func in strptime
 do :
   ac_fn_c_check_func "$LINENO" "strptime" "ac_cv_func_strptime"
-if test "x$ac_cv_func_strptime" = xyes
-then :
-  printf "%s\n" "#define HAVE_STRPTIME 1" >>confdefs.h
+if test "x$ac_cv_func_strptime" = xyes; then :
+  cat >>confdefs.h <<_ACEOF
+#define HAVE_STRPTIME 1
+_ACEOF
 
-{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking whether strptime works" >&5
-printf %s "checking whether strptime works... " >&6; }
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking whether strptime works" >&5
+$as_echo_n "checking whether strptime works... " >&6; }
 if test c${cross_compiling} = cno; then
-if test "$cross_compiling" = yes
-then :
-  { { printf "%s\n" "$as_me:${as_lineno-$LINENO}: error: in \`$ac_pwd':" >&5
-printf "%s\n" "$as_me: error: in \`$ac_pwd':" >&2;}
+if test "$cross_compiling" = yes; then :
+  { { $as_echo "$as_me:${as_lineno-$LINENO}: error: in \`$ac_pwd':" >&5
+$as_echo "$as_me: error: in \`$ac_pwd':" >&2;}
 as_fn_error $? "cannot run test program while cross compiling
 See \`config.log' for more details" "$LINENO" 5; }
-else $as_nop
+else
   cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 /* end confdefs.h.  */
 
@@ -17505,10 +16230,9 @@ res = strptime("20070207111842", "%Y%m%d%H%M%S", &tm);
 if (!res) return 1; return 0; }
 
 _ACEOF
-if ac_fn_c_try_run "$LINENO"
-then :
+if ac_fn_c_try_run "$LINENO"; then :
   eval "ac_cv_c_strptime_works=yes"
-else $as_nop
+else
   eval "ac_cv_c_strptime_works=no"
 fi
 rm -f core *.core core.conftest.* gmon.out bb.out conftest$ac_exeext \
@@ -17518,8 +16242,8 @@ fi
 else
 eval "ac_cv_c_strptime_works=maybe"
 fi
-{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $ac_cv_c_strptime_works" >&5
-printf "%s\n" "$ac_cv_c_strptime_works" >&6; }
+{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_c_strptime_works" >&5
+$as_echo "$ac_cv_c_strptime_works" >&6; }
 if test $ac_cv_c_strptime_works = no; then
 case " $LIBOBJS " in
   *" strptime.$ac_objext "* ) ;;
@@ -17529,11 +16253,13 @@ esac
 
 else
 
-printf "%s\n" "#define STRPTIME_WORKS 1" >>confdefs.h
+cat >>confdefs.h <<_ACEOF
+#define STRPTIME_WORKS 1
+_ACEOF
 
 fi
 
-else $as_nop
+else
   case " $LIBOBJS " in
   *" strptime.$ac_objext "* ) ;;
   *) LIBOBJS="$LIBOBJS strptime.$ac_objext"
@@ -17541,8 +16267,8 @@ else $as_nop
 esac
 
 fi
-
 done
+
 
 # check if we can use SO_REUSEPORT
 reuseport_default=0
@@ -17550,11 +16276,11 @@ if echo "$host" | $GREP -i -e linux >/dev/null; then reuseport_default=1; fi
 if echo "$host" | $GREP -i -e dragonfly >/dev/null; then reuseport_default=1; fi
 if test "$reuseport_default" = 1; then
 
-printf "%s\n" "#define REUSEPORT_DEFAULT 1" >>confdefs.h
+$as_echo "#define REUSEPORT_DEFAULT 1" >>confdefs.h
 
 else
 
-printf "%s\n" "#define REUSEPORT_DEFAULT 0" >>confdefs.h
+$as_echo "#define REUSEPORT_DEFAULT 0" >>confdefs.h
 
 fi
 
@@ -17563,31 +16289,29 @@ fi
 #   Copyright 2015, Sami Kerola, CloudFlare.
 #   BSD licensed.
 # Check whether --enable-systemd was given.
-if test ${enable_systemd+y}
-then :
+if test "${enable_systemd+set}" = set; then :
   enableval=$enable_systemd;
-else $as_nop
+else
   enable_systemd=no
 fi
 
 have_systemd=no
-if test "x$enable_systemd" != xno
-then :
+if test "x$enable_systemd" != xno; then :
 
 
 
 pkg_failed=no
-{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for SYSTEMD" >&5
-printf %s "checking for SYSTEMD... " >&6; }
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for SYSTEMD" >&5
+$as_echo_n "checking for SYSTEMD... " >&6; }
 
 if test -n "$SYSTEMD_CFLAGS"; then
     pkg_cv_SYSTEMD_CFLAGS="$SYSTEMD_CFLAGS"
  elif test -n "$PKG_CONFIG"; then
     if test -n "$PKG_CONFIG" && \
-    { { printf "%s\n" "$as_me:${as_lineno-$LINENO}: \$PKG_CONFIG --exists --print-errors \"libsystemd\""; } >&5
+    { { $as_echo "$as_me:${as_lineno-$LINENO}: \$PKG_CONFIG --exists --print-errors \"libsystemd\""; } >&5
   ($PKG_CONFIG --exists --print-errors "libsystemd") 2>&5
   ac_status=$?
-  printf "%s\n" "$as_me:${as_lineno-$LINENO}: \$? = $ac_status" >&5
+  $as_echo "$as_me:${as_lineno-$LINENO}: \$? = $ac_status" >&5
   test $ac_status = 0; }; then
   pkg_cv_SYSTEMD_CFLAGS=`$PKG_CONFIG --cflags "libsystemd" 2>/dev/null`
 		      test "x$?" != "x0" && pkg_failed=yes
@@ -17601,10 +16325,10 @@ if test -n "$SYSTEMD_LIBS"; then
     pkg_cv_SYSTEMD_LIBS="$SYSTEMD_LIBS"
  elif test -n "$PKG_CONFIG"; then
     if test -n "$PKG_CONFIG" && \
-    { { printf "%s\n" "$as_me:${as_lineno-$LINENO}: \$PKG_CONFIG --exists --print-errors \"libsystemd\""; } >&5
+    { { $as_echo "$as_me:${as_lineno-$LINENO}: \$PKG_CONFIG --exists --print-errors \"libsystemd\""; } >&5
   ($PKG_CONFIG --exists --print-errors "libsystemd") 2>&5
   ac_status=$?
-  printf "%s\n" "$as_me:${as_lineno-$LINENO}: \$? = $ac_status" >&5
+  $as_echo "$as_me:${as_lineno-$LINENO}: \$? = $ac_status" >&5
   test $ac_status = 0; }; then
   pkg_cv_SYSTEMD_LIBS=`$PKG_CONFIG --libs "libsystemd" 2>/dev/null`
 		      test "x$?" != "x0" && pkg_failed=yes
@@ -17618,8 +16342,8 @@ fi
 
 
 if test $pkg_failed = yes; then
-   	{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: no" >&5
-printf "%s\n" "no" >&6; }
+   	{ $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
+$as_echo "no" >&6; }
 
 if $PKG_CONFIG --atleast-pkgconfig-version 0.20; then
         _pkg_short_errors_supported=yes
@@ -17636,32 +16360,31 @@ fi
 
 	have_systemd=no
 elif test $pkg_failed = untried; then
-     	{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: no" >&5
-printf "%s\n" "no" >&6; }
+     	{ $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
+$as_echo "no" >&6; }
 	have_systemd=no
 else
 	SYSTEMD_CFLAGS=$pkg_cv_SYSTEMD_CFLAGS
 	SYSTEMD_LIBS=$pkg_cv_SYSTEMD_LIBS
-        { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: yes" >&5
-printf "%s\n" "yes" >&6; }
+        { $as_echo "$as_me:${as_lineno-$LINENO}: result: yes" >&5
+$as_echo "yes" >&6; }
 	have_systemd=yes
 fi
-		if test "x$have_systemd" != "xyes"
-then :
+		if test "x$have_systemd" != "xyes"; then :
 
 
 pkg_failed=no
-{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for SYSTEMD_DAEMON" >&5
-printf %s "checking for SYSTEMD_DAEMON... " >&6; }
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for SYSTEMD_DAEMON" >&5
+$as_echo_n "checking for SYSTEMD_DAEMON... " >&6; }
 
 if test -n "$SYSTEMD_DAEMON_CFLAGS"; then
     pkg_cv_SYSTEMD_DAEMON_CFLAGS="$SYSTEMD_DAEMON_CFLAGS"
  elif test -n "$PKG_CONFIG"; then
     if test -n "$PKG_CONFIG" && \
-    { { printf "%s\n" "$as_me:${as_lineno-$LINENO}: \$PKG_CONFIG --exists --print-errors \"libsystemd-daemon\""; } >&5
+    { { $as_echo "$as_me:${as_lineno-$LINENO}: \$PKG_CONFIG --exists --print-errors \"libsystemd-daemon\""; } >&5
   ($PKG_CONFIG --exists --print-errors "libsystemd-daemon") 2>&5
   ac_status=$?
-  printf "%s\n" "$as_me:${as_lineno-$LINENO}: \$? = $ac_status" >&5
+  $as_echo "$as_me:${as_lineno-$LINENO}: \$? = $ac_status" >&5
   test $ac_status = 0; }; then
   pkg_cv_SYSTEMD_DAEMON_CFLAGS=`$PKG_CONFIG --cflags "libsystemd-daemon" 2>/dev/null`
 		      test "x$?" != "x0" && pkg_failed=yes
@@ -17675,10 +16398,10 @@ if test -n "$SYSTEMD_DAEMON_LIBS"; then
     pkg_cv_SYSTEMD_DAEMON_LIBS="$SYSTEMD_DAEMON_LIBS"
  elif test -n "$PKG_CONFIG"; then
     if test -n "$PKG_CONFIG" && \
-    { { printf "%s\n" "$as_me:${as_lineno-$LINENO}: \$PKG_CONFIG --exists --print-errors \"libsystemd-daemon\""; } >&5
+    { { $as_echo "$as_me:${as_lineno-$LINENO}: \$PKG_CONFIG --exists --print-errors \"libsystemd-daemon\""; } >&5
   ($PKG_CONFIG --exists --print-errors "libsystemd-daemon") 2>&5
   ac_status=$?
-  printf "%s\n" "$as_me:${as_lineno-$LINENO}: \$? = $ac_status" >&5
+  $as_echo "$as_me:${as_lineno-$LINENO}: \$? = $ac_status" >&5
   test $ac_status = 0; }; then
   pkg_cv_SYSTEMD_DAEMON_LIBS=`$PKG_CONFIG --libs "libsystemd-daemon" 2>/dev/null`
 		      test "x$?" != "x0" && pkg_failed=yes
@@ -17692,8 +16415,8 @@ fi
 
 
 if test $pkg_failed = yes; then
-   	{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: no" >&5
-printf "%s\n" "no" >&6; }
+   	{ $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
+$as_echo "no" >&6; }
 
 if $PKG_CONFIG --atleast-pkgconfig-version 0.20; then
         _pkg_short_errors_supported=yes
@@ -17710,18 +16433,17 @@ fi
 
 	have_systemd_daemon=no
 elif test $pkg_failed = untried; then
-     	{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: no" >&5
-printf "%s\n" "no" >&6; }
+     	{ $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
+$as_echo "no" >&6; }
 	have_systemd_daemon=no
 else
 	SYSTEMD_DAEMON_CFLAGS=$pkg_cv_SYSTEMD_DAEMON_CFLAGS
 	SYSTEMD_DAEMON_LIBS=$pkg_cv_SYSTEMD_DAEMON_LIBS
-        { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: yes" >&5
-printf "%s\n" "yes" >&6; }
+        { $as_echo "$as_me:${as_lineno-$LINENO}: result: yes" >&5
+$as_echo "yes" >&6; }
 	have_systemd_daemon=yes
 fi
-		if test "x$have_systemd_daemon" = "xyes"
-then :
+		if test "x$have_systemd_daemon" = "xyes"; then :
   have_systemd=yes
 fi
 
@@ -17731,7 +16453,7 @@ fi
     as_fn_error $? "systemd enabled but libsystemd not found" "$LINENO" 5 ;; #(
   *:yes) :
 
-printf "%s\n" "#define HAVE_SYSTEMD 1" >>confdefs.h
+$as_echo "#define HAVE_SYSTEMD 1" >>confdefs.h
 
 		LIBS="$LIBS $SYSTEMD_LIBS"
 
@@ -17755,31 +16477,28 @@ fi
 
 # set memory allocation checking if requested
 # Check whether --enable-alloc-checks was given.
-if test ${enable_alloc_checks+y}
-then :
+if test "${enable_alloc_checks+set}" = set; then :
   enableval=$enable_alloc_checks;
 fi
 
 # Check whether --enable-alloc-lite was given.
-if test ${enable_alloc_lite+y}
-then :
+if test "${enable_alloc_lite+set}" = set; then :
   enableval=$enable_alloc_lite;
 fi
 
 # Check whether --enable-alloc-nonregional was given.
-if test ${enable_alloc_nonregional+y}
-then :
+if test "${enable_alloc_nonregional+set}" = set; then :
   enableval=$enable_alloc_nonregional;
 fi
 
 if test x_$enable_alloc_nonregional = x_yes; then
 
-printf "%s\n" "#define UNBOUND_ALLOC_NONREGIONAL 1" >>confdefs.h
+$as_echo "#define UNBOUND_ALLOC_NONREGIONAL 1" >>confdefs.h
 
 fi
 if test x_$enable_alloc_checks = x_yes; then
 
-printf "%s\n" "#define UNBOUND_ALLOC_STATS 1" >>confdefs.h
+$as_echo "#define UNBOUND_ALLOC_STATS 1" >>confdefs.h
 
 	SLDNS_ALLOCCHECK_EXTRA_OBJ="alloc.lo log.lo"
 
@@ -17788,16 +16507,15 @@ printf "%s\n" "#define UNBOUND_ALLOC_STATS 1" >>confdefs.h
 else
 	if test x_$enable_alloc_lite = x_yes; then
 
-printf "%s\n" "#define UNBOUND_ALLOC_LITE 1" >>confdefs.h
+$as_echo "#define UNBOUND_ALLOC_LITE 1" >>confdefs.h
 
 	else
 
-	{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for GNU libc compatible malloc" >&5
-printf %s "checking for GNU libc compatible malloc... " >&6; }
-	if test "$cross_compiling" = yes
-then :
-  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: no (crosscompile)" >&5
-printf "%s\n" "no (crosscompile)" >&6; }
+	{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for GNU libc compatible malloc" >&5
+$as_echo_n "checking for GNU libc compatible malloc... " >&6; }
+	if test "$cross_compiling" = yes; then :
+  { $as_echo "$as_me:${as_lineno-$LINENO}: result: no (crosscompile)" >&5
+$as_echo "no (crosscompile)" >&6; }
 	case " $LIBOBJS " in
   *" malloc.$ac_objext "* ) ;;
   *) LIBOBJS="$LIBOBJS malloc.$ac_objext"
@@ -17805,9 +16523,11 @@ printf "%s\n" "no (crosscompile)" >&6; }
 esac
 
 
-printf "%s\n" "#define malloc rpl_malloc_unbound" >>confdefs.h
+cat >>confdefs.h <<_ACEOF
+#define malloc rpl_malloc_unbound
+_ACEOF
 
-else $as_nop
+else
   cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 /* end confdefs.h.  */
 #if defined STDC_HEADERS || defined HAVE_STDLIB_H
@@ -17817,7 +16537,7 @@ char *malloc ();
 #endif
 
 int
-main (void)
+main ()
 {
  if(malloc(0) != 0) return 1;
   ;
@@ -17825,10 +16545,9 @@ main (void)
 }
 
 _ACEOF
-if ac_fn_c_try_run "$LINENO"
-then :
-  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: no" >&5
-printf "%s\n" "no" >&6; }
+if ac_fn_c_try_run "$LINENO"; then :
+  { $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
+$as_echo "no" >&6; }
 	case " $LIBOBJS " in
   *" malloc.$ac_objext "* ) ;;
   *) LIBOBJS="$LIBOBJS malloc.$ac_objext"
@@ -17836,13 +16555,15 @@ printf "%s\n" "no" >&6; }
 esac
 
 
-printf "%s\n" "#define malloc rpl_malloc_unbound" >>confdefs.h
+cat >>confdefs.h <<_ACEOF
+#define malloc rpl_malloc_unbound
+_ACEOF
 
-else $as_nop
-  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: yes" >&5
-printf "%s\n" "yes" >&6; }
+else
+  { $as_echo "$as_me:${as_lineno-$LINENO}: result: yes" >&5
+$as_echo "yes" >&6; }
 
-printf "%s\n" "#define HAVE_MALLOC 1" >>confdefs.h
+$as_echo "#define HAVE_MALLOC 1" >>confdefs.h
 
 fi
 rm -f core *.core core.conftest.* gmon.out bb.out conftest$ac_exeext \
@@ -17856,16 +16577,21 @@ fi
 # check windows threads (we use them, not pthreads, on windows).
 if test "$on_mingw" = "yes"; then
 # check windows threads
-	ac_fn_c_check_header_compile "$LINENO" "windows.h" "ac_cv_header_windows_h" "$ac_includes_default
+	for ac_header in windows.h
+do :
+  ac_fn_c_check_header_compile "$LINENO" "windows.h" "ac_cv_header_windows_h" "$ac_includes_default
 "
-if test "x$ac_cv_header_windows_h" = xyes
-then :
-  printf "%s\n" "#define HAVE_WINDOWS_H 1" >>confdefs.h
+if test "x$ac_cv_header_windows_h" = xyes; then :
+  cat >>confdefs.h <<_ACEOF
+#define HAVE_WINDOWS_H 1
+_ACEOF
 
 fi
 
-	{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for CreateThread" >&5
-printf %s "checking for CreateThread... " >&6; }
+done
+
+	{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for CreateThread" >&5
+$as_echo_n "checking for CreateThread... " >&6; }
 	cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 /* end confdefs.h.  */
 
@@ -17874,7 +16600,7 @@ printf %s "checking for CreateThread... " >&6; }
 #endif
 
 int
-main (void)
+main ()
 {
 
 	HANDLE t = CreateThread(NULL, 0, NULL, NULL, 0, NULL);
@@ -17883,20 +16609,19 @@ main (void)
   return 0;
 }
 _ACEOF
-if ac_fn_c_try_compile "$LINENO"
-then :
-  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: yes" >&5
-printf "%s\n" "yes" >&6; }
+if ac_fn_c_try_compile "$LINENO"; then :
+  { $as_echo "$as_me:${as_lineno-$LINENO}: result: yes" >&5
+$as_echo "yes" >&6; }
 
-printf "%s\n" "#define HAVE_WINDOWS_THREADS 1" >>confdefs.h
+$as_echo "#define HAVE_WINDOWS_THREADS 1" >>confdefs.h
 
 
-else $as_nop
-  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: no" >&5
-printf "%s\n" "no" >&6; }
+else
+  { $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
+$as_echo "no" >&6; }
 
 fi
-rm -f core conftest.err conftest.$ac_objext conftest.beam conftest.$ac_ext
+rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
 
 else
 # not on mingw, check thread libraries.
@@ -17907,10 +16632,9 @@ else
 # the non-threadsafe C libraries.
 
 # Check whether --with-pthreads was given.
-if test ${with_pthreads+y}
-then :
+if test "${with_pthreads+set}" = set; then :
   withval=$with_pthreads;
-else $as_nop
+else
    withval="yes"
 fi
 
@@ -17938,31 +16662,33 @@ if test x"$PTHREAD_LIBS$PTHREAD_CFLAGS" != x; then
         CFLAGS="$CFLAGS $PTHREAD_CFLAGS"
         save_LIBS="$LIBS"
         LIBS="$PTHREAD_LIBS $LIBS"
-        { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for pthread_join in LIBS=$PTHREAD_LIBS with CFLAGS=$PTHREAD_CFLAGS" >&5
-printf %s "checking for pthread_join in LIBS=$PTHREAD_LIBS with CFLAGS=$PTHREAD_CFLAGS... " >&6; }
+        { $as_echo "$as_me:${as_lineno-$LINENO}: checking for pthread_join in LIBS=$PTHREAD_LIBS with CFLAGS=$PTHREAD_CFLAGS" >&5
+$as_echo_n "checking for pthread_join in LIBS=$PTHREAD_LIBS with CFLAGS=$PTHREAD_CFLAGS... " >&6; }
         cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 /* end confdefs.h.  */
 
 /* Override any GCC internal prototype to avoid an error.
    Use char because int might match the return type of a GCC
    builtin and then its argument prototype would still apply.  */
+#ifdef __cplusplus
+extern "C"
+#endif
 char pthread_join ();
 int
-main (void)
+main ()
 {
 return pthread_join ();
   ;
   return 0;
 }
 _ACEOF
-if ac_fn_c_try_link "$LINENO"
-then :
+if ac_fn_c_try_link "$LINENO"; then :
   ax_pthread_ok=yes
 fi
-rm -f core conftest.err conftest.$ac_objext conftest.beam \
+rm -f core conftest.err conftest.$ac_objext \
     conftest$ac_exeext conftest.$ac_ext
-        { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $ax_pthread_ok" >&5
-printf "%s\n" "$ax_pthread_ok" >&6; }
+        { $as_echo "$as_me:${as_lineno-$LINENO}: result: $ax_pthread_ok" >&5
+$as_echo "$ax_pthread_ok" >&6; }
         if test x"$ax_pthread_ok" = xno; then
                 PTHREAD_LIBS=""
                 PTHREAD_CFLAGS=""
@@ -18026,8 +16752,8 @@ esac
 # -Werror. We throw in some extra Clang-specific options to ensure that
 # this doesn't happen for GCC, which also accepts -Werror.
 
-{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking if compiler needs -Werror to reject unknown flags" >&5
-printf %s "checking if compiler needs -Werror to reject unknown flags... " >&6; }
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking if compiler needs -Werror to reject unknown flags" >&5
+$as_echo_n "checking if compiler needs -Werror to reject unknown flags... " >&6; }
 save_CFLAGS="$CFLAGS"
 ax_pthread_extra_flags="-Werror"
 CFLAGS="$CFLAGS $ax_pthread_extra_flags -Wunknown-warning-option -Wsizeof-array-argument"
@@ -18035,23 +16761,22 @@ cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 /* end confdefs.h.  */
 int foo(void);
 int
-main (void)
+main ()
 {
 foo()
   ;
   return 0;
 }
 _ACEOF
-if ac_fn_c_try_compile "$LINENO"
-then :
-  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: yes" >&5
-printf "%s\n" "yes" >&6; }
-else $as_nop
+if ac_fn_c_try_compile "$LINENO"; then :
+  { $as_echo "$as_me:${as_lineno-$LINENO}: result: yes" >&5
+$as_echo "yes" >&6; }
+else
   ax_pthread_extra_flags=
-                   { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: no" >&5
-printf "%s\n" "no" >&6; }
+                   { $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
+$as_echo "no" >&6; }
 fi
-rm -f core conftest.err conftest.$ac_objext conftest.beam conftest.$ac_ext
+rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
 CFLAGS="$save_CFLAGS"
 
 if test x"$ax_pthread_ok" = xno; then
@@ -18059,25 +16784,24 @@ for flag in $ax_pthread_flags; do
 
         case $flag in
                 none)
-                { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking whether pthreads work without any flags" >&5
-printf %s "checking whether pthreads work without any flags... " >&6; }
+                { $as_echo "$as_me:${as_lineno-$LINENO}: checking whether pthreads work without any flags" >&5
+$as_echo_n "checking whether pthreads work without any flags... " >&6; }
                 ;;
 
                 -*)
-                { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking whether pthreads work with $flag" >&5
-printf %s "checking whether pthreads work with $flag... " >&6; }
+                { $as_echo "$as_me:${as_lineno-$LINENO}: checking whether pthreads work with $flag" >&5
+$as_echo_n "checking whether pthreads work with $flag... " >&6; }
                 PTHREAD_CFLAGS="$flag"
                 ;;
 
                 pthread-config)
                 # Extract the first word of "pthread-config", so it can be a program name with args.
 set dummy pthread-config; ac_word=$2
-{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for $ac_word" >&5
-printf %s "checking for $ac_word... " >&6; }
-if test ${ac_cv_prog_ax_pthread_config+y}
-then :
-  printf %s "(cached) " >&6
-else $as_nop
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for $ac_word" >&5
+$as_echo_n "checking for $ac_word... " >&6; }
+if ${ac_cv_prog_ax_pthread_config+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
   if test -n "$ax_pthread_config"; then
   ac_cv_prog_ax_pthread_config="$ax_pthread_config" # Let the user override the test.
 else
@@ -18085,15 +16809,11 @@ as_save_IFS=$IFS; IFS=$PATH_SEPARATOR
 for as_dir in $PATH
 do
   IFS=$as_save_IFS
-  case $as_dir in #(((
-    '') as_dir=./ ;;
-    */) ;;
-    *) as_dir=$as_dir/ ;;
-  esac
+  test -z "$as_dir" && as_dir=.
     for ac_exec_ext in '' $ac_executable_extensions; do
-  if as_fn_executable_p "$as_dir$ac_word$ac_exec_ext"; then
+  if as_fn_executable_p "$as_dir/$ac_word$ac_exec_ext"; then
     ac_cv_prog_ax_pthread_config="yes"
-    printf "%s\n" "$as_me:${as_lineno-$LINENO}: found $as_dir$ac_word$ac_exec_ext" >&5
+    $as_echo "$as_me:${as_lineno-$LINENO}: found $as_dir/$ac_word$ac_exec_ext" >&5
     break 2
   fi
 done
@@ -18105,11 +16825,11 @@ fi
 fi
 ax_pthread_config=$ac_cv_prog_ax_pthread_config
 if test -n "$ax_pthread_config"; then
-  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $ax_pthread_config" >&5
-printf "%s\n" "$ax_pthread_config" >&6; }
+  { $as_echo "$as_me:${as_lineno-$LINENO}: result: $ax_pthread_config" >&5
+$as_echo "$ax_pthread_config" >&6; }
 else
-  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: no" >&5
-printf "%s\n" "no" >&6; }
+  { $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
+$as_echo "no" >&6; }
 fi
 
 
@@ -18119,8 +16839,8 @@ fi
                 ;;
 
                 *)
-                { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for the pthreads library -l$flag" >&5
-printf %s "checking for the pthreads library -l$flag... " >&6; }
+                { $as_echo "$as_me:${as_lineno-$LINENO}: checking for the pthreads library -l$flag" >&5
+$as_echo_n "checking for the pthreads library -l$flag... " >&6; }
                 PTHREAD_LIBS="-l$flag"
                 ;;
         esac
@@ -18145,7 +16865,7 @@ printf %s "checking for the pthreads library -l$flag... " >&6; }
                         static void routine(void *a) { *((int*)a) = 0; }
                         static void *start_routine(void *a) { return a; }
 int
-main (void)
+main ()
 {
 pthread_t th; pthread_attr_t attr;
                         pthread_create(&th, 0, start_routine, 0);
@@ -18157,18 +16877,17 @@ pthread_t th; pthread_attr_t attr;
   return 0;
 }
 _ACEOF
-if ac_fn_c_try_link "$LINENO"
-then :
+if ac_fn_c_try_link "$LINENO"; then :
   ax_pthread_ok=yes
 fi
-rm -f core conftest.err conftest.$ac_objext conftest.beam \
+rm -f core conftest.err conftest.$ac_objext \
     conftest$ac_exeext conftest.$ac_ext
 
         LIBS="$save_LIBS"
         CFLAGS="$save_CFLAGS"
 
-        { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $ax_pthread_ok" >&5
-printf "%s\n" "$ax_pthread_ok" >&6; }
+        { $as_echo "$as_me:${as_lineno-$LINENO}: result: $ax_pthread_ok" >&5
+$as_echo "$ax_pthread_ok" >&6; }
         if test "x$ax_pthread_ok" = xyes; then
                 break;
         fi
@@ -18186,38 +16905,39 @@ if test "x$ax_pthread_ok" = xyes; then
         CFLAGS="$CFLAGS $PTHREAD_CFLAGS"
 
         # Detect AIX lossage: JOINABLE attribute is called UNDETACHED.
-        { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for joinable pthread attribute" >&5
-printf %s "checking for joinable pthread attribute... " >&6; }
+        { $as_echo "$as_me:${as_lineno-$LINENO}: checking for joinable pthread attribute" >&5
+$as_echo_n "checking for joinable pthread attribute... " >&6; }
         attr_name=unknown
         for attr in PTHREAD_CREATE_JOINABLE PTHREAD_CREATE_UNDETACHED; do
             cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 /* end confdefs.h.  */
 #include <pthread.h>
 int
-main (void)
+main ()
 {
 int attr = $attr; return attr /* ; */
   ;
   return 0;
 }
 _ACEOF
-if ac_fn_c_try_link "$LINENO"
-then :
+if ac_fn_c_try_link "$LINENO"; then :
   attr_name=$attr; break
 fi
-rm -f core conftest.err conftest.$ac_objext conftest.beam \
+rm -f core conftest.err conftest.$ac_objext \
     conftest$ac_exeext conftest.$ac_ext
         done
-        { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $attr_name" >&5
-printf "%s\n" "$attr_name" >&6; }
+        { $as_echo "$as_me:${as_lineno-$LINENO}: result: $attr_name" >&5
+$as_echo "$attr_name" >&6; }
         if test "$attr_name" != PTHREAD_CREATE_JOINABLE; then
 
-printf "%s\n" "#define PTHREAD_CREATE_JOINABLE $attr_name" >>confdefs.h
+cat >>confdefs.h <<_ACEOF
+#define PTHREAD_CREATE_JOINABLE $attr_name
+_ACEOF
 
         fi
 
-        { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking if more special flags are required for pthreads" >&5
-printf %s "checking if more special flags are required for pthreads... " >&6; }
+        { $as_echo "$as_me:${as_lineno-$LINENO}: checking if more special flags are required for pthreads" >&5
+$as_echo_n "checking if more special flags are required for pthreads... " >&6; }
         flag=no
         case ${host_os} in
             aix* | freebsd* | darwin*) flag="-D_THREAD_SAFE";;
@@ -18231,46 +16951,43 @@ printf %s "checking if more special flags are required for pthreads... " >&6; }
             fi
             ;;
         esac
-        { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $flag" >&5
-printf "%s\n" "$flag" >&6; }
+        { $as_echo "$as_me:${as_lineno-$LINENO}: result: $flag" >&5
+$as_echo "$flag" >&6; }
         if test "x$flag" != xno; then
             PTHREAD_CFLAGS="$flag $PTHREAD_CFLAGS"
         fi
 
-        { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for PTHREAD_PRIO_INHERIT" >&5
-printf %s "checking for PTHREAD_PRIO_INHERIT... " >&6; }
-if test ${ax_cv_PTHREAD_PRIO_INHERIT+y}
-then :
-  printf %s "(cached) " >&6
-else $as_nop
+        { $as_echo "$as_me:${as_lineno-$LINENO}: checking for PTHREAD_PRIO_INHERIT" >&5
+$as_echo_n "checking for PTHREAD_PRIO_INHERIT... " >&6; }
+if ${ax_cv_PTHREAD_PRIO_INHERIT+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
 
                 cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 /* end confdefs.h.  */
 #include <pthread.h>
 int
-main (void)
+main ()
 {
 int i = PTHREAD_PRIO_INHERIT;
   ;
   return 0;
 }
 _ACEOF
-if ac_fn_c_try_link "$LINENO"
-then :
+if ac_fn_c_try_link "$LINENO"; then :
   ax_cv_PTHREAD_PRIO_INHERIT=yes
-else $as_nop
+else
   ax_cv_PTHREAD_PRIO_INHERIT=no
 fi
-rm -f core conftest.err conftest.$ac_objext conftest.beam \
+rm -f core conftest.err conftest.$ac_objext \
     conftest$ac_exeext conftest.$ac_ext
 
 fi
-{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $ax_cv_PTHREAD_PRIO_INHERIT" >&5
-printf "%s\n" "$ax_cv_PTHREAD_PRIO_INHERIT" >&6; }
-        if test "x$ax_cv_PTHREAD_PRIO_INHERIT" = "xyes"
-then :
+{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $ax_cv_PTHREAD_PRIO_INHERIT" >&5
+$as_echo "$ax_cv_PTHREAD_PRIO_INHERIT" >&6; }
+        if test "x$ax_cv_PTHREAD_PRIO_INHERIT" = "xyes"; then :
 
-printf "%s\n" "#define HAVE_PTHREAD_PRIO_INHERIT 1" >>confdefs.h
+$as_echo "#define HAVE_PTHREAD_PRIO_INHERIT 1" >>confdefs.h
 
 fi
 
@@ -18286,8 +17003,7 @@ fi
     #handle absolute path differently from PATH based program lookup
                    case "x$CC" in #(
   x/*) :
-    if as_fn_executable_p ${CC}_r
-then :
+    if as_fn_executable_p ${CC}_r; then :
   PTHREAD_CC="${CC}_r"
 fi ;; #(
   *) :
@@ -18295,12 +17011,11 @@ fi ;; #(
 do
   # Extract the first word of "$ac_prog", so it can be a program name with args.
 set dummy $ac_prog; ac_word=$2
-{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for $ac_word" >&5
-printf %s "checking for $ac_word... " >&6; }
-if test ${ac_cv_prog_PTHREAD_CC+y}
-then :
-  printf %s "(cached) " >&6
-else $as_nop
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for $ac_word" >&5
+$as_echo_n "checking for $ac_word... " >&6; }
+if ${ac_cv_prog_PTHREAD_CC+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
   if test -n "$PTHREAD_CC"; then
   ac_cv_prog_PTHREAD_CC="$PTHREAD_CC" # Let the user override the test.
 else
@@ -18308,15 +17023,11 @@ as_save_IFS=$IFS; IFS=$PATH_SEPARATOR
 for as_dir in $PATH
 do
   IFS=$as_save_IFS
-  case $as_dir in #(((
-    '') as_dir=./ ;;
-    */) ;;
-    *) as_dir=$as_dir/ ;;
-  esac
+  test -z "$as_dir" && as_dir=.
     for ac_exec_ext in '' $ac_executable_extensions; do
-  if as_fn_executable_p "$as_dir$ac_word$ac_exec_ext"; then
+  if as_fn_executable_p "$as_dir/$ac_word$ac_exec_ext"; then
     ac_cv_prog_PTHREAD_CC="$ac_prog"
-    printf "%s\n" "$as_me:${as_lineno-$LINENO}: found $as_dir$ac_word$ac_exec_ext" >&5
+    $as_echo "$as_me:${as_lineno-$LINENO}: found $as_dir/$ac_word$ac_exec_ext" >&5
     break 2
   fi
 done
@@ -18327,11 +17038,11 @@ fi
 fi
 PTHREAD_CC=$ac_cv_prog_PTHREAD_CC
 if test -n "$PTHREAD_CC"; then
-  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $PTHREAD_CC" >&5
-printf "%s\n" "$PTHREAD_CC" >&6; }
+  { $as_echo "$as_me:${as_lineno-$LINENO}: result: $PTHREAD_CC" >&5
+$as_echo "$PTHREAD_CC" >&6; }
 else
-  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: no" >&5
-printf "%s\n" "no" >&6; }
+  { $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
+$as_echo "no" >&6; }
 fi
 
 
@@ -18358,7 +17069,7 @@ test -n "$PTHREAD_CC" || PTHREAD_CC="$CC"
 if test x"$ax_pthread_ok" = xyes; then
 
 
-printf "%s\n" "#define HAVE_PTHREAD 1" >>confdefs.h
+$as_echo "#define HAVE_PTHREAD 1" >>confdefs.h
 
 		if test -n "$PTHREAD_LIBS"; then
 		  LIBS="$PTHREAD_LIBS $LIBS"
@@ -18368,27 +17079,29 @@ printf "%s\n" "#define HAVE_PTHREAD 1" >>confdefs.h
 		ub_have_pthreads=yes
 		ac_fn_c_check_type "$LINENO" "pthread_spinlock_t" "ac_cv_type_pthread_spinlock_t" "#include <pthread.h>
 "
-if test "x$ac_cv_type_pthread_spinlock_t" = xyes
-then :
+if test "x$ac_cv_type_pthread_spinlock_t" = xyes; then :
 
-printf "%s\n" "#define HAVE_PTHREAD_SPINLOCK_T 1" >>confdefs.h
+cat >>confdefs.h <<_ACEOF
+#define HAVE_PTHREAD_SPINLOCK_T 1
+_ACEOF
 
 
 fi
 ac_fn_c_check_type "$LINENO" "pthread_rwlock_t" "ac_cv_type_pthread_rwlock_t" "#include <pthread.h>
 "
-if test "x$ac_cv_type_pthread_rwlock_t" = xyes
-then :
+if test "x$ac_cv_type_pthread_rwlock_t" = xyes; then :
 
-printf "%s\n" "#define HAVE_PTHREAD_RWLOCK_T 1" >>confdefs.h
+cat >>confdefs.h <<_ACEOF
+#define HAVE_PTHREAD_RWLOCK_T 1
+_ACEOF
 
 
 fi
 
 
 		if echo "$CFLAGS" | $GREP -e "-pthread" >/dev/null; then
-		{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking if -pthread unused during linking" >&5
-printf %s "checking if -pthread unused during linking... " >&6; }
+		{ $as_echo "$as_me:${as_lineno-$LINENO}: checking if -pthread unused during linking" >&5
+$as_echo_n "checking if -pthread unused during linking... " >&6; }
 		# catch clang warning 'argument unused during compilation'
 		cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 /* end confdefs.h.  */
@@ -18406,18 +17119,18 @@ _ACEOF
 			echo "$CC $CFLAGS -Werror $LDFLAGS $LIBS -o conftest contest.o" >&5
 			$CC $CFLAGS -Werror $LDFLAGS $LIBS -o conftest conftest.o 2>&5 >&5
 			if test $? -ne 0; then
-				{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: yes" >&5
-printf "%s\n" "yes" >&6; }
+				{ $as_echo "$as_me:${as_lineno-$LINENO}: result: yes" >&5
+$as_echo "yes" >&6; }
 				CFLAGS=`echo "$CFLAGS" | sed -e 's/-pthread//'`
 				PTHREAD_CFLAGS_ONLY="-pthread"
 
 			else
-				{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: no" >&5
-printf "%s\n" "no" >&6; }
+				{ $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
+$as_echo "no" >&6; }
 			fi
 		else
-			{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: no" >&5
-printf "%s\n" "no" >&6; }
+			{ $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
+$as_echo "no" >&6; }
 		fi # endif cc successful
 		rm -f conftest conftest.c conftest.o
 		fi # endif -pthread in CFLAGS
@@ -18440,25 +17153,23 @@ fi
 # check solaris thread library
 
 # Check whether --with-solaris-threads was given.
-if test ${with_solaris_threads+y}
-then :
+if test "${with_solaris_threads+set}" = set; then :
   withval=$with_solaris_threads;
-else $as_nop
+else
    withval="no"
 fi
 
 ub_have_sol_threads=no
 if test x_$withval != x_no; then
 	if test x_$ub_have_pthreads != x_no; then
-	    { printf "%s\n" "$as_me:${as_lineno-$LINENO}: WARNING: Have pthreads already, ignoring --with-solaris-threads" >&5
-printf "%s\n" "$as_me: WARNING: Have pthreads already, ignoring --with-solaris-threads" >&2;}
+	    { $as_echo "$as_me:${as_lineno-$LINENO}: WARNING: Have pthreads already, ignoring --with-solaris-threads" >&5
+$as_echo "$as_me: WARNING: Have pthreads already, ignoring --with-solaris-threads" >&2;}
 	else
-	{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for library containing thr_create" >&5
-printf %s "checking for library containing thr_create... " >&6; }
-if test ${ac_cv_search_thr_create+y}
-then :
-  printf %s "(cached) " >&6
-else $as_nop
+	{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for library containing thr_create" >&5
+$as_echo_n "checking for library containing thr_create... " >&6; }
+if ${ac_cv_search_thr_create+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
   ac_func_search_save_LIBS=$LIBS
 cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 /* end confdefs.h.  */
@@ -18466,63 +17177,60 @@ cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 /* Override any GCC internal prototype to avoid an error.
    Use char because int might match the return type of a GCC
    builtin and then its argument prototype would still apply.  */
+#ifdef __cplusplus
+extern "C"
+#endif
 char thr_create ();
 int
-main (void)
+main ()
 {
 return thr_create ();
   ;
   return 0;
 }
 _ACEOF
-for ac_lib in '' thread
-do
+for ac_lib in '' thread; do
   if test -z "$ac_lib"; then
     ac_res="none required"
   else
     ac_res=-l$ac_lib
     LIBS="-l$ac_lib  $ac_func_search_save_LIBS"
   fi
-  if ac_fn_c_try_link "$LINENO"
-then :
+  if ac_fn_c_try_link "$LINENO"; then :
   ac_cv_search_thr_create=$ac_res
 fi
-rm -f core conftest.err conftest.$ac_objext conftest.beam \
+rm -f core conftest.err conftest.$ac_objext \
     conftest$ac_exeext
-  if test ${ac_cv_search_thr_create+y}
-then :
+  if ${ac_cv_search_thr_create+:} false; then :
   break
 fi
 done
-if test ${ac_cv_search_thr_create+y}
-then :
+if ${ac_cv_search_thr_create+:} false; then :
 
-else $as_nop
+else
   ac_cv_search_thr_create=no
 fi
 rm conftest.$ac_ext
 LIBS=$ac_func_search_save_LIBS
 fi
-{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $ac_cv_search_thr_create" >&5
-printf "%s\n" "$ac_cv_search_thr_create" >&6; }
+{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_search_thr_create" >&5
+$as_echo "$ac_cv_search_thr_create" >&6; }
 ac_res=$ac_cv_search_thr_create
-if test "$ac_res" != no
-then :
+if test "$ac_res" != no; then :
   test "$ac_res" = "none required" || LIBS="$ac_res $LIBS"
 
 
-printf "%s\n" "#define HAVE_SOLARIS_THREADS 1" >>confdefs.h
+$as_echo "#define HAVE_SOLARIS_THREADS 1" >>confdefs.h
 
 
 
 
-{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking whether $CC supports -mt" >&5
-printf %s "checking whether $CC supports -mt... " >&6; }
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking whether $CC supports -mt" >&5
+$as_echo_n "checking whether $CC supports -mt... " >&6; }
 cache=`echo mt | sed 'y%.=/+-%___p_%'`
-if eval test \${cv_prog_cc_flag_$cache+y}
-then :
-  printf %s "(cached) " >&6
-else $as_nop
+if eval \${cv_prog_cc_flag_$cache+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
 
 echo 'void f(void){}' >conftest.c
 if test -z "`$CC $CPPFLAGS $CFLAGS -mt -c conftest.c 2>&1`"; then
@@ -18535,20 +17243,20 @@ rm -f conftest conftest.o conftest.c
 fi
 
 if eval "test \"`echo '$cv_prog_cc_flag_'$cache`\" = yes"; then
-{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: yes" >&5
-printf "%s\n" "yes" >&6; }
+{ $as_echo "$as_me:${as_lineno-$LINENO}: result: yes" >&5
+$as_echo "yes" >&6; }
 :
 CFLAGS="$CFLAGS -mt"
 else
-{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: no" >&5
-printf "%s\n" "no" >&6; }
+{ $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
+$as_echo "no" >&6; }
 :
 CFLAGS="$CFLAGS -D_REENTRANT"
 fi
 
 		ub_have_sol_threads=yes
 
-else $as_nop
+else
 
 		as_fn_error $? "no solaris threads found." "$LINENO" 5
 
@@ -18562,8 +17270,7 @@ fi # end of non-mingw check of thread libraries
 # Check for SYSLOG_FACILITY
 
 # Check whether --with-syslog-facility was given.
-if test ${with_syslog_facility+y}
-then :
+if test "${with_syslog_facility+set}" = set; then :
   withval=$with_syslog_facility;  UNBOUND_SYSLOG_FACILITY="$withval"
 fi
 
@@ -18575,23 +17282,24 @@ case "${UNBOUND_SYSLOG_FACILITY}" in
 
 esac
 
-printf "%s\n" "#define UB_SYSLOG_FACILITY ${UNBOUND_SYSLOG_FACILITY}" >>confdefs.h
+cat >>confdefs.h <<_ACEOF
+#define UB_SYSLOG_FACILITY ${UNBOUND_SYSLOG_FACILITY}
+_ACEOF
 
 
 # Check for dynamic library module
 
 # Check whether --with-dynlibmodule was given.
-if test ${with_dynlibmodule+y}
-then :
+if test "${with_dynlibmodule+set}" = set; then :
   withval=$with_dynlibmodule;
-else $as_nop
+else
    withval="no"
 fi
 
 
 if test x_$withval != x_no; then
 
-printf "%s\n" "#define WITH_DYNLIBMODULE 1" >>confdefs.h
+$as_echo "#define WITH_DYNLIBMODULE 1" >>confdefs.h
 
   WITH_DYNLIBMODULE=yes
 
@@ -18603,12 +17311,11 @@ printf "%s\n" "#define WITH_DYNLIBMODULE 1" >>confdefs.h
     # link with -ldl if not already there, for all executables because
     # dlopen call is in the dynlib module.  For unbound executable, also
     # export symbols.
-    { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for library containing dlopen" >&5
-printf %s "checking for library containing dlopen... " >&6; }
-if test ${ac_cv_search_dlopen+y}
-then :
-  printf %s "(cached) " >&6
-else $as_nop
+    { $as_echo "$as_me:${as_lineno-$LINENO}: checking for library containing dlopen" >&5
+$as_echo_n "checking for library containing dlopen... " >&6; }
+if ${ac_cv_search_dlopen+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
   ac_func_search_save_LIBS=$LIBS
 cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 /* end confdefs.h.  */
@@ -18616,48 +17323,46 @@ cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 /* Override any GCC internal prototype to avoid an error.
    Use char because int might match the return type of a GCC
    builtin and then its argument prototype would still apply.  */
+#ifdef __cplusplus
+extern "C"
+#endif
 char dlopen ();
 int
-main (void)
+main ()
 {
 return dlopen ();
   ;
   return 0;
 }
 _ACEOF
-for ac_lib in '' dl
-do
+for ac_lib in '' dl; do
   if test -z "$ac_lib"; then
     ac_res="none required"
   else
     ac_res=-l$ac_lib
     LIBS="-l$ac_lib  $ac_func_search_save_LIBS"
   fi
-  if ac_fn_c_try_link "$LINENO"
-then :
+  if ac_fn_c_try_link "$LINENO"; then :
   ac_cv_search_dlopen=$ac_res
 fi
-rm -f core conftest.err conftest.$ac_objext conftest.beam \
+rm -f core conftest.err conftest.$ac_objext \
     conftest$ac_exeext
-  if test ${ac_cv_search_dlopen+y}
-then :
+  if ${ac_cv_search_dlopen+:} false; then :
   break
 fi
 done
-if test ${ac_cv_search_dlopen+y}
-then :
+if ${ac_cv_search_dlopen+:} false; then :
 
-else $as_nop
+else
   ac_cv_search_dlopen=no
 fi
 rm conftest.$ac_ext
 LIBS=$ac_func_search_save_LIBS
 fi
-{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $ac_cv_search_dlopen" >&5
-printf "%s\n" "$ac_cv_search_dlopen" >&6; }
+{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_search_dlopen" >&5
+$as_echo "$ac_cv_search_dlopen" >&6; }
 ac_res=$ac_cv_search_dlopen
-if test "$ac_res" != no
-then :
+if test "$ac_res" != no; then :
   test "$ac_res" = "none required" || LIBS="$ac_res $LIBS"
 
 fi
@@ -18672,10 +17377,9 @@ fi
 # Check for PyUnbound
 
 # Check whether --with-pyunbound was given.
-if test ${with_pyunbound+y}
-then :
+if test "${with_pyunbound+set}" = set; then :
   withval=$with_pyunbound;
-else $as_nop
+else
    withval="no"
 fi
 
@@ -18690,10 +17394,9 @@ fi
 # Check for Python module
 
 # Check whether --with-pythonmodule was given.
-if test ${with_pythonmodule+y}
-then :
+if test "${with_pythonmodule+set}" = set; then :
   withval=$with_pythonmodule;
-else $as_nop
+else
    withval="no"
 fi
 
@@ -18717,12 +17420,11 @@ if test x_$ub_test_python != x_no; then
 
         # Extract the first word of "python[$PYTHON_VERSION]", so it can be a program name with args.
 set dummy python$PYTHON_VERSION; ac_word=$2
-{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for $ac_word" >&5
-printf %s "checking for $ac_word... " >&6; }
-if test ${ac_cv_path_PYTHON+y}
-then :
-  printf %s "(cached) " >&6
-else $as_nop
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for $ac_word" >&5
+$as_echo_n "checking for $ac_word... " >&6; }
+if ${ac_cv_path_PYTHON+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
   case $PYTHON in
   [\\/]* | ?:[\\/]*)
   ac_cv_path_PYTHON="$PYTHON" # Let the user override the test with a path.
@@ -18732,15 +17434,11 @@ else $as_nop
 for as_dir in $PATH
 do
   IFS=$as_save_IFS
-  case $as_dir in #(((
-    '') as_dir=./ ;;
-    */) ;;
-    *) as_dir=$as_dir/ ;;
-  esac
+  test -z "$as_dir" && as_dir=.
     for ac_exec_ext in '' $ac_executable_extensions; do
-  if as_fn_executable_p "$as_dir$ac_word$ac_exec_ext"; then
-    ac_cv_path_PYTHON="$as_dir$ac_word$ac_exec_ext"
-    printf "%s\n" "$as_me:${as_lineno-$LINENO}: found $as_dir$ac_word$ac_exec_ext" >&5
+  if as_fn_executable_p "$as_dir/$ac_word$ac_exec_ext"; then
+    ac_cv_path_PYTHON="$as_dir/$ac_word$ac_exec_ext"
+    $as_echo "$as_me:${as_lineno-$LINENO}: found $as_dir/$ac_word$ac_exec_ext" >&5
     break 2
   fi
 done
@@ -18752,11 +17450,11 @@ esac
 fi
 PYTHON=$ac_cv_path_PYTHON
 if test -n "$PYTHON"; then
-  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $PYTHON" >&5
-printf "%s\n" "$PYTHON" >&6; }
+  { $as_echo "$as_me:${as_lineno-$LINENO}: result: $PYTHON" >&5
+$as_echo "$PYTHON" >&6; }
 else
-  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: no" >&5
-printf "%s\n" "no" >&6; }
+  { $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
+$as_echo "no" >&6; }
 fi
 
 
@@ -18806,8 +17504,8 @@ $as_echo "no" >&6; }
         #
         # Check for Python include path
         #
-        { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for Python include path" >&5
-printf %s "checking for Python include path... " >&6; }
+        { $as_echo "$as_me:${as_lineno-$LINENO}: checking for Python include path" >&5
+$as_echo_n "checking for Python include path... " >&6; }
         if test -z "$PYTHON_CPPFLAGS"; then
 		if test "$sysconfig_module" = "sysconfig"; then
 			python_path=`$PYTHON -c 'import sysconfig; \
@@ -18821,21 +17519,21 @@ printf %s "checking for Python include path... " >&6; }
                 fi
                 PYTHON_CPPFLAGS=$python_path
         fi
-        { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $PYTHON_CPPFLAGS" >&5
-printf "%s\n" "$PYTHON_CPPFLAGS" >&6; }
+        { $as_echo "$as_me:${as_lineno-$LINENO}: result: $PYTHON_CPPFLAGS" >&5
+$as_echo "$PYTHON_CPPFLAGS" >&6; }
 
 
         #
         # Check for Python library path
         #
-        { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for Python library path" >&5
-printf %s "checking for Python library path... " >&6; }
+        { $as_echo "$as_me:${as_lineno-$LINENO}: checking for Python library path" >&5
+$as_echo_n "checking for Python library path... " >&6; }
         if test -z "$PYTHON_LDFLAGS"; then
                 PYTHON_LDFLAGS=`$PYTHON -c "from $sysconfig_module import *; \
                         print('-L'+get_config_var('LIBDIR')+' -L'+get_config_var('LIBDEST')+' '+get_config_var('BLDLIBRARY'));"`
         fi
-        { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $PYTHON_LDFLAGS" >&5
-printf "%s\n" "$PYTHON_LDFLAGS" >&6; }
+        { $as_echo "$as_me:${as_lineno-$LINENO}: result: $PYTHON_LDFLAGS" >&5
+$as_echo "$PYTHON_LDFLAGS" >&6; }
 
 
         if test -z "$PYTHON_LIBDIR"; then
@@ -18846,8 +17544,8 @@ printf "%s\n" "$PYTHON_LDFLAGS" >&6; }
         #
         # Check for site packages
         #
-        { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for Python site-packages path" >&5
-printf %s "checking for Python site-packages path... " >&6; }
+        { $as_echo "$as_me:${as_lineno-$LINENO}: checking for Python site-packages path" >&5
+$as_echo_n "checking for Python site-packages path... " >&6; }
         if test -z "$PYTHON_SITE_PKG"; then
 		if test "$sysconfig_module" = "sysconfig"; then
 			PYTHON_SITE_PKG=`$PYTHON -c 'import sysconfig; \
@@ -18857,15 +17555,15 @@ printf %s "checking for Python site-packages path... " >&6; }
 				print(distutils.sysconfig.get_python_lib(1,0));"`
 		fi
         fi
-        { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $PYTHON_SITE_PKG" >&5
-printf "%s\n" "$PYTHON_SITE_PKG" >&6; }
+        { $as_echo "$as_me:${as_lineno-$LINENO}: result: $PYTHON_SITE_PKG" >&5
+$as_echo "$PYTHON_SITE_PKG" >&6; }
 
 
         #
         # final check to see if everything compiles alright
         #
-        { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking consistency of all components of python development environment" >&5
-printf %s "checking consistency of all components of python development environment... " >&6; }
+        { $as_echo "$as_me:${as_lineno-$LINENO}: checking consistency of all components of python development environment" >&5
+$as_echo_n "checking consistency of all components of python development environment... " >&6; }
         ac_ext=c
 ac_cpp='$CPP $CPPFLAGS'
 ac_compile='$CC -c $CFLAGS $CPPFLAGS conftest.$ac_ext >&5'
@@ -18884,7 +17582,7 @@ ac_compiler_gnu=$ac_cv_c_compiler_gnu
                 #include <Python.h>
 
 int
-main (void)
+main ()
 {
 
                 Py_Initialize();
@@ -18893,17 +17591,16 @@ main (void)
   return 0;
 }
 _ACEOF
-if ac_fn_c_try_link "$LINENO"
-then :
+if ac_fn_c_try_link "$LINENO"; then :
   pythonexists=yes
-else $as_nop
+else
   pythonexists=no
 fi
-rm -f core conftest.err conftest.$ac_objext conftest.beam \
+rm -f core conftest.err conftest.$ac_objext \
     conftest$ac_exeext conftest.$ac_ext
 
-        { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $pythonexists" >&5
-printf "%s\n" "$pythonexists" >&6; }
+        { $as_echo "$as_me:${as_lineno-$LINENO}: result: $pythonexists" >&5
+$as_echo "$pythonexists" >&6; }
 
         if test ! "$pythonexists" = "yes"; then
            as_fn_error $? "
@@ -18942,7 +17639,7 @@ ac_compiler_gnu=$ac_cv_c_compiler_gnu
 
       # Have Python
 
-printf "%s\n" "#define HAVE_PYTHON 1" >>confdefs.h
+$as_echo "#define HAVE_PYTHON 1" >>confdefs.h
 
       if test x_$ub_with_pythonmod != x_no; then
         if test -n "$LIBS"; then
@@ -18969,10 +17666,10 @@ printf "%s\n" "#define HAVE_PYTHON 1" >>confdefs.h
       fi
       ub_have_python=yes
       if test -n "$PKG_CONFIG" && \
-    { { printf "%s\n" "$as_me:${as_lineno-$LINENO}: \$PKG_CONFIG --exists --print-errors \"\"python\${PY_MAJOR_VERSION}\"\""; } >&5
+    { { $as_echo "$as_me:${as_lineno-$LINENO}: \$PKG_CONFIG --exists --print-errors \"\"python\${PY_MAJOR_VERSION}\"\""; } >&5
   ($PKG_CONFIG --exists --print-errors ""python${PY_MAJOR_VERSION}"") 2>&5
   ac_status=$?
-  printf "%s\n" "$as_me:${as_lineno-$LINENO}: \$? = $ac_status" >&5
+  $as_echo "$as_me:${as_lineno-$LINENO}: \$? = $ac_status" >&5
   test $ac_status = 0; }; then
   PC_PY_DEPENDENCY="python${PY_MAJOR_VERSION}"
 else
@@ -18983,8 +17680,7 @@ fi
       # Check for SWIG
       ub_have_swig=no
       # Check whether --enable-swig-version-check was given.
-if test ${enable_swig_version_check+y}
-then :
+if test "${enable_swig_version_check+set}" = set; then :
   enableval=$enable_swig_version_check;
 fi
 
@@ -18992,12 +17688,11 @@ fi
 
         # Extract the first word of "swig", so it can be a program name with args.
 set dummy swig; ac_word=$2
-{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for $ac_word" >&5
-printf %s "checking for $ac_word... " >&6; }
-if test ${ac_cv_path_SWIG+y}
-then :
-  printf %s "(cached) " >&6
-else $as_nop
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for $ac_word" >&5
+$as_echo_n "checking for $ac_word... " >&6; }
+if ${ac_cv_path_SWIG+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
   case $SWIG in
   [\\/]* | ?:[\\/]*)
   ac_cv_path_SWIG="$SWIG" # Let the user override the test with a path.
@@ -19007,15 +17702,11 @@ else $as_nop
 for as_dir in $PATH
 do
   IFS=$as_save_IFS
-  case $as_dir in #(((
-    '') as_dir=./ ;;
-    */) ;;
-    *) as_dir=$as_dir/ ;;
-  esac
+  test -z "$as_dir" && as_dir=.
     for ac_exec_ext in '' $ac_executable_extensions; do
-  if as_fn_executable_p "$as_dir$ac_word$ac_exec_ext"; then
-    ac_cv_path_SWIG="$as_dir$ac_word$ac_exec_ext"
-    printf "%s\n" "$as_me:${as_lineno-$LINENO}: found $as_dir$ac_word$ac_exec_ext" >&5
+  if as_fn_executable_p "$as_dir/$ac_word$ac_exec_ext"; then
+    ac_cv_path_SWIG="$as_dir/$ac_word$ac_exec_ext"
+    $as_echo "$as_me:${as_lineno-$LINENO}: found $as_dir/$ac_word$ac_exec_ext" >&5
     break 2
   fi
 done
@@ -19027,24 +17718,24 @@ esac
 fi
 SWIG=$ac_cv_path_SWIG
 if test -n "$SWIG"; then
-  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $SWIG" >&5
-printf "%s\n" "$SWIG" >&6; }
+  { $as_echo "$as_me:${as_lineno-$LINENO}: result: $SWIG" >&5
+$as_echo "$SWIG" >&6; }
 else
-  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: no" >&5
-printf "%s\n" "no" >&6; }
+  { $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
+$as_echo "no" >&6; }
 fi
 
 
         if test -z "$SWIG" ; then
-                { printf "%s\n" "$as_me:${as_lineno-$LINENO}: WARNING: cannot find 'swig' program. You should look at http://www.swig.org" >&5
-printf "%s\n" "$as_me: WARNING: cannot find 'swig' program. You should look at http://www.swig.org" >&2;}
+                { $as_echo "$as_me:${as_lineno-$LINENO}: WARNING: cannot find 'swig' program. You should look at http://www.swig.org" >&5
+$as_echo "$as_me: WARNING: cannot find 'swig' program. You should look at http://www.swig.org" >&2;}
                 SWIG='echo "Error: SWIG is not installed. You should look at http://www.swig.org" ; false'
         elif test -n "2.0.1" ; then
-                { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for SWIG version" >&5
-printf %s "checking for SWIG version... " >&6; }
+                { $as_echo "$as_me:${as_lineno-$LINENO}: checking for SWIG version" >&5
+$as_echo_n "checking for SWIG version... " >&6; }
                 swig_version=`$SWIG -version 2>&1 | grep 'SWIG Version' | sed 's/.*\([0-9][0-9]*\.[0-9][0-9]*\.[0-9][0-9]*\).*/\1/g'`
-                { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $swig_version" >&5
-printf "%s\n" "$swig_version" >&6; }
+                { $as_echo "$as_me:${as_lineno-$LINENO}: result: $swig_version" >&5
+$as_echo "$swig_version" >&6; }
                 if test -n "$swig_version" ; then
                         # Calculate the required version number components
                         required=2.0.1
@@ -19092,19 +17783,19 @@ printf "%s\n" "$swig_version" >&6; }
 				badversion=1
 			fi
 			if test $badversion -eq 1 ; then
-                                { printf "%s\n" "$as_me:${as_lineno-$LINENO}: WARNING: SWIG version >= 2.0.1 is required.  You have $swig_version.  You should look at http://www.swig.org" >&5
-printf "%s\n" "$as_me: WARNING: SWIG version >= 2.0.1 is required.  You have $swig_version.  You should look at http://www.swig.org" >&2;}
+                                { $as_echo "$as_me:${as_lineno-$LINENO}: WARNING: SWIG version >= 2.0.1 is required.  You have $swig_version.  You should look at http://www.swig.org" >&5
+$as_echo "$as_me: WARNING: SWIG version >= 2.0.1 is required.  You have $swig_version.  You should look at http://www.swig.org" >&2;}
                                 SWIG='echo "Error: SWIG version >= 2.0.1 is required.  You have '"$swig_version"'.  You should look at http://www.swig.org" ; false'
                         else
-                                { printf "%s\n" "$as_me:${as_lineno-$LINENO}: SWIG executable is '$SWIG'" >&5
-printf "%s\n" "$as_me: SWIG executable is '$SWIG'" >&6;}
+                                { $as_echo "$as_me:${as_lineno-$LINENO}: SWIG executable is '$SWIG'" >&5
+$as_echo "$as_me: SWIG executable is '$SWIG'" >&6;}
                                 SWIG_LIB=`$SWIG -swiglib`
-                                { printf "%s\n" "$as_me:${as_lineno-$LINENO}: SWIG library directory is '$SWIG_LIB'" >&5
-printf "%s\n" "$as_me: SWIG library directory is '$SWIG_LIB'" >&6;}
+                                { $as_echo "$as_me:${as_lineno-$LINENO}: SWIG library directory is '$SWIG_LIB'" >&5
+$as_echo "$as_me: SWIG library directory is '$SWIG_LIB'" >&6;}
                         fi
                 else
-                        { printf "%s\n" "$as_me:${as_lineno-$LINENO}: WARNING: cannot determine SWIG version" >&5
-printf "%s\n" "$as_me: WARNING: cannot determine SWIG version" >&2;}
+                        { $as_echo "$as_me:${as_lineno-$LINENO}: WARNING: cannot determine SWIG version" >&5
+$as_echo "$as_me: WARNING: cannot determine SWIG version" >&2;}
                         SWIG='echo "Error: Cannot determine SWIG version.  You should look at http://www.swig.org" ; false'
                 fi
         fi
@@ -19114,12 +17805,11 @@ printf "%s\n" "$as_me: WARNING: cannot determine SWIG version" >&2;}
 
         # Extract the first word of "swig", so it can be a program name with args.
 set dummy swig; ac_word=$2
-{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for $ac_word" >&5
-printf %s "checking for $ac_word... " >&6; }
-if test ${ac_cv_path_SWIG+y}
-then :
-  printf %s "(cached) " >&6
-else $as_nop
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for $ac_word" >&5
+$as_echo_n "checking for $ac_word... " >&6; }
+if ${ac_cv_path_SWIG+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
   case $SWIG in
   [\\/]* | ?:[\\/]*)
   ac_cv_path_SWIG="$SWIG" # Let the user override the test with a path.
@@ -19129,15 +17819,11 @@ else $as_nop
 for as_dir in $PATH
 do
   IFS=$as_save_IFS
-  case $as_dir in #(((
-    '') as_dir=./ ;;
-    */) ;;
-    *) as_dir=$as_dir/ ;;
-  esac
+  test -z "$as_dir" && as_dir=.
     for ac_exec_ext in '' $ac_executable_extensions; do
-  if as_fn_executable_p "$as_dir$ac_word$ac_exec_ext"; then
-    ac_cv_path_SWIG="$as_dir$ac_word$ac_exec_ext"
-    printf "%s\n" "$as_me:${as_lineno-$LINENO}: found $as_dir$ac_word$ac_exec_ext" >&5
+  if as_fn_executable_p "$as_dir/$ac_word$ac_exec_ext"; then
+    ac_cv_path_SWIG="$as_dir/$ac_word$ac_exec_ext"
+    $as_echo "$as_me:${as_lineno-$LINENO}: found $as_dir/$ac_word$ac_exec_ext" >&5
     break 2
   fi
 done
@@ -19149,24 +17835,24 @@ esac
 fi
 SWIG=$ac_cv_path_SWIG
 if test -n "$SWIG"; then
-  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $SWIG" >&5
-printf "%s\n" "$SWIG" >&6; }
+  { $as_echo "$as_me:${as_lineno-$LINENO}: result: $SWIG" >&5
+$as_echo "$SWIG" >&6; }
 else
-  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: no" >&5
-printf "%s\n" "no" >&6; }
+  { $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
+$as_echo "no" >&6; }
 fi
 
 
         if test -z "$SWIG" ; then
-                { printf "%s\n" "$as_me:${as_lineno-$LINENO}: WARNING: cannot find 'swig' program. You should look at http://www.swig.org" >&5
-printf "%s\n" "$as_me: WARNING: cannot find 'swig' program. You should look at http://www.swig.org" >&2;}
+                { $as_echo "$as_me:${as_lineno-$LINENO}: WARNING: cannot find 'swig' program. You should look at http://www.swig.org" >&5
+$as_echo "$as_me: WARNING: cannot find 'swig' program. You should look at http://www.swig.org" >&2;}
                 SWIG='echo "Error: SWIG is not installed. You should look at http://www.swig.org" ; false'
         elif test -n "" ; then
-                { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for SWIG version" >&5
-printf %s "checking for SWIG version... " >&6; }
+                { $as_echo "$as_me:${as_lineno-$LINENO}: checking for SWIG version" >&5
+$as_echo_n "checking for SWIG version... " >&6; }
                 swig_version=`$SWIG -version 2>&1 | grep 'SWIG Version' | sed 's/.*\([0-9][0-9]*\.[0-9][0-9]*\.[0-9][0-9]*\).*/\1/g'`
-                { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $swig_version" >&5
-printf "%s\n" "$swig_version" >&6; }
+                { $as_echo "$as_me:${as_lineno-$LINENO}: result: $swig_version" >&5
+$as_echo "$swig_version" >&6; }
                 if test -n "$swig_version" ; then
                         # Calculate the required version number components
                         required=
@@ -19214,43 +17900,43 @@ printf "%s\n" "$swig_version" >&6; }
 				badversion=1
 			fi
 			if test $badversion -eq 1 ; then
-                                { printf "%s\n" "$as_me:${as_lineno-$LINENO}: WARNING: SWIG version >=  is required.  You have $swig_version.  You should look at http://www.swig.org" >&5
-printf "%s\n" "$as_me: WARNING: SWIG version >=  is required.  You have $swig_version.  You should look at http://www.swig.org" >&2;}
+                                { $as_echo "$as_me:${as_lineno-$LINENO}: WARNING: SWIG version >=  is required.  You have $swig_version.  You should look at http://www.swig.org" >&5
+$as_echo "$as_me: WARNING: SWIG version >=  is required.  You have $swig_version.  You should look at http://www.swig.org" >&2;}
                                 SWIG='echo "Error: SWIG version >=  is required.  You have '"$swig_version"'.  You should look at http://www.swig.org" ; false'
                         else
-                                { printf "%s\n" "$as_me:${as_lineno-$LINENO}: SWIG executable is '$SWIG'" >&5
-printf "%s\n" "$as_me: SWIG executable is '$SWIG'" >&6;}
+                                { $as_echo "$as_me:${as_lineno-$LINENO}: SWIG executable is '$SWIG'" >&5
+$as_echo "$as_me: SWIG executable is '$SWIG'" >&6;}
                                 SWIG_LIB=`$SWIG -swiglib`
-                                { printf "%s\n" "$as_me:${as_lineno-$LINENO}: SWIG library directory is '$SWIG_LIB'" >&5
-printf "%s\n" "$as_me: SWIG library directory is '$SWIG_LIB'" >&6;}
+                                { $as_echo "$as_me:${as_lineno-$LINENO}: SWIG library directory is '$SWIG_LIB'" >&5
+$as_echo "$as_me: SWIG library directory is '$SWIG_LIB'" >&6;}
                         fi
                 else
-                        { printf "%s\n" "$as_me:${as_lineno-$LINENO}: WARNING: cannot determine SWIG version" >&5
-printf "%s\n" "$as_me: WARNING: cannot determine SWIG version" >&2;}
+                        { $as_echo "$as_me:${as_lineno-$LINENO}: WARNING: cannot determine SWIG version" >&5
+$as_echo "$as_me: WARNING: cannot determine SWIG version" >&2;}
                         SWIG='echo "Error: Cannot determine SWIG version.  You should look at http://www.swig.org" ; false'
                 fi
         fi
 
 
       fi
-      { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking SWIG" >&5
-printf %s "checking SWIG... " >&6; }
+      { $as_echo "$as_me:${as_lineno-$LINENO}: checking SWIG" >&5
+$as_echo_n "checking SWIG... " >&6; }
       if test ! -x "$SWIG"; then
          as_fn_error $? "failed to find swig tool, install it, or do not build Python module and PyUnbound" "$LINENO" 5
       else
 
-printf "%s\n" "#define HAVE_SWIG 1" >>confdefs.h
+$as_echo "#define HAVE_SWIG 1" >>confdefs.h
 
          swig="$SWIG"
 
-         { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: present" >&5
-printf "%s\n" "present" >&6; }
+         { $as_echo "$as_me:${as_lineno-$LINENO}: result: present" >&5
+$as_echo "present" >&6; }
 
          # If have Python & SWIG
          # Declare PythonMod
          if test x_$ub_with_pythonmod != x_no; then
 
-printf "%s\n" "#define WITH_PYTHONMODULE 1" >>confdefs.h
+$as_echo "#define WITH_PYTHONMODULE 1" >>confdefs.h
 
             WITH_PYTHONMODULE=yes
 
@@ -19267,7 +17953,7 @@ printf "%s\n" "#define WITH_PYTHONMODULE 1" >>confdefs.h
          # Declare PyUnbound
          if test x_$ub_with_pyunbound != x_no; then
 
-printf "%s\n" "#define WITH_PYUNBOUND 1" >>confdefs.h
+$as_echo "#define WITH_PYUNBOUND 1" >>confdefs.h
 
             WITH_PYUNBOUND=yes
 
@@ -19282,8 +17968,8 @@ printf "%s\n" "#define WITH_PYUNBOUND 1" >>confdefs.h
          fi
       fi
    else
-      { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: *** Python libraries not found, won't build PythonMod or PyUnbound ***" >&5
-printf "%s\n" "*** Python libraries not found, won't build PythonMod or PyUnbound ***" >&6; }
+      { $as_echo "$as_me:${as_lineno-$LINENO}: result: *** Python libraries not found, won't build PythonMod or PyUnbound ***" >&5
+$as_echo "*** Python libraries not found, won't build PythonMod or PyUnbound ***" >&6; }
       ub_with_pyunbound=no
       ub_with_pythonmod=no
    fi
@@ -19308,12 +17994,11 @@ CONFIG_DATE=`date +%Y%m%d`
 USE_NSS="no"
 
 # Check whether --with-nss was given.
-if test ${with_nss+y}
-then :
+if test "${with_nss+set}" = set; then :
   withval=$with_nss;
 	USE_NSS="yes"
 
-printf "%s\n" "#define HAVE_NSS 1" >>confdefs.h
+$as_echo "#define HAVE_NSS 1" >>confdefs.h
 
 	if test "$withval" != "" -a "$withval" != "yes"; then
 		CPPFLAGS="$CPPFLAGS -I$withval/include/nss3"
@@ -19343,20 +18028,24 @@ fi
 USE_NETTLE="no"
 
 # Check whether --with-nettle was given.
-if test ${with_nettle+y}
-then :
+if test "${with_nettle+set}" = set; then :
   withval=$with_nettle;
 	USE_NETTLE="yes"
 
-printf "%s\n" "#define HAVE_NETTLE 1" >>confdefs.h
+$as_echo "#define HAVE_NETTLE 1" >>confdefs.h
 
-	ac_fn_c_check_header_compile "$LINENO" "nettle/dsa-compat.h" "ac_cv_header_nettle_dsa_compat_h" "$ac_includes_default
+	for ac_header in nettle/dsa-compat.h
+do :
+  ac_fn_c_check_header_compile "$LINENO" "nettle/dsa-compat.h" "ac_cv_header_nettle_dsa_compat_h" "$ac_includes_default
 "
-if test "x$ac_cv_header_nettle_dsa_compat_h" = xyes
-then :
-  printf "%s\n" "#define HAVE_NETTLE_DSA_COMPAT_H 1" >>confdefs.h
+if test "x$ac_cv_header_nettle_dsa_compat_h" = xyes; then :
+  cat >>confdefs.h <<_ACEOF
+#define HAVE_NETTLE_DSA_COMPAT_H 1
+_ACEOF
 
 fi
+
+done
 
 	if test "$withval" != "" -a "$withval" != "yes"; then
 		CPPFLAGS="$CPPFLAGS -I$withval/include/nettle"
@@ -19385,11 +18074,10 @@ if test $USE_NSS = "no" -a $USE_NETTLE = "no"; then
 
 
 # Check whether --with-ssl was given.
-if test ${with_ssl+y}
-then :
+if test "${with_ssl+set}" = set; then :
   withval=$with_ssl;
 
-else $as_nop
+else
 
             withval="yes"
 
@@ -19401,8 +18089,8 @@ fi
 
     withval=$withval
     if test x_$withval != x_no; then
-        { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for SSL" >&5
-printf %s "checking for SSL... " >&6; }
+        { $as_echo "$as_me:${as_lineno-$LINENO}: checking for SSL" >&5
+$as_echo_n "checking for SSL... " >&6; }
 	if test -n "$withval"; then
 										if test ! -f "$withval/include/openssl/ssl.h" -a -f "$withval/openssl/ssl.h"; then
 			ssldir="$withval"
@@ -19441,10 +18129,12 @@ printf %s "checking for SSL... " >&6; }
         if test x_$found_ssl != x_yes; then
             as_fn_error $? "Cannot find the SSL libraries in $withval" "$LINENO" 5
         else
-            { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: found in $ssldir" >&5
-printf "%s\n" "found in $ssldir" >&6; }
+            { $as_echo "$as_me:${as_lineno-$LINENO}: result: found in $ssldir" >&5
+$as_echo "found in $ssldir" >&6; }
 
-printf "%s\n" "#define HAVE_SSL /**/" >>confdefs.h
+cat >>confdefs.h <<_ACEOF
+#define HAVE_SSL /**/
+_ACEOF
 
             HAVE_SSL=yes
 	                if test "$ssldir" != "/usr"; then
@@ -19461,15 +18151,15 @@ printf "%s\n" "#define HAVE_SSL /**/" >>confdefs.h
 
 	    fi
 
-            { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for EVP_sha256 in -lcrypto" >&5
-printf %s "checking for EVP_sha256 in -lcrypto... " >&6; }
+            { $as_echo "$as_me:${as_lineno-$LINENO}: checking for EVP_sha256 in -lcrypto" >&5
+$as_echo_n "checking for EVP_sha256 in -lcrypto... " >&6; }
             LIBS="$LIBS -lcrypto"
             LIBSSL_LIBS="$LIBSSL_LIBS -lcrypto"
             cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 /* end confdefs.h.  */
 
 int
-main (void)
+main ()
 {
 
                 int EVP_sha256(void);
@@ -19479,31 +18169,30 @@ main (void)
   return 0;
 }
 _ACEOF
-if ac_fn_c_try_link "$LINENO"
-then :
+if ac_fn_c_try_link "$LINENO"; then :
 
-                { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: yes" >&5
-printf "%s\n" "yes" >&6; }
+                { $as_echo "$as_me:${as_lineno-$LINENO}: result: yes" >&5
+$as_echo "yes" >&6; }
 
-printf "%s\n" "#define HAVE_EVP_SHA256 1" >>confdefs.h
+$as_echo "#define HAVE_EVP_SHA256 1" >>confdefs.h
 
 
-else $as_nop
+else
 
-                { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: no" >&5
-printf "%s\n" "no" >&6; }
+                { $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
+$as_echo "no" >&6; }
                 # check if -lwsock32 or -lgdi32 are needed.
                 BAKLIBS="$LIBS"
                 BAKSSLLIBS="$LIBSSL_LIBS"
 		LIBS="$LIBS -lgdi32 -lws2_32"
 		LIBSSL_LIBS="$LIBSSL_LIBS -lgdi32 -lws2_32"
-                { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking if -lcrypto needs -lgdi32" >&5
-printf %s "checking if -lcrypto needs -lgdi32... " >&6; }
+                { $as_echo "$as_me:${as_lineno-$LINENO}: checking if -lcrypto needs -lgdi32" >&5
+$as_echo_n "checking if -lcrypto needs -lgdi32... " >&6; }
                 cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 /* end confdefs.h.  */
 
 int
-main (void)
+main ()
 {
 
                     int EVP_sha256(void);
@@ -19513,30 +18202,29 @@ main (void)
   return 0;
 }
 _ACEOF
-if ac_fn_c_try_link "$LINENO"
-then :
+if ac_fn_c_try_link "$LINENO"; then :
 
 
-printf "%s\n" "#define HAVE_EVP_SHA256 1" >>confdefs.h
+$as_echo "#define HAVE_EVP_SHA256 1" >>confdefs.h
 
-                    { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: yes" >&5
-printf "%s\n" "yes" >&6; }
+                    { $as_echo "$as_me:${as_lineno-$LINENO}: result: yes" >&5
+$as_echo "yes" >&6; }
 
-else $as_nop
+else
 
-                    { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: no" >&5
-printf "%s\n" "no" >&6; }
+                    { $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
+$as_echo "no" >&6; }
                     LIBS="$BAKLIBS"
                     LIBSSL_LIBS="$BAKSSLLIBS"
                     LIBS="$LIBS -ldl"
                     LIBSSL_LIBS="$LIBSSL_LIBS -ldl"
-                    { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking if -lcrypto needs -ldl" >&5
-printf %s "checking if -lcrypto needs -ldl... " >&6; }
+                    { $as_echo "$as_me:${as_lineno-$LINENO}: checking if -lcrypto needs -ldl" >&5
+$as_echo_n "checking if -lcrypto needs -ldl... " >&6; }
                     cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 /* end confdefs.h.  */
 
 int
-main (void)
+main ()
 {
 
                         int EVP_sha256(void);
@@ -19546,30 +18234,29 @@ main (void)
   return 0;
 }
 _ACEOF
-if ac_fn_c_try_link "$LINENO"
-then :
+if ac_fn_c_try_link "$LINENO"; then :
 
 
-printf "%s\n" "#define HAVE_EVP_SHA256 1" >>confdefs.h
+$as_echo "#define HAVE_EVP_SHA256 1" >>confdefs.h
 
-                        { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: yes" >&5
-printf "%s\n" "yes" >&6; }
+                        { $as_echo "$as_me:${as_lineno-$LINENO}: result: yes" >&5
+$as_echo "yes" >&6; }
 
-else $as_nop
+else
 
-                        { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: no" >&5
-printf "%s\n" "no" >&6; }
+                        { $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
+$as_echo "no" >&6; }
                         LIBS="$BAKLIBS"
                         LIBSSL_LIBS="$BAKSSLLIBS"
                         LIBS="$LIBS -ldl -pthread"
                         LIBSSL_LIBS="$LIBSSL_LIBS -ldl -pthread"
-                        { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking if -lcrypto needs -ldl -pthread" >&5
-printf %s "checking if -lcrypto needs -ldl -pthread... " >&6; }
+                        { $as_echo "$as_me:${as_lineno-$LINENO}: checking if -lcrypto needs -ldl -pthread" >&5
+$as_echo_n "checking if -lcrypto needs -ldl -pthread... " >&6; }
                         cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 /* end confdefs.h.  */
 
 int
-main (void)
+main ()
 {
 
                             int EVP_sha256(void);
@@ -19579,63 +18266,77 @@ main (void)
   return 0;
 }
 _ACEOF
-if ac_fn_c_try_link "$LINENO"
-then :
+if ac_fn_c_try_link "$LINENO"; then :
 
 
-printf "%s\n" "#define HAVE_EVP_SHA256 1" >>confdefs.h
+$as_echo "#define HAVE_EVP_SHA256 1" >>confdefs.h
 
-                            { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: yes" >&5
-printf "%s\n" "yes" >&6; }
+                            { $as_echo "$as_me:${as_lineno-$LINENO}: result: yes" >&5
+$as_echo "yes" >&6; }
 
-else $as_nop
+else
 
-                            { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: no" >&5
-printf "%s\n" "no" >&6; }
+                            { $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
+$as_echo "no" >&6; }
                             as_fn_error $? "OpenSSL found in $ssldir, but version 0.9.7 or higher is required" "$LINENO" 5
 
 fi
-rm -f core conftest.err conftest.$ac_objext conftest.beam \
+rm -f core conftest.err conftest.$ac_objext \
     conftest$ac_exeext conftest.$ac_ext
 
 fi
-rm -f core conftest.err conftest.$ac_objext conftest.beam \
+rm -f core conftest.err conftest.$ac_objext \
     conftest$ac_exeext conftest.$ac_ext
 
 fi
-rm -f core conftest.err conftest.$ac_objext conftest.beam \
+rm -f core conftest.err conftest.$ac_objext \
     conftest$ac_exeext conftest.$ac_ext
 
 fi
-rm -f core conftest.err conftest.$ac_objext conftest.beam \
+rm -f core conftest.err conftest.$ac_objext \
     conftest$ac_exeext conftest.$ac_ext
         fi
 
 
     fi
-ac_fn_c_check_header_compile "$LINENO" "openssl/ssl.h" "ac_cv_header_openssl_ssl_h" "$ac_includes_default
+for ac_header in openssl/ssl.h
+do :
+  ac_fn_c_check_header_compile "$LINENO" "openssl/ssl.h" "ac_cv_header_openssl_ssl_h" "$ac_includes_default
 "
-if test "x$ac_cv_header_openssl_ssl_h" = xyes
-then :
-  printf "%s\n" "#define HAVE_OPENSSL_SSL_H 1" >>confdefs.h
+if test "x$ac_cv_header_openssl_ssl_h" = xyes; then :
+  cat >>confdefs.h <<_ACEOF
+#define HAVE_OPENSSL_SSL_H 1
+_ACEOF
 
 fi
 
-ac_fn_c_check_header_compile "$LINENO" "openssl/err.h" "ac_cv_header_openssl_err_h" "$ac_includes_default
+done
+
+for ac_header in openssl/err.h
+do :
+  ac_fn_c_check_header_compile "$LINENO" "openssl/err.h" "ac_cv_header_openssl_err_h" "$ac_includes_default
 "
-if test "x$ac_cv_header_openssl_err_h" = xyes
-then :
-  printf "%s\n" "#define HAVE_OPENSSL_ERR_H 1" >>confdefs.h
+if test "x$ac_cv_header_openssl_err_h" = xyes; then :
+  cat >>confdefs.h <<_ACEOF
+#define HAVE_OPENSSL_ERR_H 1
+_ACEOF
 
 fi
 
-ac_fn_c_check_header_compile "$LINENO" "openssl/rand.h" "ac_cv_header_openssl_rand_h" "$ac_includes_default
+done
+
+for ac_header in openssl/rand.h
+do :
+  ac_fn_c_check_header_compile "$LINENO" "openssl/rand.h" "ac_cv_header_openssl_rand_h" "$ac_includes_default
 "
-if test "x$ac_cv_header_openssl_rand_h" = xyes
-then :
-  printf "%s\n" "#define HAVE_OPENSSL_RAND_H 1" >>confdefs.h
+if test "x$ac_cv_header_openssl_rand_h" = xyes; then :
+  cat >>confdefs.h <<_ACEOF
+#define HAVE_OPENSSL_RAND_H 1
+_ACEOF
 
 fi
+
+done
 
 
 
@@ -19643,41 +18344,42 @@ fi
 # check if libssl needs libdl
 BAKLIBS="$LIBS"
 LIBS="-lssl $LIBS"
-{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking if libssl needs libdl" >&5
-printf %s "checking if libssl needs libdl... " >&6; }
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking if libssl needs libdl" >&5
+$as_echo_n "checking if libssl needs libdl... " >&6; }
 cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 /* end confdefs.h.  */
 
 /* Override any GCC internal prototype to avoid an error.
    Use char because int might match the return type of a GCC
    builtin and then its argument prototype would still apply.  */
+#ifdef __cplusplus
+extern "C"
+#endif
 char SSL_CTX_new ();
 int
-main (void)
+main ()
 {
 return SSL_CTX_new ();
   ;
   return 0;
 }
 _ACEOF
-if ac_fn_c_try_link "$LINENO"
-then :
+if ac_fn_c_try_link "$LINENO"; then :
 
-	{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: no" >&5
-printf "%s\n" "no" >&6; }
+	{ $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
+$as_echo "no" >&6; }
 	LIBS="$BAKLIBS"
 
-else $as_nop
+else
 
-	{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: yes" >&5
-printf "%s\n" "yes" >&6; }
+	{ $as_echo "$as_me:${as_lineno-$LINENO}: result: yes" >&5
+$as_echo "yes" >&6; }
 	LIBS="$BAKLIBS"
-	{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for library containing dlopen" >&5
-printf %s "checking for library containing dlopen... " >&6; }
-if test ${ac_cv_search_dlopen+y}
-then :
-  printf %s "(cached) " >&6
-else $as_nop
+	{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for library containing dlopen" >&5
+$as_echo_n "checking for library containing dlopen... " >&6; }
+if ${ac_cv_search_dlopen+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
   ac_func_search_save_LIBS=$LIBS
 cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 /* end confdefs.h.  */
@@ -19685,55 +18387,53 @@ cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 /* Override any GCC internal prototype to avoid an error.
    Use char because int might match the return type of a GCC
    builtin and then its argument prototype would still apply.  */
+#ifdef __cplusplus
+extern "C"
+#endif
 char dlopen ();
 int
-main (void)
+main ()
 {
 return dlopen ();
   ;
   return 0;
 }
 _ACEOF
-for ac_lib in '' dl
-do
+for ac_lib in '' dl; do
   if test -z "$ac_lib"; then
     ac_res="none required"
   else
     ac_res=-l$ac_lib
     LIBS="-l$ac_lib  $ac_func_search_save_LIBS"
   fi
-  if ac_fn_c_try_link "$LINENO"
-then :
+  if ac_fn_c_try_link "$LINENO"; then :
   ac_cv_search_dlopen=$ac_res
 fi
-rm -f core conftest.err conftest.$ac_objext conftest.beam \
+rm -f core conftest.err conftest.$ac_objext \
     conftest$ac_exeext
-  if test ${ac_cv_search_dlopen+y}
-then :
+  if ${ac_cv_search_dlopen+:} false; then :
   break
 fi
 done
-if test ${ac_cv_search_dlopen+y}
-then :
+if ${ac_cv_search_dlopen+:} false; then :
 
-else $as_nop
+else
   ac_cv_search_dlopen=no
 fi
 rm conftest.$ac_ext
 LIBS=$ac_func_search_save_LIBS
 fi
-{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $ac_cv_search_dlopen" >&5
-printf "%s\n" "$ac_cv_search_dlopen" >&6; }
+{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_search_dlopen" >&5
+$as_echo "$ac_cv_search_dlopen" >&6; }
 ac_res=$ac_cv_search_dlopen
-if test "$ac_res" != no
-then :
+if test "$ac_res" != no; then :
   test "$ac_res" = "none required" || LIBS="$ac_res $LIBS"
 
 fi
 
 
 fi
-rm -f core conftest.err conftest.$ac_objext conftest.beam \
+rm -f core conftest.err conftest.$ac_objext \
     conftest$ac_exeext conftest.$ac_ext
 SSLLIB="-lssl"
 
@@ -19743,13 +18443,13 @@ PC_CRYPTO_DEPENDENCY=""
 # check if -lcrypt32 is needed because CAPIENG needs that. (on windows)
 BAKLIBS="$LIBS"
 LIBS="-lssl $LIBS"
-{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking if libssl needs -lcrypt32" >&5
-printf %s "checking if libssl needs -lcrypt32... " >&6; }
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking if libssl needs -lcrypt32" >&5
+$as_echo_n "checking if libssl needs -lcrypt32... " >&6; }
 cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 /* end confdefs.h.  */
 
 int
-main (void)
+main ()
 {
 
 	int EVP_sha256(void);
@@ -19759,427 +18459,123 @@ main (void)
   return 0;
 }
 _ACEOF
-if ac_fn_c_try_link "$LINENO"
-then :
+if ac_fn_c_try_link "$LINENO"; then :
 
-	{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: no" >&5
-printf "%s\n" "no" >&6; }
+	{ $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
+$as_echo "no" >&6; }
 	LIBS="$BAKLIBS"
 
-else $as_nop
+else
 
-	{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: yes" >&5
-printf "%s\n" "yes" >&6; }
+	{ $as_echo "$as_me:${as_lineno-$LINENO}: result: yes" >&5
+$as_echo "yes" >&6; }
 	LIBS="$BAKLIBS"
 	LIBS="$LIBS -lcrypt32"
 
 fi
-rm -f core conftest.err conftest.$ac_objext conftest.beam \
+rm -f core conftest.err conftest.$ac_objext \
     conftest$ac_exeext conftest.$ac_ext
 
-{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for LibreSSL" >&5
-printf %s "checking for LibreSSL... " >&6; }
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for LibreSSL" >&5
+$as_echo_n "checking for LibreSSL... " >&6; }
 if grep VERSION_TEXT $ssldir_include/openssl/opensslv.h | grep "LibreSSL" >/dev/null; then
-	{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: yes" >&5
-printf "%s\n" "yes" >&6; }
+	{ $as_echo "$as_me:${as_lineno-$LINENO}: result: yes" >&5
+$as_echo "yes" >&6; }
 
-printf "%s\n" "#define HAVE_LIBRESSL 1" >>confdefs.h
+$as_echo "#define HAVE_LIBRESSL 1" >>confdefs.h
 
 	# libressl provides these compat functions, but they may also be
 	# declared by the OS in libc.  See if they have been declared.
-	{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for $CC options needed to detect all undeclared functions" >&5
-printf %s "checking for $CC options needed to detect all undeclared functions... " >&6; }
-if test ${ac_cv_c_undeclared_builtin_options+y}
-then :
-  printf %s "(cached) " >&6
-else $as_nop
-  ac_save_CFLAGS=$CFLAGS
-   ac_cv_c_undeclared_builtin_options='cannot detect'
-   for ac_arg in '' -fno-builtin; do
-     CFLAGS="$ac_save_CFLAGS $ac_arg"
-     # This test program should *not* compile successfully.
-     cat confdefs.h - <<_ACEOF >conftest.$ac_ext
-/* end confdefs.h.  */
+	ac_fn_c_check_decl "$LINENO" "strlcpy" "ac_cv_have_decl_strlcpy" "$ac_includes_default"
+if test "x$ac_cv_have_decl_strlcpy" = xyes; then :
+  ac_have_decl=1
+else
+  ac_have_decl=0
+fi
 
-int
-main (void)
-{
-(void) strchr;
-  ;
-  return 0;
-}
+cat >>confdefs.h <<_ACEOF
+#define HAVE_DECL_STRLCPY $ac_have_decl
 _ACEOF
-if ac_fn_c_try_compile "$LINENO"
-then :
+ac_fn_c_check_decl "$LINENO" "strlcat" "ac_cv_have_decl_strlcat" "$ac_includes_default"
+if test "x$ac_cv_have_decl_strlcat" = xyes; then :
+  ac_have_decl=1
+else
+  ac_have_decl=0
+fi
 
-else $as_nop
-  # This test program should compile successfully.
-        # No library function is consistently available on
-        # freestanding implementations, so test against a dummy
-        # declaration.  Include always-available headers on the
-        # off chance that they somehow elicit warnings.
-        cat confdefs.h - <<_ACEOF >conftest.$ac_ext
-/* end confdefs.h.  */
-#include <float.h>
-#include <limits.h>
-#include <stdarg.h>
-#include <stddef.h>
-extern void ac_decl (int, char *);
-
-int
-main (void)
-{
-(void) ac_decl (0, (char *) 0);
-  (void) ac_decl;
-
-  ;
-  return 0;
-}
+cat >>confdefs.h <<_ACEOF
+#define HAVE_DECL_STRLCAT $ac_have_decl
 _ACEOF
-if ac_fn_c_try_compile "$LINENO"
-then :
-  if test x"$ac_arg" = x
-then :
-  ac_cv_c_undeclared_builtin_options='none needed'
-else $as_nop
-  ac_cv_c_undeclared_builtin_options=$ac_arg
+ac_fn_c_check_decl "$LINENO" "arc4random" "ac_cv_have_decl_arc4random" "$ac_includes_default"
+if test "x$ac_cv_have_decl_arc4random" = xyes; then :
+  ac_have_decl=1
+else
+  ac_have_decl=0
 fi
-          break
-fi
-rm -f core conftest.err conftest.$ac_objext conftest.beam conftest.$ac_ext
-fi
-rm -f core conftest.err conftest.$ac_objext conftest.beam conftest.$ac_ext
-    done
-    CFLAGS=$ac_save_CFLAGS
 
+cat >>confdefs.h <<_ACEOF
+#define HAVE_DECL_ARC4RANDOM $ac_have_decl
+_ACEOF
+ac_fn_c_check_decl "$LINENO" "arc4random_uniform" "ac_cv_have_decl_arc4random_uniform" "$ac_includes_default"
+if test "x$ac_cv_have_decl_arc4random_uniform" = xyes; then :
+  ac_have_decl=1
+else
+  ac_have_decl=0
 fi
-{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $ac_cv_c_undeclared_builtin_options" >&5
-printf "%s\n" "$ac_cv_c_undeclared_builtin_options" >&6; }
-  case $ac_cv_c_undeclared_builtin_options in #(
-  'cannot detect') :
-    { { printf "%s\n" "$as_me:${as_lineno-$LINENO}: error: in \`$ac_pwd':" >&5
-printf "%s\n" "$as_me: error: in \`$ac_pwd':" >&2;}
-as_fn_error $? "cannot make $CC report undeclared builtins
-See \`config.log' for more details" "$LINENO" 5; } ;; #(
-  'none needed') :
-    ac_c_undeclared_builtin_options='' ;; #(
-  *) :
-    ac_c_undeclared_builtin_options=$ac_cv_c_undeclared_builtin_options ;;
-esac
 
-ac_fn_check_decl "$LINENO" "strlcpy" "ac_cv_have_decl_strlcpy" "$ac_includes_default" "$ac_c_undeclared_builtin_options" "CFLAGS"
-if test "x$ac_cv_have_decl_strlcpy" = xyes
-then :
-  ac_have_decl=1
-else $as_nop
-  ac_have_decl=0
-fi
-printf "%s\n" "#define HAVE_DECL_STRLCPY $ac_have_decl" >>confdefs.h
-ac_fn_check_decl "$LINENO" "strlcat" "ac_cv_have_decl_strlcat" "$ac_includes_default" "$ac_c_undeclared_builtin_options" "CFLAGS"
-if test "x$ac_cv_have_decl_strlcat" = xyes
-then :
-  ac_have_decl=1
-else $as_nop
-  ac_have_decl=0
-fi
-printf "%s\n" "#define HAVE_DECL_STRLCAT $ac_have_decl" >>confdefs.h
-ac_fn_check_decl "$LINENO" "arc4random" "ac_cv_have_decl_arc4random" "$ac_includes_default" "$ac_c_undeclared_builtin_options" "CFLAGS"
-if test "x$ac_cv_have_decl_arc4random" = xyes
-then :
-  ac_have_decl=1
-else $as_nop
-  ac_have_decl=0
-fi
-printf "%s\n" "#define HAVE_DECL_ARC4RANDOM $ac_have_decl" >>confdefs.h
-ac_fn_check_decl "$LINENO" "arc4random_uniform" "ac_cv_have_decl_arc4random_uniform" "$ac_includes_default" "$ac_c_undeclared_builtin_options" "CFLAGS"
-if test "x$ac_cv_have_decl_arc4random_uniform" = xyes
-then :
-  ac_have_decl=1
-else $as_nop
-  ac_have_decl=0
-fi
-printf "%s\n" "#define HAVE_DECL_ARC4RANDOM_UNIFORM $ac_have_decl" >>confdefs.h
+cat >>confdefs.h <<_ACEOF
+#define HAVE_DECL_ARC4RANDOM_UNIFORM $ac_have_decl
+_ACEOF
 
 else
-	{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: no" >&5
-printf "%s\n" "no" >&6; }
+	{ $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
+$as_echo "no" >&6; }
 fi
-ac_fn_c_check_header_compile "$LINENO" "openssl/conf.h" "ac_cv_header_openssl_conf_h" "$ac_includes_default
+for ac_header in openssl/conf.h openssl/engine.h openssl/bn.h openssl/dh.h openssl/dsa.h openssl/rsa.h openssl/core_names.h openssl/param_build.h
+do :
+  as_ac_Header=`$as_echo "ac_cv_header_$ac_header" | $as_tr_sh`
+ac_fn_c_check_header_compile "$LINENO" "$ac_header" "$as_ac_Header" "$ac_includes_default
 "
-if test "x$ac_cv_header_openssl_conf_h" = xyes
-then :
-  printf "%s\n" "#define HAVE_OPENSSL_CONF_H 1" >>confdefs.h
-
-fi
-ac_fn_c_check_header_compile "$LINENO" "openssl/engine.h" "ac_cv_header_openssl_engine_h" "$ac_includes_default
-"
-if test "x$ac_cv_header_openssl_engine_h" = xyes
-then :
-  printf "%s\n" "#define HAVE_OPENSSL_ENGINE_H 1" >>confdefs.h
-
-fi
-ac_fn_c_check_header_compile "$LINENO" "openssl/bn.h" "ac_cv_header_openssl_bn_h" "$ac_includes_default
-"
-if test "x$ac_cv_header_openssl_bn_h" = xyes
-then :
-  printf "%s\n" "#define HAVE_OPENSSL_BN_H 1" >>confdefs.h
-
-fi
-ac_fn_c_check_header_compile "$LINENO" "openssl/dh.h" "ac_cv_header_openssl_dh_h" "$ac_includes_default
-"
-if test "x$ac_cv_header_openssl_dh_h" = xyes
-then :
-  printf "%s\n" "#define HAVE_OPENSSL_DH_H 1" >>confdefs.h
-
-fi
-ac_fn_c_check_header_compile "$LINENO" "openssl/dsa.h" "ac_cv_header_openssl_dsa_h" "$ac_includes_default
-"
-if test "x$ac_cv_header_openssl_dsa_h" = xyes
-then :
-  printf "%s\n" "#define HAVE_OPENSSL_DSA_H 1" >>confdefs.h
-
-fi
-ac_fn_c_check_header_compile "$LINENO" "openssl/rsa.h" "ac_cv_header_openssl_rsa_h" "$ac_includes_default
-"
-if test "x$ac_cv_header_openssl_rsa_h" = xyes
-then :
-  printf "%s\n" "#define HAVE_OPENSSL_RSA_H 1" >>confdefs.h
-
-fi
-ac_fn_c_check_header_compile "$LINENO" "openssl/core_names.h" "ac_cv_header_openssl_core_names_h" "$ac_includes_default
-"
-if test "x$ac_cv_header_openssl_core_names_h" = xyes
-then :
-  printf "%s\n" "#define HAVE_OPENSSL_CORE_NAMES_H 1" >>confdefs.h
-
-fi
-ac_fn_c_check_header_compile "$LINENO" "openssl/param_build.h" "ac_cv_header_openssl_param_build_h" "$ac_includes_default
-"
-if test "x$ac_cv_header_openssl_param_build_h" = xyes
-then :
-  printf "%s\n" "#define HAVE_OPENSSL_PARAM_BUILD_H 1" >>confdefs.h
+if eval test \"x\$"$as_ac_Header"\" = x"yes"; then :
+  cat >>confdefs.h <<_ACEOF
+#define `$as_echo "HAVE_$ac_header" | $as_tr_cpp` 1
+_ACEOF
 
 fi
 
-ac_fn_c_check_func "$LINENO" "OPENSSL_config" "ac_cv_func_OPENSSL_config"
-if test "x$ac_cv_func_OPENSSL_config" = xyes
-then :
-  printf "%s\n" "#define HAVE_OPENSSL_CONFIG 1" >>confdefs.h
+done
+
+for ac_func in OPENSSL_config EVP_sha1 EVP_sha256 EVP_sha512 FIPS_mode EVP_default_properties_is_fips_enabled EVP_MD_CTX_new OpenSSL_add_all_digests OPENSSL_init_crypto EVP_cleanup ENGINE_cleanup ERR_load_crypto_strings CRYPTO_cleanup_all_ex_data ERR_free_strings RAND_cleanup DSA_SIG_set0 EVP_dss1 EVP_DigestVerify EVP_aes_256_cbc EVP_EncryptInit_ex HMAC_Init_ex CRYPTO_THREADID_set_callback EVP_MAC_CTX_set_params OSSL_PARAM_BLD_new BIO_set_callback_ex
+do :
+  as_ac_var=`$as_echo "ac_cv_func_$ac_func" | $as_tr_sh`
+ac_fn_c_check_func "$LINENO" "$ac_func" "$as_ac_var"
+if eval test \"x\$"$as_ac_var"\" = x"yes"; then :
+  cat >>confdefs.h <<_ACEOF
+#define `$as_echo "HAVE_$ac_func" | $as_tr_cpp` 1
+_ACEOF
 
 fi
-ac_fn_c_check_func "$LINENO" "EVP_sha1" "ac_cv_func_EVP_sha1"
-if test "x$ac_cv_func_EVP_sha1" = xyes
-then :
-  printf "%s\n" "#define HAVE_EVP_SHA1 1" >>confdefs.h
-
-fi
-ac_fn_c_check_func "$LINENO" "EVP_sha256" "ac_cv_func_EVP_sha256"
-if test "x$ac_cv_func_EVP_sha256" = xyes
-then :
-  printf "%s\n" "#define HAVE_EVP_SHA256 1" >>confdefs.h
-
-fi
-ac_fn_c_check_func "$LINENO" "EVP_sha512" "ac_cv_func_EVP_sha512"
-if test "x$ac_cv_func_EVP_sha512" = xyes
-then :
-  printf "%s\n" "#define HAVE_EVP_SHA512 1" >>confdefs.h
-
-fi
-ac_fn_c_check_func "$LINENO" "FIPS_mode" "ac_cv_func_FIPS_mode"
-if test "x$ac_cv_func_FIPS_mode" = xyes
-then :
-  printf "%s\n" "#define HAVE_FIPS_MODE 1" >>confdefs.h
-
-fi
-ac_fn_c_check_func "$LINENO" "EVP_MD_CTX_new" "ac_cv_func_EVP_MD_CTX_new"
-if test "x$ac_cv_func_EVP_MD_CTX_new" = xyes
-then :
-  printf "%s\n" "#define HAVE_EVP_MD_CTX_NEW 1" >>confdefs.h
-
-fi
-ac_fn_c_check_func "$LINENO" "OpenSSL_add_all_digests" "ac_cv_func_OpenSSL_add_all_digests"
-if test "x$ac_cv_func_OpenSSL_add_all_digests" = xyes
-then :
-  printf "%s\n" "#define HAVE_OPENSSL_ADD_ALL_DIGESTS 1" >>confdefs.h
-
-fi
-ac_fn_c_check_func "$LINENO" "OPENSSL_init_crypto" "ac_cv_func_OPENSSL_init_crypto"
-if test "x$ac_cv_func_OPENSSL_init_crypto" = xyes
-then :
-  printf "%s\n" "#define HAVE_OPENSSL_INIT_CRYPTO 1" >>confdefs.h
-
-fi
-ac_fn_c_check_func "$LINENO" "EVP_cleanup" "ac_cv_func_EVP_cleanup"
-if test "x$ac_cv_func_EVP_cleanup" = xyes
-then :
-  printf "%s\n" "#define HAVE_EVP_CLEANUP 1" >>confdefs.h
-
-fi
-ac_fn_c_check_func "$LINENO" "ENGINE_cleanup" "ac_cv_func_ENGINE_cleanup"
-if test "x$ac_cv_func_ENGINE_cleanup" = xyes
-then :
-  printf "%s\n" "#define HAVE_ENGINE_CLEANUP 1" >>confdefs.h
-
-fi
-ac_fn_c_check_func "$LINENO" "ERR_load_crypto_strings" "ac_cv_func_ERR_load_crypto_strings"
-if test "x$ac_cv_func_ERR_load_crypto_strings" = xyes
-then :
-  printf "%s\n" "#define HAVE_ERR_LOAD_CRYPTO_STRINGS 1" >>confdefs.h
-
-fi
-ac_fn_c_check_func "$LINENO" "CRYPTO_cleanup_all_ex_data" "ac_cv_func_CRYPTO_cleanup_all_ex_data"
-if test "x$ac_cv_func_CRYPTO_cleanup_all_ex_data" = xyes
-then :
-  printf "%s\n" "#define HAVE_CRYPTO_CLEANUP_ALL_EX_DATA 1" >>confdefs.h
-
-fi
-ac_fn_c_check_func "$LINENO" "ERR_free_strings" "ac_cv_func_ERR_free_strings"
-if test "x$ac_cv_func_ERR_free_strings" = xyes
-then :
-  printf "%s\n" "#define HAVE_ERR_FREE_STRINGS 1" >>confdefs.h
-
-fi
-ac_fn_c_check_func "$LINENO" "RAND_cleanup" "ac_cv_func_RAND_cleanup"
-if test "x$ac_cv_func_RAND_cleanup" = xyes
-then :
-  printf "%s\n" "#define HAVE_RAND_CLEANUP 1" >>confdefs.h
-
-fi
-ac_fn_c_check_func "$LINENO" "DSA_SIG_set0" "ac_cv_func_DSA_SIG_set0"
-if test "x$ac_cv_func_DSA_SIG_set0" = xyes
-then :
-  printf "%s\n" "#define HAVE_DSA_SIG_SET0 1" >>confdefs.h
-
-fi
-ac_fn_c_check_func "$LINENO" "EVP_dss1" "ac_cv_func_EVP_dss1"
-if test "x$ac_cv_func_EVP_dss1" = xyes
-then :
-  printf "%s\n" "#define HAVE_EVP_DSS1 1" >>confdefs.h
-
-fi
-ac_fn_c_check_func "$LINENO" "EVP_DigestVerify" "ac_cv_func_EVP_DigestVerify"
-if test "x$ac_cv_func_EVP_DigestVerify" = xyes
-then :
-  printf "%s\n" "#define HAVE_EVP_DIGESTVERIFY 1" >>confdefs.h
-
-fi
-ac_fn_c_check_func "$LINENO" "EVP_aes_256_cbc" "ac_cv_func_EVP_aes_256_cbc"
-if test "x$ac_cv_func_EVP_aes_256_cbc" = xyes
-then :
-  printf "%s\n" "#define HAVE_EVP_AES_256_CBC 1" >>confdefs.h
-
-fi
-ac_fn_c_check_func "$LINENO" "EVP_EncryptInit_ex" "ac_cv_func_EVP_EncryptInit_ex"
-if test "x$ac_cv_func_EVP_EncryptInit_ex" = xyes
-then :
-  printf "%s\n" "#define HAVE_EVP_ENCRYPTINIT_EX 1" >>confdefs.h
-
-fi
-ac_fn_c_check_func "$LINENO" "HMAC_Init_ex" "ac_cv_func_HMAC_Init_ex"
-if test "x$ac_cv_func_HMAC_Init_ex" = xyes
-then :
-  printf "%s\n" "#define HAVE_HMAC_INIT_EX 1" >>confdefs.h
-
-fi
-ac_fn_c_check_func "$LINENO" "CRYPTO_THREADID_set_callback" "ac_cv_func_CRYPTO_THREADID_set_callback"
-if test "x$ac_cv_func_CRYPTO_THREADID_set_callback" = xyes
-then :
-  printf "%s\n" "#define HAVE_CRYPTO_THREADID_SET_CALLBACK 1" >>confdefs.h
-
-fi
-ac_fn_c_check_func "$LINENO" "EVP_MAC_CTX_set_params" "ac_cv_func_EVP_MAC_CTX_set_params"
-if test "x$ac_cv_func_EVP_MAC_CTX_set_params" = xyes
-then :
-  printf "%s\n" "#define HAVE_EVP_MAC_CTX_SET_PARAMS 1" >>confdefs.h
-
-fi
-ac_fn_c_check_func "$LINENO" "OSSL_PARAM_BLD_new" "ac_cv_func_OSSL_PARAM_BLD_new"
-if test "x$ac_cv_func_OSSL_PARAM_BLD_new" = xyes
-then :
-  printf "%s\n" "#define HAVE_OSSL_PARAM_BLD_NEW 1" >>confdefs.h
-
-fi
-ac_fn_c_check_func "$LINENO" "BIO_set_callback_ex" "ac_cv_func_BIO_set_callback_ex"
-if test "x$ac_cv_func_BIO_set_callback_ex" = xyes
-then :
-  printf "%s\n" "#define HAVE_BIO_SET_CALLBACK_EX 1" >>confdefs.h
-
-fi
+done
 
 
 # these check_funcs need -lssl
 BAKLIBS="$LIBS"
 LIBS="-lssl $LIBS"
-ac_fn_c_check_func "$LINENO" "OPENSSL_init_ssl" "ac_cv_func_OPENSSL_init_ssl"
-if test "x$ac_cv_func_OPENSSL_init_ssl" = xyes
-then :
-  printf "%s\n" "#define HAVE_OPENSSL_INIT_SSL 1" >>confdefs.h
+for ac_func in OPENSSL_init_ssl SSL_CTX_set_security_level SSL_set1_host SSL_get0_peername X509_VERIFY_PARAM_set1_host SSL_CTX_set_ciphersuites SSL_CTX_set_tlsext_ticket_key_evp_cb SSL_CTX_set_alpn_select_cb SSL_get0_alpn_selected SSL_CTX_set_alpn_protos SSL_get1_peer_certificate
+do :
+  as_ac_var=`$as_echo "ac_cv_func_$ac_func" | $as_tr_sh`
+ac_fn_c_check_func "$LINENO" "$ac_func" "$as_ac_var"
+if eval test \"x\$"$as_ac_var"\" = x"yes"; then :
+  cat >>confdefs.h <<_ACEOF
+#define `$as_echo "HAVE_$ac_func" | $as_tr_cpp` 1
+_ACEOF
 
 fi
-ac_fn_c_check_func "$LINENO" "SSL_CTX_set_security_level" "ac_cv_func_SSL_CTX_set_security_level"
-if test "x$ac_cv_func_SSL_CTX_set_security_level" = xyes
-then :
-  printf "%s\n" "#define HAVE_SSL_CTX_SET_SECURITY_LEVEL 1" >>confdefs.h
-
-fi
-ac_fn_c_check_func "$LINENO" "SSL_set1_host" "ac_cv_func_SSL_set1_host"
-if test "x$ac_cv_func_SSL_set1_host" = xyes
-then :
-  printf "%s\n" "#define HAVE_SSL_SET1_HOST 1" >>confdefs.h
-
-fi
-ac_fn_c_check_func "$LINENO" "SSL_get0_peername" "ac_cv_func_SSL_get0_peername"
-if test "x$ac_cv_func_SSL_get0_peername" = xyes
-then :
-  printf "%s\n" "#define HAVE_SSL_GET0_PEERNAME 1" >>confdefs.h
-
-fi
-ac_fn_c_check_func "$LINENO" "X509_VERIFY_PARAM_set1_host" "ac_cv_func_X509_VERIFY_PARAM_set1_host"
-if test "x$ac_cv_func_X509_VERIFY_PARAM_set1_host" = xyes
-then :
-  printf "%s\n" "#define HAVE_X509_VERIFY_PARAM_SET1_HOST 1" >>confdefs.h
-
-fi
-ac_fn_c_check_func "$LINENO" "SSL_CTX_set_ciphersuites" "ac_cv_func_SSL_CTX_set_ciphersuites"
-if test "x$ac_cv_func_SSL_CTX_set_ciphersuites" = xyes
-then :
-  printf "%s\n" "#define HAVE_SSL_CTX_SET_CIPHERSUITES 1" >>confdefs.h
-
-fi
-ac_fn_c_check_func "$LINENO" "SSL_CTX_set_tlsext_ticket_key_evp_cb" "ac_cv_func_SSL_CTX_set_tlsext_ticket_key_evp_cb"
-if test "x$ac_cv_func_SSL_CTX_set_tlsext_ticket_key_evp_cb" = xyes
-then :
-  printf "%s\n" "#define HAVE_SSL_CTX_SET_TLSEXT_TICKET_KEY_EVP_CB 1" >>confdefs.h
-
-fi
-ac_fn_c_check_func "$LINENO" "SSL_CTX_set_alpn_select_cb" "ac_cv_func_SSL_CTX_set_alpn_select_cb"
-if test "x$ac_cv_func_SSL_CTX_set_alpn_select_cb" = xyes
-then :
-  printf "%s\n" "#define HAVE_SSL_CTX_SET_ALPN_SELECT_CB 1" >>confdefs.h
-
-fi
-ac_fn_c_check_func "$LINENO" "SSL_get0_alpn_selected" "ac_cv_func_SSL_get0_alpn_selected"
-if test "x$ac_cv_func_SSL_get0_alpn_selected" = xyes
-then :
-  printf "%s\n" "#define HAVE_SSL_GET0_ALPN_SELECTED 1" >>confdefs.h
-
-fi
-ac_fn_c_check_func "$LINENO" "SSL_CTX_set_alpn_protos" "ac_cv_func_SSL_CTX_set_alpn_protos"
-if test "x$ac_cv_func_SSL_CTX_set_alpn_protos" = xyes
-then :
-  printf "%s\n" "#define HAVE_SSL_CTX_SET_ALPN_PROTOS 1" >>confdefs.h
-
-fi
-ac_fn_c_check_func "$LINENO" "SSL_get1_peer_certificate" "ac_cv_func_SSL_get1_peer_certificate"
-if test "x$ac_cv_func_SSL_get1_peer_certificate" = xyes
-then :
-  printf "%s\n" "#define HAVE_SSL_GET1_PEER_CERTIFICATE 1" >>confdefs.h
-
-fi
+done
 
 LIBS="$BAKLIBS"
 
-ac_fn_check_decl "$LINENO" "SSL_COMP_get_compression_methods" "ac_cv_have_decl_SSL_COMP_get_compression_methods" "
+ac_fn_c_check_decl "$LINENO" "SSL_COMP_get_compression_methods" "ac_cv_have_decl_SSL_COMP_get_compression_methods" "
 $ac_includes_default
 #ifdef HAVE_OPENSSL_ERR_H
 #include <openssl/err.h>
@@ -20199,15 +18595,17 @@ $ac_includes_default
 #include <openssl/ssl.h>
 #include <openssl/evp.h>
 
-" "$ac_c_undeclared_builtin_options" "CFLAGS"
-if test "x$ac_cv_have_decl_SSL_COMP_get_compression_methods" = xyes
-then :
+"
+if test "x$ac_cv_have_decl_SSL_COMP_get_compression_methods" = xyes; then :
   ac_have_decl=1
-else $as_nop
+else
   ac_have_decl=0
 fi
-printf "%s\n" "#define HAVE_DECL_SSL_COMP_GET_COMPRESSION_METHODS $ac_have_decl" >>confdefs.h
-ac_fn_check_decl "$LINENO" "sk_SSL_COMP_pop_free" "ac_cv_have_decl_sk_SSL_COMP_pop_free" "
+
+cat >>confdefs.h <<_ACEOF
+#define HAVE_DECL_SSL_COMP_GET_COMPRESSION_METHODS $ac_have_decl
+_ACEOF
+ac_fn_c_check_decl "$LINENO" "sk_SSL_COMP_pop_free" "ac_cv_have_decl_sk_SSL_COMP_pop_free" "
 $ac_includes_default
 #ifdef HAVE_OPENSSL_ERR_H
 #include <openssl/err.h>
@@ -20227,15 +18625,17 @@ $ac_includes_default
 #include <openssl/ssl.h>
 #include <openssl/evp.h>
 
-" "$ac_c_undeclared_builtin_options" "CFLAGS"
-if test "x$ac_cv_have_decl_sk_SSL_COMP_pop_free" = xyes
-then :
+"
+if test "x$ac_cv_have_decl_sk_SSL_COMP_pop_free" = xyes; then :
   ac_have_decl=1
-else $as_nop
+else
   ac_have_decl=0
 fi
-printf "%s\n" "#define HAVE_DECL_SK_SSL_COMP_POP_FREE $ac_have_decl" >>confdefs.h
-ac_fn_check_decl "$LINENO" "SSL_CTX_set_ecdh_auto" "ac_cv_have_decl_SSL_CTX_set_ecdh_auto" "
+
+cat >>confdefs.h <<_ACEOF
+#define HAVE_DECL_SK_SSL_COMP_POP_FREE $ac_have_decl
+_ACEOF
+ac_fn_c_check_decl "$LINENO" "SSL_CTX_set_ecdh_auto" "ac_cv_have_decl_SSL_CTX_set_ecdh_auto" "
 $ac_includes_default
 #ifdef HAVE_OPENSSL_ERR_H
 #include <openssl/err.h>
@@ -20255,20 +18655,22 @@ $ac_includes_default
 #include <openssl/ssl.h>
 #include <openssl/evp.h>
 
-" "$ac_c_undeclared_builtin_options" "CFLAGS"
-if test "x$ac_cv_have_decl_SSL_CTX_set_ecdh_auto" = xyes
-then :
+"
+if test "x$ac_cv_have_decl_SSL_CTX_set_ecdh_auto" = xyes; then :
   ac_have_decl=1
-else $as_nop
+else
   ac_have_decl=0
 fi
-printf "%s\n" "#define HAVE_DECL_SSL_CTX_SET_ECDH_AUTO $ac_have_decl" >>confdefs.h
+
+cat >>confdefs.h <<_ACEOF
+#define HAVE_DECL_SSL_CTX_SET_ECDH_AUTO $ac_have_decl
+_ACEOF
 
 
 if test "$ac_cv_func_HMAC_Init_ex" = "yes"; then
 # check function return type.
-{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking the return type of HMAC_Init_ex" >&5
-printf %s "checking the return type of HMAC_Init_ex... " >&6; }
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking the return type of HMAC_Init_ex" >&5
+$as_echo_n "checking the return type of HMAC_Init_ex... " >&6; }
 cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 /* end confdefs.h.  */
 
@@ -20291,7 +18693,7 @@ cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 #include <openssl/evp.h>
 
 int
-main (void)
+main ()
 {
 
 	HMAC_CTX* hmac_ctx = NULL;
@@ -20304,22 +18706,21 @@ main (void)
   return 0;
 }
 _ACEOF
-if ac_fn_c_try_compile "$LINENO"
-then :
+if ac_fn_c_try_compile "$LINENO"; then :
 
-	{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: int" >&5
-printf "%s\n" "int" >&6; }
+	{ $as_echo "$as_me:${as_lineno-$LINENO}: result: int" >&5
+$as_echo "int" >&6; }
 
-else $as_nop
+else
 
-	{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: void" >&5
-printf "%s\n" "void" >&6; }
+	{ $as_echo "$as_me:${as_lineno-$LINENO}: result: void" >&5
+$as_echo "void" >&6; }
 
-printf "%s\n" "#define HMAC_INIT_EX_RETURNS_VOID 1" >>confdefs.h
+$as_echo "#define HMAC_INIT_EX_RETURNS_VOID 1" >>confdefs.h
 
 
 fi
-rm -f core conftest.err conftest.$ac_objext conftest.beam conftest.$ac_ext
+rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
 fi
 
 fi
@@ -20328,33 +18729,30 @@ fi
 # libbsd
 
 # Check whether --with-libbsd was given.
-if test ${with_libbsd+y}
-then :
+if test "${with_libbsd+set}" = set; then :
   withval=$with_libbsd;
-	ac_fn_c_check_header_compile "$LINENO" "bsd/string.h" "ac_cv_header_bsd_string_h" "$ac_includes_default
+	for ac_header in bsd/string.h bsd/stdlib.h
+do :
+  as_ac_Header=`$as_echo "ac_cv_header_$ac_header" | $as_tr_sh`
+ac_fn_c_check_header_compile "$LINENO" "$ac_header" "$as_ac_Header" "$ac_includes_default
 "
-if test "x$ac_cv_header_bsd_string_h" = xyes
-then :
-  printf "%s\n" "#define HAVE_BSD_STRING_H 1" >>confdefs.h
+if eval test \"x\$"$as_ac_Header"\" = x"yes"; then :
+  cat >>confdefs.h <<_ACEOF
+#define `$as_echo "HAVE_$ac_header" | $as_tr_cpp` 1
+_ACEOF
 
 fi
-ac_fn_c_check_header_compile "$LINENO" "bsd/stdlib.h" "ac_cv_header_bsd_stdlib_h" "$ac_includes_default
-"
-if test "x$ac_cv_header_bsd_stdlib_h" = xyes
-then :
-  printf "%s\n" "#define HAVE_BSD_STDLIB_H 1" >>confdefs.h
 
-fi
+done
 
 	if test "x$ac_cv_header_bsd_string_h" = xyes -a "x$ac_cv_header_bsd_stdlib_h" = xyes; then
 		for func in strlcpy strlcat arc4random arc4random_uniform reallocarray; do
-			as_ac_Search=`printf "%s\n" "ac_cv_search_$func" | $as_tr_sh`
-{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for library containing $func" >&5
-printf %s "checking for library containing $func... " >&6; }
-if eval test \${$as_ac_Search+y}
-then :
-  printf %s "(cached) " >&6
-else $as_nop
+			as_ac_Search=`$as_echo "ac_cv_search_$func" | $as_tr_sh`
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for library containing $func" >&5
+$as_echo_n "checking for library containing $func... " >&6; }
+if eval \${$as_ac_Search+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
   ac_func_search_save_LIBS=$LIBS
 cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 /* end confdefs.h.  */
@@ -20362,53 +18760,51 @@ cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 /* Override any GCC internal prototype to avoid an error.
    Use char because int might match the return type of a GCC
    builtin and then its argument prototype would still apply.  */
+#ifdef __cplusplus
+extern "C"
+#endif
 char $func ();
 int
-main (void)
+main ()
 {
 return $func ();
   ;
   return 0;
 }
 _ACEOF
-for ac_lib in '' bsd
-do
+for ac_lib in '' bsd; do
   if test -z "$ac_lib"; then
     ac_res="none required"
   else
     ac_res=-l$ac_lib
     LIBS="-l$ac_lib  $ac_func_search_save_LIBS"
   fi
-  if ac_fn_c_try_link "$LINENO"
-then :
+  if ac_fn_c_try_link "$LINENO"; then :
   eval "$as_ac_Search=\$ac_res"
 fi
-rm -f core conftest.err conftest.$ac_objext conftest.beam \
+rm -f core conftest.err conftest.$ac_objext \
     conftest$ac_exeext
-  if eval test \${$as_ac_Search+y}
-then :
+  if eval \${$as_ac_Search+:} false; then :
   break
 fi
 done
-if eval test \${$as_ac_Search+y}
-then :
+if eval \${$as_ac_Search+:} false; then :
 
-else $as_nop
+else
   eval "$as_ac_Search=no"
 fi
 rm conftest.$ac_ext
 LIBS=$ac_func_search_save_LIBS
 fi
 eval ac_res=\$$as_ac_Search
-	       { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $ac_res" >&5
-printf "%s\n" "$ac_res" >&6; }
+	       { $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_res" >&5
+$as_echo "$ac_res" >&6; }
 eval ac_res=\$$as_ac_Search
-if test "$ac_res" != no
-then :
+if test "$ac_res" != no; then :
   test "$ac_res" = "none required" || LIBS="$ac_res $LIBS"
 
 
-printf "%s\n" "#define HAVE_LIBBSD 1" >>confdefs.h
+$as_echo "#define HAVE_LIBBSD 1" >>confdefs.h
 
 				PC_LIBBSD_DEPENDENCY=libbsd
 
@@ -20422,8 +18818,7 @@ fi
 
 
 # Check whether --enable-sha1 was given.
-if test ${enable_sha1+y}
-then :
+if test "${enable_sha1+set}" = set; then :
   enableval=$enable_sha1;
 fi
 
@@ -20432,15 +18827,14 @@ case "$enable_sha1" in
 	;;
 	yes|*)
 
-printf "%s\n" "#define USE_SHA1 1" >>confdefs.h
+$as_echo "#define USE_SHA1 1" >>confdefs.h
 
 	;;
 esac
 
 
 # Check whether --enable-sha2 was given.
-if test ${enable_sha2+y}
-then :
+if test "${enable_sha2+set}" = set; then :
   enableval=$enable_sha2;
 fi
 
@@ -20449,21 +18843,20 @@ case "$enable_sha2" in
 	;;
 	yes|*)
 
-printf "%s\n" "#define USE_SHA2 1" >>confdefs.h
+$as_echo "#define USE_SHA2 1" >>confdefs.h
 
 	;;
 esac
 
 # Check whether --enable-subnet was given.
-if test ${enable_subnet+y}
-then :
+if test "${enable_subnet+set}" = set; then :
   enableval=$enable_subnet;
 fi
 
 case "$enable_subnet" in
 	yes)
 
-printf "%s\n" "#define CLIENT_SUBNET 1" >>confdefs.h
+$as_echo "#define CLIENT_SUBNET 1" >>confdefs.h
 
 	SUBNET_OBJ="edns-subnet.lo subnetmod.lo addrtree.lo subnet-whitelist.lo"
 
@@ -20477,8 +18870,7 @@ esac
 # check whether gost also works
 
 # Check whether --enable-gost was given.
-if test ${enable_gost+y}
-then :
+if test "${enable_gost+set}" = set; then :
   enableval=$enable_gost;
 fi
 
@@ -20489,36 +18881,33 @@ case "$enable_gost" in
 	;;
 	*)
 	ac_fn_c_check_func "$LINENO" "EVP_PKEY_set_type_str" "ac_cv_func_EVP_PKEY_set_type_str"
-if test "x$ac_cv_func_EVP_PKEY_set_type_str" = xyes
-then :
+if test "x$ac_cv_func_EVP_PKEY_set_type_str" = xyes; then :
   :
-else $as_nop
+else
   as_fn_error $? "OpenSSL 1.0.0 is needed for GOST support" "$LINENO" 5
 fi
 
 	ac_fn_c_check_func "$LINENO" "EC_KEY_new" "ac_cv_func_EC_KEY_new"
-if test "x$ac_cv_func_EC_KEY_new" = xyes
-then :
+if test "x$ac_cv_func_EC_KEY_new" = xyes; then :
 
-else $as_nop
+else
   as_fn_error $? "OpenSSL does not support ECC, needed for GOST support" "$LINENO" 5
 fi
 
 
-{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking if GOST works" >&5
-printf %s "checking if GOST works... " >&6; }
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking if GOST works" >&5
+$as_echo_n "checking if GOST works... " >&6; }
 if test c${cross_compiling} = cno; then
 BAKCFLAGS="$CFLAGS"
 if test -n "$ssldir"; then
 	CFLAGS="$CFLAGS -Wl,-rpath,$ssldir_lib"
 fi
-if test "$cross_compiling" = yes
-then :
-  { { printf "%s\n" "$as_me:${as_lineno-$LINENO}: error: in \`$ac_pwd':" >&5
-printf "%s\n" "$as_me: error: in \`$ac_pwd':" >&2;}
+if test "$cross_compiling" = yes; then :
+  { { $as_echo "$as_me:${as_lineno-$LINENO}: error: in \`$ac_pwd':" >&5
+$as_echo "$as_me: error: in \`$ac_pwd':" >&2;}
 as_fn_error $? "cannot run test program while cross compiling
 See \`config.log' for more details" "$LINENO" 5; }
-else $as_nop
+else
   cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 /* end confdefs.h.  */
 
@@ -20604,10 +18993,9 @@ int main(void) {
 }
 
 _ACEOF
-if ac_fn_c_try_run "$LINENO"
-then :
+if ac_fn_c_try_run "$LINENO"; then :
   eval "ac_cv_c_gost_works=yes"
-else $as_nop
+else
   eval "ac_cv_c_gost_works=no"
 fi
 rm -f core *.core core.conftest.* gmon.out bb.out conftest$ac_exeext \
@@ -20618,21 +19006,20 @@ CFLAGS="$BAKCFLAGS"
 else
 eval "ac_cv_c_gost_works=maybe"
 fi
-{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $ac_cv_c_gost_works" >&5
-printf "%s\n" "$ac_cv_c_gost_works" >&6; }
+{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_c_gost_works" >&5
+$as_echo "$ac_cv_c_gost_works" >&6; }
 
 	if test "$ac_cv_c_gost_works" != no; then
 		use_gost="yes"
 
-printf "%s\n" "#define USE_GOST 1" >>confdefs.h
+$as_echo "#define USE_GOST 1" >>confdefs.h
 
 	fi
 	;;
 esac
 fi
 # Check whether --enable-ecdsa was given.
-if test ${enable_ecdsa+y}
-then :
+if test "${enable_ecdsa+set}" = set; then :
   enableval=$enable_ecdsa;
 fi
 
@@ -20643,87 +19030,90 @@ case "$enable_ecdsa" in
     *)
       if test $USE_NSS = "no" -a $USE_NETTLE = "no"; then
 	      ac_fn_c_check_func "$LINENO" "ECDSA_sign" "ac_cv_func_ECDSA_sign"
-if test "x$ac_cv_func_ECDSA_sign" = xyes
-then :
+if test "x$ac_cv_func_ECDSA_sign" = xyes; then :
 
-else $as_nop
+else
   as_fn_error $? "OpenSSL does not support ECDSA: please upgrade or rerun with --disable-ecdsa" "$LINENO" 5
 fi
 
 	      ac_fn_c_check_func "$LINENO" "SHA384_Init" "ac_cv_func_SHA384_Init"
-if test "x$ac_cv_func_SHA384_Init" = xyes
-then :
+if test "x$ac_cv_func_SHA384_Init" = xyes; then :
 
-else $as_nop
+else
   as_fn_error $? "OpenSSL does not support SHA384: please upgrade or rerun with --disable-ecdsa" "$LINENO" 5
 fi
 
-	      ac_fn_check_decl "$LINENO" "NID_X9_62_prime256v1" "ac_cv_have_decl_NID_X9_62_prime256v1" "$ac_includes_default
+	      ac_fn_c_check_decl "$LINENO" "NID_X9_62_prime256v1" "ac_cv_have_decl_NID_X9_62_prime256v1" "$ac_includes_default
 #include <openssl/evp.h>
 
-" "$ac_c_undeclared_builtin_options" "CFLAGS"
-if test "x$ac_cv_have_decl_NID_X9_62_prime256v1" = xyes
-then :
+"
+if test "x$ac_cv_have_decl_NID_X9_62_prime256v1" = xyes; then :
   ac_have_decl=1
-else $as_nop
+else
   ac_have_decl=0
 fi
-printf "%s\n" "#define HAVE_DECL_NID_X9_62_PRIME256V1 $ac_have_decl" >>confdefs.h
-if test $ac_have_decl = 1
-then :
 
-else $as_nop
+cat >>confdefs.h <<_ACEOF
+#define HAVE_DECL_NID_X9_62_PRIME256V1 $ac_have_decl
+_ACEOF
+if test $ac_have_decl = 1; then :
+
+else
   as_fn_error $? "OpenSSL does not support the ECDSA curves: please upgrade or rerun with --disable-ecdsa" "$LINENO" 5
 fi
-ac_fn_check_decl "$LINENO" "NID_secp384r1" "ac_cv_have_decl_NID_secp384r1" "$ac_includes_default
+ac_fn_c_check_decl "$LINENO" "NID_secp384r1" "ac_cv_have_decl_NID_secp384r1" "$ac_includes_default
 #include <openssl/evp.h>
 
-" "$ac_c_undeclared_builtin_options" "CFLAGS"
-if test "x$ac_cv_have_decl_NID_secp384r1" = xyes
-then :
+"
+if test "x$ac_cv_have_decl_NID_secp384r1" = xyes; then :
   ac_have_decl=1
-else $as_nop
+else
   ac_have_decl=0
 fi
-printf "%s\n" "#define HAVE_DECL_NID_SECP384R1 $ac_have_decl" >>confdefs.h
-if test $ac_have_decl = 1
-then :
 
-else $as_nop
+cat >>confdefs.h <<_ACEOF
+#define HAVE_DECL_NID_SECP384R1 $ac_have_decl
+_ACEOF
+if test $ac_have_decl = 1; then :
+
+else
   as_fn_error $? "OpenSSL does not support the ECDSA curves: please upgrade or rerun with --disable-ecdsa" "$LINENO" 5
 fi
 
 	      # see if OPENSSL 1.0.0 or later (has EVP MD and Verify independency)
-	      { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking if openssl supports SHA2 and ECDSA with EVP" >&5
-printf %s "checking if openssl supports SHA2 and ECDSA with EVP... " >&6; }
+	      { $as_echo "$as_me:${as_lineno-$LINENO}: checking if openssl supports SHA2 and ECDSA with EVP" >&5
+$as_echo_n "checking if openssl supports SHA2 and ECDSA with EVP... " >&6; }
 	      if grep OPENSSL_VERSION_TEXT $ssldir_include/openssl/opensslv.h | grep "OpenSSL" >/dev/null; then
 		if grep OPENSSL_VERSION_NUMBER $ssldir_include/openssl/opensslv.h | grep 0x0 >/dev/null; then
-		  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: no" >&5
-printf "%s\n" "no" >&6; }
+		  { $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
+$as_echo "no" >&6; }
 
-printf "%s\n" "#define USE_ECDSA_EVP_WORKAROUND 1" >>confdefs.h
+cat >>confdefs.h <<_ACEOF
+#define USE_ECDSA_EVP_WORKAROUND 1
+_ACEOF
 
 		else
-		  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: yes" >&5
-printf "%s\n" "yes" >&6; }
+		  { $as_echo "$as_me:${as_lineno-$LINENO}: result: yes" >&5
+$as_echo "yes" >&6; }
 		fi
 	      else
 		# not OpenSSL, thus likely LibreSSL, which supports it
-		{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: yes" >&5
-printf "%s\n" "yes" >&6; }
+		{ $as_echo "$as_me:${as_lineno-$LINENO}: result: yes" >&5
+$as_echo "yes" >&6; }
 	      fi
       fi
       # we now know we have ECDSA and the required curves.
 
-printf "%s\n" "#define USE_ECDSA 1" >>confdefs.h
+cat >>confdefs.h <<_ACEOF
+#define USE_ECDSA 1
+_ACEOF
 
       use_ecdsa="yes"
       ;;
 esac
 
 # Check whether --enable-dsa was given.
-if test ${enable_dsa+y}
-then :
+if test "${enable_dsa+set}" = set; then :
   enableval=$enable_dsa;
 fi
 
@@ -20733,10 +19123,9 @@ case "$enable_dsa" in
       # detect if DSA is supported, and turn it off if not.
       if test $USE_NSS = "no" -a $USE_NETTLE = "no"; then
       ac_fn_c_check_func "$LINENO" "DSA_SIG_new" "ac_cv_func_DSA_SIG_new"
-if test "x$ac_cv_func_DSA_SIG_new" = xyes
-then :
+if test "x$ac_cv_func_DSA_SIG_new" = xyes; then :
 
-      as_ac_Type=`printf "%s\n" "ac_cv_type_DSA_SIG*" | $as_tr_sh`
+      as_ac_Type=`$as_echo "ac_cv_type_DSA_SIG*" | $as_tr_sh`
 ac_fn_c_check_type "$LINENO" "DSA_SIG*" "$as_ac_Type" "
 $ac_includes_default
 #ifdef HAVE_OPENSSL_ERR_H
@@ -20756,27 +19145,30 @@ $ac_includes_default
 #endif
 
 "
-if eval test \"x\$"$as_ac_Type"\" = x"yes"
-then :
+if eval test \"x\$"$as_ac_Type"\" = x"yes"; then :
 
 
-printf "%s\n" "#define USE_DSA 1" >>confdefs.h
+cat >>confdefs.h <<_ACEOF
+#define USE_DSA 1
+_ACEOF
 
 
-else $as_nop
+else
   if test "x$enable_dsa" = "xyes"; then as_fn_error $? "OpenSSL does not support DSA and you used --enable-dsa." "$LINENO" 5
                fi
 fi
 
 
-else $as_nop
+else
   if test "x$enable_dsa" = "xyes"; then as_fn_error $? "OpenSSL does not support DSA and you used --enable-dsa." "$LINENO" 5
                fi
 fi
 
       else
 
-printf "%s\n" "#define USE_DSA 1" >>confdefs.h
+cat >>confdefs.h <<_ACEOF
+#define USE_DSA 1
+_ACEOF
 
       fi
       ;;
@@ -20788,20 +19180,18 @@ esac
 
 
 # Check whether --with-deprecate-rsa-1024 was given.
-if test ${with_deprecate_rsa_1024+y}
-then :
+if test "${with_deprecate_rsa_1024+set}" = set; then :
   withval=$with_deprecate_rsa_1024;
 fi
 
 if test "$with_deprecate_rsa_1024" = "yes"; then
 
-printf "%s\n" "#define DEPRECATE_RSA_1024 1" >>confdefs.h
+$as_echo "#define DEPRECATE_RSA_1024 1" >>confdefs.h
 
 fi
 
 # Check whether --enable-ed25519 was given.
-if test ${enable_ed25519+y}
-then :
+if test "${enable_ed25519+set}" = set; then :
   enableval=$enable_ed25519;
 fi
 
@@ -20811,52 +19201,56 @@ case "$enable_ed25519" in
       ;;
     *)
       if test $USE_NSS = "no" -a $USE_NETTLE = "no"; then
-	      ac_fn_check_decl "$LINENO" "NID_ED25519" "ac_cv_have_decl_NID_ED25519" "$ac_includes_default
+	      ac_fn_c_check_decl "$LINENO" "NID_ED25519" "ac_cv_have_decl_NID_ED25519" "$ac_includes_default
 #include <openssl/evp.h>
 
-" "$ac_c_undeclared_builtin_options" "CFLAGS"
-if test "x$ac_cv_have_decl_NID_ED25519" = xyes
-then :
+"
+if test "x$ac_cv_have_decl_NID_ED25519" = xyes; then :
   ac_have_decl=1
-else $as_nop
+else
   ac_have_decl=0
 fi
-printf "%s\n" "#define HAVE_DECL_NID_ED25519 $ac_have_decl" >>confdefs.h
-if test $ac_have_decl = 1
-then :
+
+cat >>confdefs.h <<_ACEOF
+#define HAVE_DECL_NID_ED25519 $ac_have_decl
+_ACEOF
+if test $ac_have_decl = 1; then :
 
       		use_ed25519="yes"
 
-else $as_nop
+else
    if test "x$enable_ed25519" = "xyes"; then as_fn_error $? "OpenSSL does not support ED25519 and you used --enable-ed25519." "$LINENO" 5
 	      	fi
 fi
 
       fi
       if test $USE_NETTLE = "yes"; then
-		       for ac_header in nettle/eddsa.h
+		for ac_header in nettle/eddsa.h
 do :
   ac_fn_c_check_header_compile "$LINENO" "nettle/eddsa.h" "ac_cv_header_nettle_eddsa_h" "$ac_includes_default
 "
-if test "x$ac_cv_header_nettle_eddsa_h" = xyes
-then :
-  printf "%s\n" "#define HAVE_NETTLE_EDDSA_H 1" >>confdefs.h
+if test "x$ac_cv_header_nettle_eddsa_h" = xyes; then :
+  cat >>confdefs.h <<_ACEOF
+#define HAVE_NETTLE_EDDSA_H 1
+_ACEOF
  use_ed25519="yes"
 fi
 
 done
+
       fi
       if test $use_ed25519 = "yes"; then
 
-printf "%s\n" "#define USE_ED25519 1" >>confdefs.h
+cat >>confdefs.h <<_ACEOF
+#define USE_ED25519 1
+_ACEOF
 
       fi
       ;;
 esac
 
 # Check whether --enable-ed448 was given.
-if test ${enable_ed448+y}
-then :
+if test "${enable_ed448+set}" = set; then :
   enableval=$enable_ed448;
 fi
 
@@ -20866,23 +19260,24 @@ case "$enable_ed448" in
       ;;
     *)
       if test $USE_NSS = "no" -a $USE_NETTLE = "no"; then
-	      ac_fn_check_decl "$LINENO" "NID_ED448" "ac_cv_have_decl_NID_ED448" "$ac_includes_default
+	      ac_fn_c_check_decl "$LINENO" "NID_ED448" "ac_cv_have_decl_NID_ED448" "$ac_includes_default
 #include <openssl/evp.h>
 
-" "$ac_c_undeclared_builtin_options" "CFLAGS"
-if test "x$ac_cv_have_decl_NID_ED448" = xyes
-then :
+"
+if test "x$ac_cv_have_decl_NID_ED448" = xyes; then :
   ac_have_decl=1
-else $as_nop
+else
   ac_have_decl=0
 fi
-printf "%s\n" "#define HAVE_DECL_NID_ED448 $ac_have_decl" >>confdefs.h
-if test $ac_have_decl = 1
-then :
+
+cat >>confdefs.h <<_ACEOF
+#define HAVE_DECL_NID_ED448 $ac_have_decl
+_ACEOF
+if test $ac_have_decl = 1; then :
 
       		use_ed448="yes"
 
-else $as_nop
+else
    if test "x$enable_ed448" = "xyes"; then as_fn_error $? "OpenSSL does not support ED448 and you used --enable-ed448." "$LINENO" 5
 	      	fi
 fi
@@ -20890,15 +19285,16 @@ fi
       fi
       if test $use_ed448 = "yes"; then
 
-printf "%s\n" "#define USE_ED448 1" >>confdefs.h
+cat >>confdefs.h <<_ACEOF
+#define USE_ED448 1
+_ACEOF
 
       fi
       ;;
 esac
 
 # Check whether --enable-event-api was given.
-if test ${enable_event_api+y}
-then :
+if test "${enable_event_api+set}" = set; then :
   enableval=$enable_event_api;
 fi
 
@@ -20914,42 +19310,45 @@ case "$enable_event_api" in
 esac
 
 # Check whether --enable-tfo-client was given.
-if test ${enable_tfo_client+y}
-then :
+if test "${enable_tfo_client+set}" = set; then :
   enableval=$enable_tfo_client;
 fi
 
 case "$enable_tfo_client" in
 	yes)
 		case "$host_os" in
-			linux*) ac_fn_check_decl "$LINENO" "MSG_FASTOPEN" "ac_cv_have_decl_MSG_FASTOPEN" "$ac_includes_default
+			linux*) ac_fn_c_check_decl "$LINENO" "MSG_FASTOPEN" "ac_cv_have_decl_MSG_FASTOPEN" "$ac_includes_default
 #include <netinet/tcp.h>
 
-" "$ac_c_undeclared_builtin_options" "CFLAGS"
-if test "x$ac_cv_have_decl_MSG_FASTOPEN" = xyes
-then :
-  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: WARNING: Check the platform specific TFO kernel parameters are correctly configured to support client mode TFO" >&5
-printf "%s\n" "$as_me: WARNING: Check the platform specific TFO kernel parameters are correctly configured to support client mode TFO" >&2;}
-else $as_nop
+"
+if test "x$ac_cv_have_decl_MSG_FASTOPEN" = xyes; then :
+  { $as_echo "$as_me:${as_lineno-$LINENO}: WARNING: Check the platform specific TFO kernel parameters are correctly configured to support client mode TFO" >&5
+$as_echo "$as_me: WARNING: Check the platform specific TFO kernel parameters are correctly configured to support client mode TFO" >&2;}
+else
   as_fn_error $? "TCP Fast Open is not available for client mode: please rerun without --enable-tfo-client" "$LINENO" 5
 fi
 
-printf "%s\n" "#define USE_MSG_FASTOPEN 1" >>confdefs.h
+
+cat >>confdefs.h <<_ACEOF
+#define USE_MSG_FASTOPEN 1
+_ACEOF
 
 				;;
-			darwin*) ac_fn_check_decl "$LINENO" "CONNECT_RESUME_ON_READ_WRITE" "ac_cv_have_decl_CONNECT_RESUME_ON_READ_WRITE" "$ac_includes_default
+			darwin*) ac_fn_c_check_decl "$LINENO" "CONNECT_RESUME_ON_READ_WRITE" "ac_cv_have_decl_CONNECT_RESUME_ON_READ_WRITE" "$ac_includes_default
 #include <sys/socket.h>
 
-" "$ac_c_undeclared_builtin_options" "CFLAGS"
-if test "x$ac_cv_have_decl_CONNECT_RESUME_ON_READ_WRITE" = xyes
-then :
-  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: WARNING: Check the platform specific TFO kernel parameters are correctly configured to support client mode TFO" >&5
-printf "%s\n" "$as_me: WARNING: Check the platform specific TFO kernel parameters are correctly configured to support client mode TFO" >&2;}
-else $as_nop
+"
+if test "x$ac_cv_have_decl_CONNECT_RESUME_ON_READ_WRITE" = xyes; then :
+  { $as_echo "$as_me:${as_lineno-$LINENO}: WARNING: Check the platform specific TFO kernel parameters are correctly configured to support client mode TFO" >&5
+$as_echo "$as_me: WARNING: Check the platform specific TFO kernel parameters are correctly configured to support client mode TFO" >&2;}
+else
   as_fn_error $? "TCP Fast Open is not available for client mode: please rerun without --enable-tfo-client" "$LINENO" 5
 fi
 
-printf "%s\n" "#define USE_OSX_MSG_FASTOPEN 1" >>confdefs.h
+
+cat >>confdefs.h <<_ACEOF
+#define USE_OSX_MSG_FASTOPEN 1
+_ACEOF
 
 				;;
 		esac
@@ -20959,26 +19358,27 @@ printf "%s\n" "#define USE_OSX_MSG_FASTOPEN 1" >>confdefs.h
 esac
 
 # Check whether --enable-tfo-server was given.
-if test ${enable_tfo_server+y}
-then :
+if test "${enable_tfo_server+set}" = set; then :
   enableval=$enable_tfo_server;
 fi
 
 case "$enable_tfo_server" in
 	yes)
-	      ac_fn_check_decl "$LINENO" "TCP_FASTOPEN" "ac_cv_have_decl_TCP_FASTOPEN" "$ac_includes_default
+	      ac_fn_c_check_decl "$LINENO" "TCP_FASTOPEN" "ac_cv_have_decl_TCP_FASTOPEN" "$ac_includes_default
 #include <netinet/tcp.h>
 
-" "$ac_c_undeclared_builtin_options" "CFLAGS"
-if test "x$ac_cv_have_decl_TCP_FASTOPEN" = xyes
-then :
-  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: WARNING: Check the platform specific TFO kernel parameters are correctly configured to support server mode TFO" >&5
-printf "%s\n" "$as_me: WARNING: Check the platform specific TFO kernel parameters are correctly configured to support server mode TFO" >&2;}
-else $as_nop
+"
+if test "x$ac_cv_have_decl_TCP_FASTOPEN" = xyes; then :
+  { $as_echo "$as_me:${as_lineno-$LINENO}: WARNING: Check the platform specific TFO kernel parameters are correctly configured to support server mode TFO" >&5
+$as_echo "$as_me: WARNING: Check the platform specific TFO kernel parameters are correctly configured to support server mode TFO" >&2;}
+else
   as_fn_error $? "TCP Fast Open is not available for server mode: please rerun without --enable-tfo-server" "$LINENO" 5
 fi
 
-printf "%s\n" "#define USE_TCP_FASTOPEN 1" >>confdefs.h
+
+cat >>confdefs.h <<_ACEOF
+#define USE_TCP_FASTOPEN 1
+_ACEOF
 
 		;;
 	no|*)
@@ -20988,19 +19388,18 @@ esac
 # check for libevent
 
 # Check whether --with-libevent was given.
-if test ${with_libevent+y}
-then :
+if test "${with_libevent+set}" = set; then :
   withval=$with_libevent;
-else $as_nop
+else
    with_libevent="no"
 fi
 
 if test "x_$with_libevent" != x_no; then
 
-printf "%s\n" "#define USE_LIBEVENT 1" >>confdefs.h
+$as_echo "#define USE_LIBEVENT 1" >>confdefs.h
 
-        { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for libevent" >&5
-printf %s "checking for libevent... " >&6; }
+        { $as_echo "$as_me:${as_lineno-$LINENO}: checking for libevent" >&5
+$as_echo_n "checking for libevent... " >&6; }
         if test "x_$with_libevent" = x_ -o "x_$with_libevent" = x_yes; then
             with_libevent="/usr/local /opt/local /usr/lib /usr/pkg /usr/sfw /usr"
         fi
@@ -21017,8 +19416,8 @@ printf %s "checking for libevent... " >&6; }
         if test x_$found_libevent != x_yes; then
 		if test -f "$dir/event.h" -a \( -f "$dir/libevent.la" -o -f "$dir/libev.la" \) ; then
 			# libevent source directory
-			{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: found in $thedir" >&5
-printf "%s\n" "found in $thedir" >&6; }
+			{ $as_echo "$as_me:${as_lineno-$LINENO}: result: found in $thedir" >&5
+$as_echo "found in $thedir" >&6; }
 			CPPFLAGS="$CPPFLAGS -I$thedir -I$thedir/include"
 			BAK_LDFLAGS_SET="1"
 			BAK_LDFLAGS="$LDFLAGS"
@@ -21041,8 +19440,8 @@ Please note that this alternative is not as capable as libevent when using
 large outgoing port ranges.  " "$LINENO" 5
 		fi
         else
-            { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: found in $thedir" >&5
-printf "%s\n" "found in $thedir" >&6; }
+            { $as_echo "$as_me:${as_lineno-$LINENO}: result: found in $thedir" >&5
+$as_echo "found in $thedir" >&6; }
 	    	    if test ! -f $thedir/lib/libevent.a -a ! -f $thedir/lib/libevent.so -a -d "$thedir/lib/event2"; then
 		    LDFLAGS="$LDFLAGS -L$thedir/lib/event2"
 
@@ -21066,12 +19465,11 @@ printf "%s\n" "found in $thedir" >&6; }
 	    fi
         fi
 	# check for library used by libevent after 1.3c
-	{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for library containing clock_gettime" >&5
-printf %s "checking for library containing clock_gettime... " >&6; }
-if test ${ac_cv_search_clock_gettime+y}
-then :
-  printf %s "(cached) " >&6
-else $as_nop
+	{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for library containing clock_gettime" >&5
+$as_echo_n "checking for library containing clock_gettime... " >&6; }
+if ${ac_cv_search_clock_gettime+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
   ac_func_search_save_LIBS=$LIBS
 cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 /* end confdefs.h.  */
@@ -21079,75 +19477,76 @@ cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 /* Override any GCC internal prototype to avoid an error.
    Use char because int might match the return type of a GCC
    builtin and then its argument prototype would still apply.  */
+#ifdef __cplusplus
+extern "C"
+#endif
 char clock_gettime ();
 int
-main (void)
+main ()
 {
 return clock_gettime ();
   ;
   return 0;
 }
 _ACEOF
-for ac_lib in '' rt
-do
+for ac_lib in '' rt; do
   if test -z "$ac_lib"; then
     ac_res="none required"
   else
     ac_res=-l$ac_lib
     LIBS="-l$ac_lib  $ac_func_search_save_LIBS"
   fi
-  if ac_fn_c_try_link "$LINENO"
-then :
+  if ac_fn_c_try_link "$LINENO"; then :
   ac_cv_search_clock_gettime=$ac_res
 fi
-rm -f core conftest.err conftest.$ac_objext conftest.beam \
+rm -f core conftest.err conftest.$ac_objext \
     conftest$ac_exeext
-  if test ${ac_cv_search_clock_gettime+y}
-then :
+  if ${ac_cv_search_clock_gettime+:} false; then :
   break
 fi
 done
-if test ${ac_cv_search_clock_gettime+y}
-then :
+if ${ac_cv_search_clock_gettime+:} false; then :
 
-else $as_nop
+else
   ac_cv_search_clock_gettime=no
 fi
 rm conftest.$ac_ext
 LIBS=$ac_func_search_save_LIBS
 fi
-{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $ac_cv_search_clock_gettime" >&5
-printf "%s\n" "$ac_cv_search_clock_gettime" >&6; }
+{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_search_clock_gettime" >&5
+$as_echo "$ac_cv_search_clock_gettime" >&6; }
 ac_res=$ac_cv_search_clock_gettime
-if test "$ac_res" != no
-then :
+if test "$ac_res" != no; then :
   test "$ac_res" = "none required" || LIBS="$ac_res $LIBS"
 
 fi
 
 
 	# is the event.h header libev or libevent?
-	ac_fn_c_check_header_compile "$LINENO" "event.h" "ac_cv_header_event_h" "$ac_includes_default
+	for ac_header in event.h
+do :
+  ac_fn_c_check_header_compile "$LINENO" "event.h" "ac_cv_header_event_h" "$ac_includes_default
 "
-if test "x$ac_cv_header_event_h" = xyes
-then :
-  printf "%s\n" "#define HAVE_EVENT_H 1" >>confdefs.h
+if test "x$ac_cv_header_event_h" = xyes; then :
+  cat >>confdefs.h <<_ACEOF
+#define HAVE_EVENT_H 1
+_ACEOF
 
 fi
 
-	ac_fn_check_decl "$LINENO" "EV_VERSION_MAJOR" "ac_cv_have_decl_EV_VERSION_MAJOR" "$ac_includes_default
+done
+
+	ac_fn_c_check_decl "$LINENO" "EV_VERSION_MAJOR" "ac_cv_have_decl_EV_VERSION_MAJOR" "$ac_includes_default
 #include <event.h>
 
-" "$ac_c_undeclared_builtin_options" "CFLAGS"
-if test "x$ac_cv_have_decl_EV_VERSION_MAJOR" = xyes
-then :
+"
+if test "x$ac_cv_have_decl_EV_VERSION_MAJOR" = xyes; then :
 
-		{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for library containing event_set" >&5
-printf %s "checking for library containing event_set... " >&6; }
-if test ${ac_cv_search_event_set+y}
-then :
-  printf %s "(cached) " >&6
-else $as_nop
+		{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for library containing event_set" >&5
+$as_echo_n "checking for library containing event_set... " >&6; }
+if ${ac_cv_search_event_set+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
   ac_func_search_save_LIBS=$LIBS
 cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 /* end confdefs.h.  */
@@ -21155,61 +19554,58 @@ cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 /* Override any GCC internal prototype to avoid an error.
    Use char because int might match the return type of a GCC
    builtin and then its argument prototype would still apply.  */
+#ifdef __cplusplus
+extern "C"
+#endif
 char event_set ();
 int
-main (void)
+main ()
 {
 return event_set ();
   ;
   return 0;
 }
 _ACEOF
-for ac_lib in '' ev
-do
+for ac_lib in '' ev; do
   if test -z "$ac_lib"; then
     ac_res="none required"
   else
     ac_res=-l$ac_lib
     LIBS="-l$ac_lib  $ac_func_search_save_LIBS"
   fi
-  if ac_fn_c_try_link "$LINENO"
-then :
+  if ac_fn_c_try_link "$LINENO"; then :
   ac_cv_search_event_set=$ac_res
 fi
-rm -f core conftest.err conftest.$ac_objext conftest.beam \
+rm -f core conftest.err conftest.$ac_objext \
     conftest$ac_exeext
-  if test ${ac_cv_search_event_set+y}
-then :
+  if ${ac_cv_search_event_set+:} false; then :
   break
 fi
 done
-if test ${ac_cv_search_event_set+y}
-then :
+if ${ac_cv_search_event_set+:} false; then :
 
-else $as_nop
+else
   ac_cv_search_event_set=no
 fi
 rm conftest.$ac_ext
 LIBS=$ac_func_search_save_LIBS
 fi
-{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $ac_cv_search_event_set" >&5
-printf "%s\n" "$ac_cv_search_event_set" >&6; }
+{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_search_event_set" >&5
+$as_echo "$ac_cv_search_event_set" >&6; }
 ac_res=$ac_cv_search_event_set
-if test "$ac_res" != no
-then :
+if test "$ac_res" != no; then :
   test "$ac_res" = "none required" || LIBS="$ac_res $LIBS"
 
 fi
 
 
-else $as_nop
+else
 
-		{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for library containing event_set" >&5
-printf %s "checking for library containing event_set... " >&6; }
-if test ${ac_cv_search_event_set+y}
-then :
-  printf %s "(cached) " >&6
-else $as_nop
+		{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for library containing event_set" >&5
+$as_echo_n "checking for library containing event_set... " >&6; }
+if ${ac_cv_search_event_set+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
   ac_func_search_save_LIBS=$LIBS
 cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 /* end confdefs.h.  */
@@ -21217,118 +19613,147 @@ cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 /* Override any GCC internal prototype to avoid an error.
    Use char because int might match the return type of a GCC
    builtin and then its argument prototype would still apply.  */
+#ifdef __cplusplus
+extern "C"
+#endif
 char event_set ();
 int
-main (void)
+main ()
 {
 return event_set ();
   ;
   return 0;
 }
 _ACEOF
-for ac_lib in '' event
-do
+for ac_lib in '' event; do
   if test -z "$ac_lib"; then
     ac_res="none required"
   else
     ac_res=-l$ac_lib
     LIBS="-l$ac_lib  $ac_func_search_save_LIBS"
   fi
-  if ac_fn_c_try_link "$LINENO"
-then :
+  if ac_fn_c_try_link "$LINENO"; then :
   ac_cv_search_event_set=$ac_res
 fi
-rm -f core conftest.err conftest.$ac_objext conftest.beam \
+rm -f core conftest.err conftest.$ac_objext \
     conftest$ac_exeext
-  if test ${ac_cv_search_event_set+y}
-then :
+  if ${ac_cv_search_event_set+:} false; then :
   break
 fi
 done
-if test ${ac_cv_search_event_set+y}
-then :
+if ${ac_cv_search_event_set+:} false; then :
 
-else $as_nop
+else
   ac_cv_search_event_set=no
 fi
 rm conftest.$ac_ext
 LIBS=$ac_func_search_save_LIBS
 fi
-{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $ac_cv_search_event_set" >&5
-printf "%s\n" "$ac_cv_search_event_set" >&6; }
+{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_search_event_set" >&5
+$as_echo "$ac_cv_search_event_set" >&6; }
 ac_res=$ac_cv_search_event_set
-if test "$ac_res" != no
-then :
+if test "$ac_res" != no; then :
   test "$ac_res" = "none required" || LIBS="$ac_res $LIBS"
 
 fi
 
 
 fi
-	ac_fn_c_check_func "$LINENO" "event_base_free" "ac_cv_func_event_base_free"
-if test "x$ac_cv_func_event_base_free" = xyes
-then :
-  printf "%s\n" "#define HAVE_EVENT_BASE_FREE 1" >>confdefs.h
+
+	for ac_func in event_base_free
+do :
+  ac_fn_c_check_func "$LINENO" "event_base_free" "ac_cv_func_event_base_free"
+if test "x$ac_cv_func_event_base_free" = xyes; then :
+  cat >>confdefs.h <<_ACEOF
+#define HAVE_EVENT_BASE_FREE 1
+_ACEOF
 
 fi
+done
  # only in libevent 1.2 and later
-	ac_fn_c_check_func "$LINENO" "event_base_once" "ac_cv_func_event_base_once"
-if test "x$ac_cv_func_event_base_once" = xyes
-then :
-  printf "%s\n" "#define HAVE_EVENT_BASE_ONCE 1" >>confdefs.h
+	for ac_func in event_base_once
+do :
+  ac_fn_c_check_func "$LINENO" "event_base_once" "ac_cv_func_event_base_once"
+if test "x$ac_cv_func_event_base_once" = xyes; then :
+  cat >>confdefs.h <<_ACEOF
+#define HAVE_EVENT_BASE_ONCE 1
+_ACEOF
 
 fi
+done
  # only in libevent 1.4.1 and later
-	ac_fn_c_check_func "$LINENO" "event_base_new" "ac_cv_func_event_base_new"
-if test "x$ac_cv_func_event_base_new" = xyes
-then :
-  printf "%s\n" "#define HAVE_EVENT_BASE_NEW 1" >>confdefs.h
+	for ac_func in event_base_new
+do :
+  ac_fn_c_check_func "$LINENO" "event_base_new" "ac_cv_func_event_base_new"
+if test "x$ac_cv_func_event_base_new" = xyes; then :
+  cat >>confdefs.h <<_ACEOF
+#define HAVE_EVENT_BASE_NEW 1
+_ACEOF
 
 fi
+done
  # only in libevent 1.4.1 and later
-	ac_fn_c_check_func "$LINENO" "event_base_get_method" "ac_cv_func_event_base_get_method"
-if test "x$ac_cv_func_event_base_get_method" = xyes
-then :
-  printf "%s\n" "#define HAVE_EVENT_BASE_GET_METHOD 1" >>confdefs.h
+	for ac_func in event_base_get_method
+do :
+  ac_fn_c_check_func "$LINENO" "event_base_get_method" "ac_cv_func_event_base_get_method"
+if test "x$ac_cv_func_event_base_get_method" = xyes; then :
+  cat >>confdefs.h <<_ACEOF
+#define HAVE_EVENT_BASE_GET_METHOD 1
+_ACEOF
 
 fi
+done
  # only in libevent 1.4.3 and later
-	ac_fn_c_check_func "$LINENO" "ev_loop" "ac_cv_func_ev_loop"
-if test "x$ac_cv_func_ev_loop" = xyes
-then :
-  printf "%s\n" "#define HAVE_EV_LOOP 1" >>confdefs.h
+	for ac_func in ev_loop
+do :
+  ac_fn_c_check_func "$LINENO" "ev_loop" "ac_cv_func_ev_loop"
+if test "x$ac_cv_func_ev_loop" = xyes; then :
+  cat >>confdefs.h <<_ACEOF
+#define HAVE_EV_LOOP 1
+_ACEOF
 
 fi
+done
  # only in libev. (tested on 3.51)
-	ac_fn_c_check_func "$LINENO" "ev_default_loop" "ac_cv_func_ev_default_loop"
-if test "x$ac_cv_func_ev_default_loop" = xyes
-then :
-  printf "%s\n" "#define HAVE_EV_DEFAULT_LOOP 1" >>confdefs.h
+	for ac_func in ev_default_loop
+do :
+  ac_fn_c_check_func "$LINENO" "ev_default_loop" "ac_cv_func_ev_default_loop"
+if test "x$ac_cv_func_ev_default_loop" = xyes; then :
+  cat >>confdefs.h <<_ACEOF
+#define HAVE_EV_DEFAULT_LOOP 1
+_ACEOF
 
 fi
+done
  # only in libev. (tested on 4.00)
-	ac_fn_c_check_func "$LINENO" "event_assign" "ac_cv_func_event_assign"
-if test "x$ac_cv_func_event_assign" = xyes
-then :
-  printf "%s\n" "#define HAVE_EVENT_ASSIGN 1" >>confdefs.h
+	for ac_func in event_assign
+do :
+  ac_fn_c_check_func "$LINENO" "event_assign" "ac_cv_func_event_assign"
+if test "x$ac_cv_func_event_assign" = xyes; then :
+  cat >>confdefs.h <<_ACEOF
+#define HAVE_EVENT_ASSIGN 1
+_ACEOF
 
 fi
+done
  # in libevent, for thread-safety
-	ac_fn_check_decl "$LINENO" "evsignal_assign" "ac_cv_have_decl_evsignal_assign" "$ac_includes_default
+	ac_fn_c_check_decl "$LINENO" "evsignal_assign" "ac_cv_have_decl_evsignal_assign" "$ac_includes_default
 #ifdef HAVE_EVENT_H
 #  include <event.h>
 #else
 #  include \"event2/event.h\"
 #endif
 
-" "$ac_c_undeclared_builtin_options" "CFLAGS"
-if test "x$ac_cv_have_decl_evsignal_assign" = xyes
-then :
+"
+if test "x$ac_cv_have_decl_evsignal_assign" = xyes; then :
   ac_have_decl=1
-else $as_nop
+else
   ac_have_decl=0
 fi
-printf "%s\n" "#define HAVE_DECL_EVSIGNAL_ASSIGN $ac_have_decl" >>confdefs.h
+
+cat >>confdefs.h <<_ACEOF
+#define HAVE_DECL_EVSIGNAL_ASSIGN $ac_have_decl
+_ACEOF
 
         PC_LIBEVENT_DEPENDENCY="libevent"
 
@@ -21337,22 +19762,21 @@ printf "%s\n" "#define HAVE_DECL_EVSIGNAL_ASSIGN $ac_have_decl" >>confdefs.h
 	fi
 else
 
-printf "%s\n" "#define USE_MINI_EVENT 1" >>confdefs.h
+$as_echo "#define USE_MINI_EVENT 1" >>confdefs.h
 
 fi
 
 # check for libexpat
 
 # Check whether --with-libexpat was given.
-if test ${with_libexpat+y}
-then :
+if test "${with_libexpat+set}" = set; then :
   withval=$with_libexpat;
-else $as_nop
+else
    withval="/usr/local /opt/local /usr/lib /usr/pkg /usr/sfw /usr"
 fi
 
-{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for libexpat" >&5
-printf %s "checking for libexpat... " >&6; }
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for libexpat" >&5
+$as_echo_n "checking for libexpat... " >&6; }
 found_libexpat="no"
 for dir in $withval ; do
             if test -f "$dir/include/expat.h"; then
@@ -21361,49 +19785,55 @@ for dir in $withval ; do
                     CPPFLAGS="$CPPFLAGS -I$dir/include"
 		    LDFLAGS="$LDFLAGS -L$dir/lib"
 		fi
-            	{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: found in $dir" >&5
-printf "%s\n" "found in $dir" >&6; }
+            	{ $as_echo "$as_me:${as_lineno-$LINENO}: result: found in $dir" >&5
+$as_echo "found in $dir" >&6; }
                 break;
             fi
 done
 if test x_$found_libexpat != x_yes; then
 	as_fn_error $? "Could not find libexpat, expat.h" "$LINENO" 5
 fi
-ac_fn_c_check_header_compile "$LINENO" "expat.h" "ac_cv_header_expat_h" "$ac_includes_default
+for ac_header in expat.h
+do :
+  ac_fn_c_check_header_compile "$LINENO" "expat.h" "ac_cv_header_expat_h" "$ac_includes_default
 "
-if test "x$ac_cv_header_expat_h" = xyes
-then :
-  printf "%s\n" "#define HAVE_EXPAT_H 1" >>confdefs.h
+if test "x$ac_cv_header_expat_h" = xyes; then :
+  cat >>confdefs.h <<_ACEOF
+#define HAVE_EXPAT_H 1
+_ACEOF
 
 fi
 
-ac_fn_check_decl "$LINENO" "XML_StopParser" "ac_cv_have_decl_XML_StopParser" "$ac_includes_default
+done
+
+ac_fn_c_check_decl "$LINENO" "XML_StopParser" "ac_cv_have_decl_XML_StopParser" "$ac_includes_default
 #include <expat.h>
 
-" "$ac_c_undeclared_builtin_options" "CFLAGS"
-if test "x$ac_cv_have_decl_XML_StopParser" = xyes
-then :
+"
+if test "x$ac_cv_have_decl_XML_StopParser" = xyes; then :
   ac_have_decl=1
-else $as_nop
+else
   ac_have_decl=0
 fi
-printf "%s\n" "#define HAVE_DECL_XML_STOPPARSER $ac_have_decl" >>confdefs.h
+
+cat >>confdefs.h <<_ACEOF
+#define HAVE_DECL_XML_STOPPARSER $ac_have_decl
+_ACEOF
 
 
 # hiredis (redis C client for cachedb)
 
 # Check whether --with-libhiredis was given.
-if test ${with_libhiredis+y}
-then :
+if test "${with_libhiredis+set}" = set; then :
   withval=$with_libhiredis;
-else $as_nop
+else
    withval="no"
 fi
 
 found_libhiredis="no"
 if test x_$withval = x_yes -o x_$withval != x_no; then
-   { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for libhiredis" >&5
-printf %s "checking for libhiredis... " >&6; }
+   { $as_echo "$as_me:${as_lineno-$LINENO}: checking for libhiredis" >&5
+$as_echo_n "checking for libhiredis... " >&6; }
    if test x_$withval = x_ -o x_$withval = x_yes; then
             withval="/usr/local /opt/local /usr/lib /usr/pkg /usr/sfw /usr"
    fi
@@ -21414,10 +19844,10 @@ printf %s "checking for libhiredis... " >&6; }
                     CPPFLAGS="$CPPFLAGS -I$dir/include"
 		    LDFLAGS="$LDFLAGS -L$dir/lib"
 		fi
-		{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: found in $dir" >&5
-printf "%s\n" "found in $dir" >&6; }
+		{ $as_echo "$as_me:${as_lineno-$LINENO}: result: found in $dir" >&5
+$as_echo "found in $dir" >&6; }
 
-printf "%s\n" "#define USE_REDIS 1" >>confdefs.h
+$as_echo "#define USE_REDIS 1" >>confdefs.h
 
 		LIBS="$LIBS -lhiredis"
                 break;
@@ -21426,42 +19856,48 @@ printf "%s\n" "#define USE_REDIS 1" >>confdefs.h
     if test x_$found_libhiredis != x_yes; then
 	as_fn_error $? "Could not find libhiredis, hiredis.h" "$LINENO" 5
     fi
-    ac_fn_c_check_header_compile "$LINENO" "hiredis/hiredis.h" "ac_cv_header_hiredis_hiredis_h" "$ac_includes_default
+    for ac_header in hiredis/hiredis.h
+do :
+  ac_fn_c_check_header_compile "$LINENO" "hiredis/hiredis.h" "ac_cv_header_hiredis_hiredis_h" "$ac_includes_default
 "
-if test "x$ac_cv_header_hiredis_hiredis_h" = xyes
-then :
-  printf "%s\n" "#define HAVE_HIREDIS_HIREDIS_H 1" >>confdefs.h
+if test "x$ac_cv_header_hiredis_hiredis_h" = xyes; then :
+  cat >>confdefs.h <<_ACEOF
+#define HAVE_HIREDIS_HIREDIS_H 1
+_ACEOF
 
 fi
 
-    ac_fn_check_decl "$LINENO" "redisConnect" "ac_cv_have_decl_redisConnect" "$ac_includes_default
+done
+
+    ac_fn_c_check_decl "$LINENO" "redisConnect" "ac_cv_have_decl_redisConnect" "$ac_includes_default
     #include <hiredis/hiredis.h>
 
-" "$ac_c_undeclared_builtin_options" "CFLAGS"
-if test "x$ac_cv_have_decl_redisConnect" = xyes
-then :
+"
+if test "x$ac_cv_have_decl_redisConnect" = xyes; then :
   ac_have_decl=1
-else $as_nop
+else
   ac_have_decl=0
 fi
-printf "%s\n" "#define HAVE_DECL_REDISCONNECT $ac_have_decl" >>confdefs.h
+
+cat >>confdefs.h <<_ACEOF
+#define HAVE_DECL_REDISCONNECT $ac_have_decl
+_ACEOF
 
 fi
 
 # nghttp2
 
 # Check whether --with-libnghttp2 was given.
-if test ${with_libnghttp2+y}
-then :
+if test "${with_libnghttp2+set}" = set; then :
   withval=$with_libnghttp2;
-else $as_nop
+else
    withval="no"
 fi
 
 found_libnghttp2="no"
 if test x_$withval = x_yes -o x_$withval != x_no; then
-   { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for libnghttp2" >&5
-printf %s "checking for libnghttp2... " >&6; }
+   { $as_echo "$as_me:${as_lineno-$LINENO}: checking for libnghttp2" >&5
+$as_echo_n "checking for libnghttp2... " >&6; }
    if test x_$withval = x_ -o x_$withval = x_yes; then
             withval="/usr/local /opt/local /usr/lib /usr/pkg /usr/sfw /usr"
    fi
@@ -21472,10 +19908,10 @@ printf %s "checking for libnghttp2... " >&6; }
                     CPPFLAGS="$CPPFLAGS -I$dir/include"
 		    LDFLAGS="$LDFLAGS -L$dir/lib"
 		fi
-		{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: found in $dir" >&5
-printf "%s\n" "found in $dir" >&6; }
+		{ $as_echo "$as_me:${as_lineno-$LINENO}: result: found in $dir" >&5
+$as_echo "found in $dir" >&6; }
 
-printf "%s\n" "#define HAVE_NGHTTP2 1" >>confdefs.h
+$as_echo "#define HAVE_NGHTTP2 1" >>confdefs.h
 
 		LIBS="$LIBS -lnghttp2"
                 break;
@@ -21484,25 +19920,32 @@ printf "%s\n" "#define HAVE_NGHTTP2 1" >>confdefs.h
     if test x_$found_libnghttp2 != x_yes; then
 	as_fn_error $? "Could not find libnghttp2, nghttp2.h" "$LINENO" 5
     fi
-    ac_fn_c_check_header_compile "$LINENO" "nghttp2/nghttp2.h" "ac_cv_header_nghttp2_nghttp2_h" "$ac_includes_default
+    for ac_header in nghttp2/nghttp2.h
+do :
+  ac_fn_c_check_header_compile "$LINENO" "nghttp2/nghttp2.h" "ac_cv_header_nghttp2_nghttp2_h" "$ac_includes_default
 "
-if test "x$ac_cv_header_nghttp2_nghttp2_h" = xyes
-then :
-  printf "%s\n" "#define HAVE_NGHTTP2_NGHTTP2_H 1" >>confdefs.h
+if test "x$ac_cv_header_nghttp2_nghttp2_h" = xyes; then :
+  cat >>confdefs.h <<_ACEOF
+#define HAVE_NGHTTP2_NGHTTP2_H 1
+_ACEOF
 
 fi
 
-    ac_fn_check_decl "$LINENO" "nghttp2_session_server_new" "ac_cv_have_decl_nghttp2_session_server_new" "$ac_includes_default
+done
+
+    ac_fn_c_check_decl "$LINENO" "nghttp2_session_server_new" "ac_cv_have_decl_nghttp2_session_server_new" "$ac_includes_default
     #include <nghttp2/nghttp2.h>
 
-" "$ac_c_undeclared_builtin_options" "CFLAGS"
-if test "x$ac_cv_have_decl_nghttp2_session_server_new" = xyes
-then :
+"
+if test "x$ac_cv_have_decl_nghttp2_session_server_new" = xyes; then :
   ac_have_decl=1
-else $as_nop
+else
   ac_have_decl=0
 fi
-printf "%s\n" "#define HAVE_DECL_NGHTTP2_SESSION_SERVER_NEW $ac_have_decl" >>confdefs.h
+
+cat >>confdefs.h <<_ACEOF
+#define HAVE_DECL_NGHTTP2_SESSION_SERVER_NEW $ac_have_decl
+_ACEOF
 
 fi
 
@@ -21510,8 +19953,7 @@ fi
 
 staticexe=""
 # Check whether --enable-static-exe was given.
-if test ${enable_static_exe+y}
-then :
+if test "${enable_static_exe+set}" = set; then :
   enableval=$enable_static_exe;
 fi
 
@@ -21532,8 +19974,7 @@ fi
 
 # set full static linking if requested
 # Check whether --enable-fully-static was given.
-if test ${enable_fully_static+y}
-then :
+if test "${enable_fully_static+set}" = set; then :
   enableval=$enable_fully_static;
 fi
 
@@ -21553,22 +19994,21 @@ fi
 
 # set lock checking if requested
 # Check whether --enable-lock_checks was given.
-if test ${enable_lock_checks+y}
-then :
+if test "${enable_lock_checks+set}" = set; then :
   enableval=$enable_lock_checks;
 fi
 
 if test x_$enable_lock_checks = x_yes; then
 
-printf "%s\n" "#define ENABLE_LOCK_CHECKS 1" >>confdefs.h
+$as_echo "#define ENABLE_LOCK_CHECKS 1" >>confdefs.h
 
 	CHECKLOCK_OBJ="checklocks.lo"
 
 fi
 
 
-{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for getaddrinfo" >&5
-printf %s "checking for getaddrinfo... " >&6; }
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for getaddrinfo" >&5
+$as_echo_n "checking for getaddrinfo... " >&6; }
 ac_cv_func_getaddrinfo=no
 cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 /* end confdefs.h.  */
@@ -21588,12 +20028,11 @@ int main() {
 }
 
 _ACEOF
-if ac_fn_c_try_link "$LINENO"
-then :
+if ac_fn_c_try_link "$LINENO"; then :
   ac_cv_func_getaddrinfo="yes"
 if test "$ac_cv_header_windows_h" = "yes"; then
 
-printf "%s\n" "#define USE_WINSOCK 1" >>confdefs.h
+$as_echo "#define USE_WINSOCK 1" >>confdefs.h
 
 	USE_WINSOCK="1"
 	if echo $LIBS | grep 'lws2_32' >/dev/null; then
@@ -21603,7 +20042,7 @@ printf "%s\n" "#define USE_WINSOCK 1" >>confdefs.h
 	fi
 fi
 
-else $as_nop
+else
   ORIGLIBS="$LIBS"
 LIBS="$LIBS -lws2_32"
 cat confdefs.h - <<_ACEOF >conftest.$ac_ext
@@ -21614,7 +20053,7 @@ cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 #endif
 
 int
-main (void)
+main ()
 {
 
         (void)getaddrinfo(NULL, NULL, NULL, NULL);
@@ -21624,59 +20063,62 @@ main (void)
   return 0;
 }
 _ACEOF
-if ac_fn_c_try_link "$LINENO"
-then :
+if ac_fn_c_try_link "$LINENO"; then :
 
 ac_cv_func_getaddrinfo="yes"
 
-printf "%s\n" "#define USE_WINSOCK 1" >>confdefs.h
+$as_echo "#define USE_WINSOCK 1" >>confdefs.h
 
 USE_WINSOCK="1"
 
-else $as_nop
+else
 
 ac_cv_func_getaddrinfo="no"
 LIBS="$ORIGLIBS"
 
 fi
-rm -f core conftest.err conftest.$ac_objext conftest.beam \
+rm -f core conftest.err conftest.$ac_objext \
     conftest$ac_exeext conftest.$ac_ext
 
 fi
-rm -f core conftest.err conftest.$ac_objext conftest.beam \
+rm -f core conftest.err conftest.$ac_objext \
     conftest$ac_exeext conftest.$ac_ext
 
-{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $ac_cv_func_getaddrinfo" >&5
-printf "%s\n" "$ac_cv_func_getaddrinfo" >&6; }
+{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_func_getaddrinfo" >&5
+$as_echo "$ac_cv_func_getaddrinfo" >&6; }
 if test $ac_cv_func_getaddrinfo = yes; then
 
-printf "%s\n" "#define HAVE_GETADDRINFO 1" >>confdefs.h
+$as_echo "#define HAVE_GETADDRINFO 1" >>confdefs.h
 
 fi
 
 if test "$USE_WINSOCK" = 1; then
 
-printf "%s\n" "#define UB_ON_WINDOWS 1" >>confdefs.h
+$as_echo "#define UB_ON_WINDOWS 1" >>confdefs.h
 
-	ac_fn_c_check_header_compile "$LINENO" "iphlpapi.h" "ac_cv_header_iphlpapi_h" "$ac_includes_default
+	for ac_header in iphlpapi.h
+do :
+  ac_fn_c_check_header_compile "$LINENO" "iphlpapi.h" "ac_cv_header_iphlpapi_h" "$ac_includes_default
 #include <windows.h>
 
 "
-if test "x$ac_cv_header_iphlpapi_h" = xyes
-then :
-  printf "%s\n" "#define HAVE_IPHLPAPI_H 1" >>confdefs.h
+if test "x$ac_cv_header_iphlpapi_h" = xyes; then :
+  cat >>confdefs.h <<_ACEOF
+#define HAVE_IPHLPAPI_H 1
+_ACEOF
 
 fi
+
+done
 
 	if test -n "$ac_tool_prefix"; then
   # Extract the first word of "${ac_tool_prefix}windres", so it can be a program name with args.
 set dummy ${ac_tool_prefix}windres; ac_word=$2
-{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for $ac_word" >&5
-printf %s "checking for $ac_word... " >&6; }
-if test ${ac_cv_prog_WINDRES+y}
-then :
-  printf %s "(cached) " >&6
-else $as_nop
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for $ac_word" >&5
+$as_echo_n "checking for $ac_word... " >&6; }
+if ${ac_cv_prog_WINDRES+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
   if test -n "$WINDRES"; then
   ac_cv_prog_WINDRES="$WINDRES" # Let the user override the test.
 else
@@ -21684,15 +20126,11 @@ as_save_IFS=$IFS; IFS=$PATH_SEPARATOR
 for as_dir in $PATH
 do
   IFS=$as_save_IFS
-  case $as_dir in #(((
-    '') as_dir=./ ;;
-    */) ;;
-    *) as_dir=$as_dir/ ;;
-  esac
+  test -z "$as_dir" && as_dir=.
     for ac_exec_ext in '' $ac_executable_extensions; do
-  if as_fn_executable_p "$as_dir$ac_word$ac_exec_ext"; then
+  if as_fn_executable_p "$as_dir/$ac_word$ac_exec_ext"; then
     ac_cv_prog_WINDRES="${ac_tool_prefix}windres"
-    printf "%s\n" "$as_me:${as_lineno-$LINENO}: found $as_dir$ac_word$ac_exec_ext" >&5
+    $as_echo "$as_me:${as_lineno-$LINENO}: found $as_dir/$ac_word$ac_exec_ext" >&5
     break 2
   fi
 done
@@ -21703,11 +20141,11 @@ fi
 fi
 WINDRES=$ac_cv_prog_WINDRES
 if test -n "$WINDRES"; then
-  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $WINDRES" >&5
-printf "%s\n" "$WINDRES" >&6; }
+  { $as_echo "$as_me:${as_lineno-$LINENO}: result: $WINDRES" >&5
+$as_echo "$WINDRES" >&6; }
 else
-  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: no" >&5
-printf "%s\n" "no" >&6; }
+  { $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
+$as_echo "no" >&6; }
 fi
 
 
@@ -21716,12 +20154,11 @@ if test -z "$ac_cv_prog_WINDRES"; then
   ac_ct_WINDRES=$WINDRES
   # Extract the first word of "windres", so it can be a program name with args.
 set dummy windres; ac_word=$2
-{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for $ac_word" >&5
-printf %s "checking for $ac_word... " >&6; }
-if test ${ac_cv_prog_ac_ct_WINDRES+y}
-then :
-  printf %s "(cached) " >&6
-else $as_nop
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for $ac_word" >&5
+$as_echo_n "checking for $ac_word... " >&6; }
+if ${ac_cv_prog_ac_ct_WINDRES+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
   if test -n "$ac_ct_WINDRES"; then
   ac_cv_prog_ac_ct_WINDRES="$ac_ct_WINDRES" # Let the user override the test.
 else
@@ -21729,15 +20166,11 @@ as_save_IFS=$IFS; IFS=$PATH_SEPARATOR
 for as_dir in $PATH
 do
   IFS=$as_save_IFS
-  case $as_dir in #(((
-    '') as_dir=./ ;;
-    */) ;;
-    *) as_dir=$as_dir/ ;;
-  esac
+  test -z "$as_dir" && as_dir=.
     for ac_exec_ext in '' $ac_executable_extensions; do
-  if as_fn_executable_p "$as_dir$ac_word$ac_exec_ext"; then
+  if as_fn_executable_p "$as_dir/$ac_word$ac_exec_ext"; then
     ac_cv_prog_ac_ct_WINDRES="windres"
-    printf "%s\n" "$as_me:${as_lineno-$LINENO}: found $as_dir$ac_word$ac_exec_ext" >&5
+    $as_echo "$as_me:${as_lineno-$LINENO}: found $as_dir/$ac_word$ac_exec_ext" >&5
     break 2
   fi
 done
@@ -21748,11 +20181,11 @@ fi
 fi
 ac_ct_WINDRES=$ac_cv_prog_ac_ct_WINDRES
 if test -n "$ac_ct_WINDRES"; then
-  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $ac_ct_WINDRES" >&5
-printf "%s\n" "$ac_ct_WINDRES" >&6; }
+  { $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_ct_WINDRES" >&5
+$as_echo "$ac_ct_WINDRES" >&6; }
 else
-  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: no" >&5
-printf "%s\n" "no" >&6; }
+  { $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
+$as_echo "no" >&6; }
 fi
 
   if test "x$ac_ct_WINDRES" = x; then
@@ -21760,8 +20193,8 @@ fi
   else
     case $cross_compiling:$ac_tool_warned in
 yes:)
-{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: WARNING: using cross tools not prefixed with host triplet" >&5
-printf "%s\n" "$as_me: WARNING: using cross tools not prefixed with host triplet" >&2;}
+{ $as_echo "$as_me:${as_lineno-$LINENO}: WARNING: using cross tools not prefixed with host triplet" >&5
+$as_echo "$as_me: WARNING: using cross tools not prefixed with host triplet" >&2;}
 ac_tool_warned=yes ;;
 esac
     WINDRES=$ac_ct_WINDRES
@@ -21802,8 +20235,8 @@ fi
 # check after getaddrinfo for its libraries
 
 # check ioctlsocket
-{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for ioctlsocket" >&5
-printf %s "checking for ioctlsocket... " >&6; }
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for ioctlsocket" >&5
+$as_echo_n "checking for ioctlsocket... " >&6; }
 cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 /* end confdefs.h.  */
 
@@ -21812,7 +20245,7 @@ cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 #endif
 
 int
-main (void)
+main ()
 {
 
 	(void)ioctlsocket(0, 0, NULL);
@@ -21821,41 +20254,43 @@ main (void)
   return 0;
 }
 _ACEOF
-if ac_fn_c_try_link "$LINENO"
-then :
+if ac_fn_c_try_link "$LINENO"; then :
 
-{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: yes" >&5
-printf "%s\n" "yes" >&6; }
+{ $as_echo "$as_me:${as_lineno-$LINENO}: result: yes" >&5
+$as_echo "yes" >&6; }
 
-printf "%s\n" "#define HAVE_IOCTLSOCKET 1" >>confdefs.h
+$as_echo "#define HAVE_IOCTLSOCKET 1" >>confdefs.h
 
 
-else $as_nop
-  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: no" >&5
-printf "%s\n" "no" >&6; }
+else
+  { $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
+$as_echo "no" >&6; }
 fi
-rm -f core conftest.err conftest.$ac_objext conftest.beam \
+rm -f core conftest.err conftest.$ac_objext \
     conftest$ac_exeext conftest.$ac_ext
 
 
 # see if daemon(3) exists, and if it is deprecated.
-ac_fn_c_check_func "$LINENO" "daemon" "ac_cv_func_daemon"
-if test "x$ac_cv_func_daemon" = xyes
-then :
-  printf "%s\n" "#define HAVE_DAEMON 1" >>confdefs.h
+for ac_func in daemon
+do :
+  ac_fn_c_check_func "$LINENO" "daemon" "ac_cv_func_daemon"
+if test "x$ac_cv_func_daemon" = xyes; then :
+  cat >>confdefs.h <<_ACEOF
+#define HAVE_DAEMON 1
+_ACEOF
 
 fi
+done
 
 if test $ac_cv_func_daemon = yes; then
 
 
-{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking if daemon is deprecated" >&5
-printf %s "checking if daemon is deprecated... " >&6; }
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking if daemon is deprecated" >&5
+$as_echo_n "checking if daemon is deprecated... " >&6; }
 cache=`echo daemon | sed 'y%.=/+-%___p_%'`
-if eval test \${cv_cc_deprecated_$cache+y}
-then :
-  printf %s "(cached) " >&6
-else $as_nop
+if eval \${cv_cc_deprecated_$cache+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
 
 echo '
 #include <stdlib.h>
@@ -21872,16 +20307,18 @@ rm -f conftest conftest.o conftest.c
 fi
 
 if eval "test \"`echo '$cv_cc_deprecated_'$cache`\" = yes"; then
-{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: yes" >&5
-printf "%s\n" "yes" >&6; }
+{ $as_echo "$as_me:${as_lineno-$LINENO}: result: yes" >&5
+$as_echo "yes" >&6; }
 
-printf "%s\n" "#define DEPRECATED_DAEMON 1" >>confdefs.h
+cat >>confdefs.h <<_ACEOF
+#define DEPRECATED_DAEMON 1
+_ACEOF
 
 :
 
 else
-{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: no" >&5
-printf "%s\n" "no" >&6; }
+{ $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
+$as_echo "no" >&6; }
 :
 
 fi
@@ -21895,10 +20332,11 @@ $ac_includes_default
 #endif
 
 "
-if test "x$ac_cv_member_struct_sockaddr_un_sun_len" = xyes
-then :
+if test "x$ac_cv_member_struct_sockaddr_un_sun_len" = xyes; then :
 
-printf "%s\n" "#define HAVE_STRUCT_SOCKADDR_UN_SUN_LEN 1" >>confdefs.h
+cat >>confdefs.h <<_ACEOF
+#define HAVE_STRUCT_SOCKADDR_UN_SUN_LEN 1
+_ACEOF
 
 
 fi
@@ -21938,17 +20376,18 @@ $ac_includes_default
 #endif
 
 "
-if test "x$ac_cv_member_struct_in_pktinfo_ipi_spec_dst" = xyes
-then :
+if test "x$ac_cv_member_struct_in_pktinfo_ipi_spec_dst" = xyes; then :
 
-printf "%s\n" "#define HAVE_STRUCT_IN_PKTINFO_IPI_SPEC_DST 1" >>confdefs.h
+cat >>confdefs.h <<_ACEOF
+#define HAVE_STRUCT_IN_PKTINFO_IPI_SPEC_DST 1
+_ACEOF
 
 
 fi
 
 
-{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for htobe64" >&5
-printf %s "checking for htobe64... " >&6; }
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for htobe64" >&5
+$as_echo_n "checking for htobe64... " >&6; }
 cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 /* end confdefs.h.  */
 
@@ -21961,29 +20400,28 @@ cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 #endif
 
 int
-main (void)
+main ()
 {
 unsigned long long x = htobe64(0); printf("%u", (unsigned)x);
   ;
   return 0;
 }
 _ACEOF
-if ac_fn_c_try_link "$LINENO"
-then :
-  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: yes" >&5
-printf "%s\n" "yes" >&6; }
+if ac_fn_c_try_link "$LINENO"; then :
+  { $as_echo "$as_me:${as_lineno-$LINENO}: result: yes" >&5
+$as_echo "yes" >&6; }
 
-printf "%s\n" "#define HAVE_HTOBE64 1" >>confdefs.h
+$as_echo "#define HAVE_HTOBE64 1" >>confdefs.h
 
-else $as_nop
-  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: no" >&5
-printf "%s\n" "no" >&6; }
+else
+  { $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
+$as_echo "no" >&6; }
 fi
-rm -f core conftest.err conftest.$ac_objext conftest.beam \
+rm -f core conftest.err conftest.$ac_objext \
     conftest$ac_exeext conftest.$ac_ext
 
-{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for be64toh" >&5
-printf %s "checking for be64toh... " >&6; }
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for be64toh" >&5
+$as_echo_n "checking for be64toh... " >&6; }
 cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 /* end confdefs.h.  */
 
@@ -21996,33 +20434,31 @@ cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 #endif
 
 int
-main (void)
+main ()
 {
 unsigned long long x = be64toh(0); printf("%u", (unsigned)x);
   ;
   return 0;
 }
 _ACEOF
-if ac_fn_c_try_link "$LINENO"
-then :
-  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: yes" >&5
-printf "%s\n" "yes" >&6; }
+if ac_fn_c_try_link "$LINENO"; then :
+  { $as_echo "$as_me:${as_lineno-$LINENO}: result: yes" >&5
+$as_echo "yes" >&6; }
 
-printf "%s\n" "#define HAVE_BE64TOH 1" >>confdefs.h
+$as_echo "#define HAVE_BE64TOH 1" >>confdefs.h
 
-else $as_nop
-  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: no" >&5
-printf "%s\n" "no" >&6; }
+else
+  { $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
+$as_echo "no" >&6; }
 fi
-rm -f core conftest.err conftest.$ac_objext conftest.beam \
+rm -f core conftest.err conftest.$ac_objext \
     conftest$ac_exeext conftest.$ac_ext
 
-{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for library containing setusercontext" >&5
-printf %s "checking for library containing setusercontext... " >&6; }
-if test ${ac_cv_search_setusercontext+y}
-then :
-  printf %s "(cached) " >&6
-else $as_nop
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for library containing setusercontext" >&5
+$as_echo_n "checking for library containing setusercontext... " >&6; }
+if ${ac_cv_search_setusercontext+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
   ac_func_search_save_LIBS=$LIBS
 cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 /* end confdefs.h.  */
@@ -22030,291 +20466,116 @@ cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 /* Override any GCC internal prototype to avoid an error.
    Use char because int might match the return type of a GCC
    builtin and then its argument prototype would still apply.  */
+#ifdef __cplusplus
+extern "C"
+#endif
 char setusercontext ();
 int
-main (void)
+main ()
 {
 return setusercontext ();
   ;
   return 0;
 }
 _ACEOF
-for ac_lib in '' util
-do
+for ac_lib in '' util; do
   if test -z "$ac_lib"; then
     ac_res="none required"
   else
     ac_res=-l$ac_lib
     LIBS="-l$ac_lib  $ac_func_search_save_LIBS"
   fi
-  if ac_fn_c_try_link "$LINENO"
-then :
+  if ac_fn_c_try_link "$LINENO"; then :
   ac_cv_search_setusercontext=$ac_res
 fi
-rm -f core conftest.err conftest.$ac_objext conftest.beam \
+rm -f core conftest.err conftest.$ac_objext \
     conftest$ac_exeext
-  if test ${ac_cv_search_setusercontext+y}
-then :
+  if ${ac_cv_search_setusercontext+:} false; then :
   break
 fi
 done
-if test ${ac_cv_search_setusercontext+y}
-then :
+if ${ac_cv_search_setusercontext+:} false; then :
 
-else $as_nop
+else
   ac_cv_search_setusercontext=no
 fi
 rm conftest.$ac_ext
 LIBS=$ac_func_search_save_LIBS
 fi
-{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $ac_cv_search_setusercontext" >&5
-printf "%s\n" "$ac_cv_search_setusercontext" >&6; }
+{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_search_setusercontext" >&5
+$as_echo "$ac_cv_search_setusercontext" >&6; }
 ac_res=$ac_cv_search_setusercontext
-if test "$ac_res" != no
-then :
+if test "$ac_res" != no; then :
   test "$ac_res" = "none required" || LIBS="$ac_res $LIBS"
 
 fi
 
-ac_fn_c_check_func "$LINENO" "tzset" "ac_cv_func_tzset"
-if test "x$ac_cv_func_tzset" = xyes
-then :
-  printf "%s\n" "#define HAVE_TZSET 1" >>confdefs.h
+for ac_func in tzset sigprocmask fcntl getpwnam endpwent getrlimit setrlimit setsid chroot kill chown sleep usleep random srandom recvmsg sendmsg writev socketpair glob initgroups strftime localtime_r setusercontext _beginthreadex endservent endprotoent fsync shmget accept4 getifaddrs if_nametoindex
+do :
+  as_ac_var=`$as_echo "ac_cv_func_$ac_func" | $as_tr_sh`
+ac_fn_c_check_func "$LINENO" "$ac_func" "$as_ac_var"
+if eval test \"x\$"$as_ac_var"\" = x"yes"; then :
+  cat >>confdefs.h <<_ACEOF
+#define `$as_echo "HAVE_$ac_func" | $as_tr_cpp` 1
+_ACEOF
 
 fi
-ac_fn_c_check_func "$LINENO" "sigprocmask" "ac_cv_func_sigprocmask"
-if test "x$ac_cv_func_sigprocmask" = xyes
-then :
-  printf "%s\n" "#define HAVE_SIGPROCMASK 1" >>confdefs.h
+done
 
-fi
-ac_fn_c_check_func "$LINENO" "fcntl" "ac_cv_func_fcntl"
-if test "x$ac_cv_func_fcntl" = xyes
-then :
-  printf "%s\n" "#define HAVE_FCNTL 1" >>confdefs.h
-
-fi
-ac_fn_c_check_func "$LINENO" "getpwnam" "ac_cv_func_getpwnam"
-if test "x$ac_cv_func_getpwnam" = xyes
-then :
-  printf "%s\n" "#define HAVE_GETPWNAM 1" >>confdefs.h
-
-fi
-ac_fn_c_check_func "$LINENO" "endpwent" "ac_cv_func_endpwent"
-if test "x$ac_cv_func_endpwent" = xyes
-then :
-  printf "%s\n" "#define HAVE_ENDPWENT 1" >>confdefs.h
-
-fi
-ac_fn_c_check_func "$LINENO" "getrlimit" "ac_cv_func_getrlimit"
-if test "x$ac_cv_func_getrlimit" = xyes
-then :
-  printf "%s\n" "#define HAVE_GETRLIMIT 1" >>confdefs.h
-
-fi
-ac_fn_c_check_func "$LINENO" "setrlimit" "ac_cv_func_setrlimit"
-if test "x$ac_cv_func_setrlimit" = xyes
-then :
-  printf "%s\n" "#define HAVE_SETRLIMIT 1" >>confdefs.h
-
-fi
-ac_fn_c_check_func "$LINENO" "setsid" "ac_cv_func_setsid"
-if test "x$ac_cv_func_setsid" = xyes
-then :
-  printf "%s\n" "#define HAVE_SETSID 1" >>confdefs.h
-
-fi
-ac_fn_c_check_func "$LINENO" "chroot" "ac_cv_func_chroot"
-if test "x$ac_cv_func_chroot" = xyes
-then :
-  printf "%s\n" "#define HAVE_CHROOT 1" >>confdefs.h
-
-fi
-ac_fn_c_check_func "$LINENO" "kill" "ac_cv_func_kill"
-if test "x$ac_cv_func_kill" = xyes
-then :
-  printf "%s\n" "#define HAVE_KILL 1" >>confdefs.h
-
-fi
-ac_fn_c_check_func "$LINENO" "chown" "ac_cv_func_chown"
-if test "x$ac_cv_func_chown" = xyes
-then :
-  printf "%s\n" "#define HAVE_CHOWN 1" >>confdefs.h
-
-fi
-ac_fn_c_check_func "$LINENO" "sleep" "ac_cv_func_sleep"
-if test "x$ac_cv_func_sleep" = xyes
-then :
-  printf "%s\n" "#define HAVE_SLEEP 1" >>confdefs.h
-
-fi
-ac_fn_c_check_func "$LINENO" "usleep" "ac_cv_func_usleep"
-if test "x$ac_cv_func_usleep" = xyes
-then :
-  printf "%s\n" "#define HAVE_USLEEP 1" >>confdefs.h
-
-fi
-ac_fn_c_check_func "$LINENO" "random" "ac_cv_func_random"
-if test "x$ac_cv_func_random" = xyes
-then :
-  printf "%s\n" "#define HAVE_RANDOM 1" >>confdefs.h
-
-fi
-ac_fn_c_check_func "$LINENO" "srandom" "ac_cv_func_srandom"
-if test "x$ac_cv_func_srandom" = xyes
-then :
-  printf "%s\n" "#define HAVE_SRANDOM 1" >>confdefs.h
-
-fi
-ac_fn_c_check_func "$LINENO" "recvmsg" "ac_cv_func_recvmsg"
-if test "x$ac_cv_func_recvmsg" = xyes
-then :
-  printf "%s\n" "#define HAVE_RECVMSG 1" >>confdefs.h
-
-fi
-ac_fn_c_check_func "$LINENO" "sendmsg" "ac_cv_func_sendmsg"
-if test "x$ac_cv_func_sendmsg" = xyes
-then :
-  printf "%s\n" "#define HAVE_SENDMSG 1" >>confdefs.h
-
-fi
-ac_fn_c_check_func "$LINENO" "writev" "ac_cv_func_writev"
-if test "x$ac_cv_func_writev" = xyes
-then :
-  printf "%s\n" "#define HAVE_WRITEV 1" >>confdefs.h
-
-fi
-ac_fn_c_check_func "$LINENO" "socketpair" "ac_cv_func_socketpair"
-if test "x$ac_cv_func_socketpair" = xyes
-then :
-  printf "%s\n" "#define HAVE_SOCKETPAIR 1" >>confdefs.h
-
-fi
-ac_fn_c_check_func "$LINENO" "glob" "ac_cv_func_glob"
-if test "x$ac_cv_func_glob" = xyes
-then :
-  printf "%s\n" "#define HAVE_GLOB 1" >>confdefs.h
-
-fi
-ac_fn_c_check_func "$LINENO" "initgroups" "ac_cv_func_initgroups"
-if test "x$ac_cv_func_initgroups" = xyes
-then :
-  printf "%s\n" "#define HAVE_INITGROUPS 1" >>confdefs.h
-
-fi
-ac_fn_c_check_func "$LINENO" "strftime" "ac_cv_func_strftime"
-if test "x$ac_cv_func_strftime" = xyes
-then :
-  printf "%s\n" "#define HAVE_STRFTIME 1" >>confdefs.h
-
-fi
-ac_fn_c_check_func "$LINENO" "localtime_r" "ac_cv_func_localtime_r"
-if test "x$ac_cv_func_localtime_r" = xyes
-then :
-  printf "%s\n" "#define HAVE_LOCALTIME_R 1" >>confdefs.h
-
-fi
-ac_fn_c_check_func "$LINENO" "setusercontext" "ac_cv_func_setusercontext"
-if test "x$ac_cv_func_setusercontext" = xyes
-then :
-  printf "%s\n" "#define HAVE_SETUSERCONTEXT 1" >>confdefs.h
-
-fi
-ac_fn_c_check_func "$LINENO" "_beginthreadex" "ac_cv_func__beginthreadex"
-if test "x$ac_cv_func__beginthreadex" = xyes
-then :
-  printf "%s\n" "#define HAVE__BEGINTHREADEX 1" >>confdefs.h
-
-fi
-ac_fn_c_check_func "$LINENO" "endservent" "ac_cv_func_endservent"
-if test "x$ac_cv_func_endservent" = xyes
-then :
-  printf "%s\n" "#define HAVE_ENDSERVENT 1" >>confdefs.h
-
-fi
-ac_fn_c_check_func "$LINENO" "endprotoent" "ac_cv_func_endprotoent"
-if test "x$ac_cv_func_endprotoent" = xyes
-then :
-  printf "%s\n" "#define HAVE_ENDPROTOENT 1" >>confdefs.h
-
-fi
-ac_fn_c_check_func "$LINENO" "fsync" "ac_cv_func_fsync"
-if test "x$ac_cv_func_fsync" = xyes
-then :
-  printf "%s\n" "#define HAVE_FSYNC 1" >>confdefs.h
-
-fi
-ac_fn_c_check_func "$LINENO" "shmget" "ac_cv_func_shmget"
-if test "x$ac_cv_func_shmget" = xyes
-then :
-  printf "%s\n" "#define HAVE_SHMGET 1" >>confdefs.h
-
-fi
-ac_fn_c_check_func "$LINENO" "accept4" "ac_cv_func_accept4"
-if test "x$ac_cv_func_accept4" = xyes
-then :
-  printf "%s\n" "#define HAVE_ACCEPT4 1" >>confdefs.h
-
-fi
-ac_fn_c_check_func "$LINENO" "getifaddrs" "ac_cv_func_getifaddrs"
-if test "x$ac_cv_func_getifaddrs" = xyes
-then :
-  printf "%s\n" "#define HAVE_GETIFADDRS 1" >>confdefs.h
-
-fi
-ac_fn_c_check_func "$LINENO" "if_nametoindex" "ac_cv_func_if_nametoindex"
-if test "x$ac_cv_func_if_nametoindex" = xyes
-then :
-  printf "%s\n" "#define HAVE_IF_NAMETOINDEX 1" >>confdefs.h
-
-fi
-
-
-  for ac_func in setresuid
+for ac_func in setresuid
 do :
   ac_fn_c_check_func "$LINENO" "setresuid" "ac_cv_func_setresuid"
-if test "x$ac_cv_func_setresuid" = xyes
-then :
-  printf "%s\n" "#define HAVE_SETRESUID 1" >>confdefs.h
+if test "x$ac_cv_func_setresuid" = xyes; then :
+  cat >>confdefs.h <<_ACEOF
+#define HAVE_SETRESUID 1
+_ACEOF
 
-else $as_nop
+else
+  for ac_func in setreuid
+do :
   ac_fn_c_check_func "$LINENO" "setreuid" "ac_cv_func_setreuid"
-if test "x$ac_cv_func_setreuid" = xyes
-then :
-  printf "%s\n" "#define HAVE_SETREUID 1" >>confdefs.h
+if test "x$ac_cv_func_setreuid" = xyes; then :
+  cat >>confdefs.h <<_ACEOF
+#define HAVE_SETREUID 1
+_ACEOF
 
 fi
-
-fi
-
 done
 
-  for ac_func in setresgid
+fi
+done
+
+for ac_func in setresgid
 do :
   ac_fn_c_check_func "$LINENO" "setresgid" "ac_cv_func_setresgid"
-if test "x$ac_cv_func_setresgid" = xyes
-then :
-  printf "%s\n" "#define HAVE_SETRESGID 1" >>confdefs.h
+if test "x$ac_cv_func_setresgid" = xyes; then :
+  cat >>confdefs.h <<_ACEOF
+#define HAVE_SETRESGID 1
+_ACEOF
 
-else $as_nop
+else
+  for ac_func in setregid
+do :
   ac_fn_c_check_func "$LINENO" "setregid" "ac_cv_func_setregid"
-if test "x$ac_cv_func_setregid" = xyes
-then :
-  printf "%s\n" "#define HAVE_SETREGID 1" >>confdefs.h
+if test "x$ac_cv_func_setregid" = xyes; then :
+  cat >>confdefs.h <<_ACEOF
+#define HAVE_SETREGID 1
+_ACEOF
 
 fi
-
-fi
-
 done
+
+fi
+done
+
 
 # check if setreuid en setregid fail, on MacOSX10.4(darwin8).
 if echo $host_os | grep darwin8 > /dev/null; then
 
-printf "%s\n" "#define DARWIN_BROKEN_SETREUID 1" >>confdefs.h
+$as_echo "#define DARWIN_BROKEN_SETREUID 1" >>confdefs.h
 
 fi
-ac_fn_check_decl "$LINENO" "inet_pton" "ac_cv_have_decl_inet_pton" "
+ac_fn_c_check_decl "$LINENO" "inet_pton" "ac_cv_have_decl_inet_pton" "
 $ac_includes_default
 #ifdef HAVE_NETINET_IN_H
 #include <netinet/in.h>
@@ -22336,15 +20597,17 @@ $ac_includes_default
 #include <ws2tcpip.h>
 #endif
 
-" "$ac_c_undeclared_builtin_options" "CFLAGS"
-if test "x$ac_cv_have_decl_inet_pton" = xyes
-then :
+"
+if test "x$ac_cv_have_decl_inet_pton" = xyes; then :
   ac_have_decl=1
-else $as_nop
+else
   ac_have_decl=0
 fi
-printf "%s\n" "#define HAVE_DECL_INET_PTON $ac_have_decl" >>confdefs.h
-ac_fn_check_decl "$LINENO" "inet_ntop" "ac_cv_have_decl_inet_ntop" "
+
+cat >>confdefs.h <<_ACEOF
+#define HAVE_DECL_INET_PTON $ac_have_decl
+_ACEOF
+ac_fn_c_check_decl "$LINENO" "inet_ntop" "ac_cv_have_decl_inet_ntop" "
 $ac_includes_default
 #ifdef HAVE_NETINET_IN_H
 #include <netinet/in.h>
@@ -22366,21 +20629,22 @@ $ac_includes_default
 #include <ws2tcpip.h>
 #endif
 
-" "$ac_c_undeclared_builtin_options" "CFLAGS"
-if test "x$ac_cv_have_decl_inet_ntop" = xyes
-then :
+"
+if test "x$ac_cv_have_decl_inet_ntop" = xyes; then :
   ac_have_decl=1
-else $as_nop
+else
   ac_have_decl=0
 fi
-printf "%s\n" "#define HAVE_DECL_INET_NTOP $ac_have_decl" >>confdefs.h
+
+cat >>confdefs.h <<_ACEOF
+#define HAVE_DECL_INET_NTOP $ac_have_decl
+_ACEOF
 
 ac_fn_c_check_func "$LINENO" "inet_aton" "ac_cv_func_inet_aton"
-if test "x$ac_cv_func_inet_aton" = xyes
-then :
-  printf "%s\n" "#define HAVE_INET_ATON 1" >>confdefs.h
+if test "x$ac_cv_func_inet_aton" = xyes; then :
+  $as_echo "#define HAVE_INET_ATON 1" >>confdefs.h
 
-else $as_nop
+else
   case " $LIBOBJS " in
   *" inet_aton.$ac_objext "* ) ;;
   *) LIBOBJS="$LIBOBJS inet_aton.$ac_objext"
@@ -22389,12 +20653,12 @@ esac
 
 fi
 
-ac_fn_c_check_func "$LINENO" "inet_pton" "ac_cv_func_inet_pton"
-if test "x$ac_cv_func_inet_pton" = xyes
-then :
-  printf "%s\n" "#define HAVE_INET_PTON 1" >>confdefs.h
 
-else $as_nop
+ac_fn_c_check_func "$LINENO" "inet_pton" "ac_cv_func_inet_pton"
+if test "x$ac_cv_func_inet_pton" = xyes; then :
+  $as_echo "#define HAVE_INET_PTON 1" >>confdefs.h
+
+else
   case " $LIBOBJS " in
   *" inet_pton.$ac_objext "* ) ;;
   *) LIBOBJS="$LIBOBJS inet_pton.$ac_objext"
@@ -22403,12 +20667,12 @@ esac
 
 fi
 
-ac_fn_c_check_func "$LINENO" "inet_ntop" "ac_cv_func_inet_ntop"
-if test "x$ac_cv_func_inet_ntop" = xyes
-then :
-  printf "%s\n" "#define HAVE_INET_NTOP 1" >>confdefs.h
 
-else $as_nop
+ac_fn_c_check_func "$LINENO" "inet_ntop" "ac_cv_func_inet_ntop"
+if test "x$ac_cv_func_inet_ntop" = xyes; then :
+  $as_echo "#define HAVE_INET_NTOP 1" >>confdefs.h
+
+else
   case " $LIBOBJS " in
   *" inet_ntop.$ac_objext "* ) ;;
   *) LIBOBJS="$LIBOBJS inet_ntop.$ac_objext"
@@ -22417,12 +20681,12 @@ esac
 
 fi
 
-ac_fn_c_check_func "$LINENO" "snprintf" "ac_cv_func_snprintf"
-if test "x$ac_cv_func_snprintf" = xyes
-then :
-  printf "%s\n" "#define HAVE_SNPRINTF 1" >>confdefs.h
 
-else $as_nop
+ac_fn_c_check_func "$LINENO" "snprintf" "ac_cv_func_snprintf"
+if test "x$ac_cv_func_snprintf" = xyes; then :
+  $as_echo "#define HAVE_SNPRINTF 1" >>confdefs.h
+
+else
   case " $LIBOBJS " in
   *" snprintf.$ac_objext "* ) ;;
   *) LIBOBJS="$LIBOBJS snprintf.$ac_objext"
@@ -22431,18 +20695,18 @@ esac
 
 fi
 
+
 # test if snprintf return the proper length
 if test "x$ac_cv_func_snprintf" = xyes; then
     if test c${cross_compiling} = cno; then
-	{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for correct snprintf return value" >&5
-printf %s "checking for correct snprintf return value... " >&6; }
-	if test "$cross_compiling" = yes
-then :
-  { { printf "%s\n" "$as_me:${as_lineno-$LINENO}: error: in \`$ac_pwd':" >&5
-printf "%s\n" "$as_me: error: in \`$ac_pwd':" >&2;}
+	{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for correct snprintf return value" >&5
+$as_echo_n "checking for correct snprintf return value... " >&6; }
+	if test "$cross_compiling" = yes; then :
+  { { $as_echo "$as_me:${as_lineno-$LINENO}: error: in \`$ac_pwd':" >&5
+$as_echo "$as_me: error: in \`$ac_pwd':" >&2;}
 as_fn_error $? "cannot run test program while cross compiling
 See \`config.log' for more details" "$LINENO" 5; }
-else $as_nop
+else
   cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 /* end confdefs.h.  */
 $ac_includes_default
@@ -22450,16 +20714,15 @@ $ac_includes_default
 int main(void) { return !(snprintf(NULL, 0, "test") == 4); }
 
 _ACEOF
-if ac_fn_c_try_run "$LINENO"
-then :
-  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: yes" >&5
-printf "%s\n" "yes" >&6; }
-else $as_nop
+if ac_fn_c_try_run "$LINENO"; then :
+  { $as_echo "$as_me:${as_lineno-$LINENO}: result: yes" >&5
+$as_echo "yes" >&6; }
+else
 
-		{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: no" >&5
-printf "%s\n" "no" >&6; }
+		{ $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
+$as_echo "no" >&6; }
 
-printf "%s\n" "#define SNPRINTF_RET_BROKEN /**/" >>confdefs.h
+$as_echo "#define SNPRINTF_RET_BROKEN /**/" >>confdefs.h
 
 		case " $LIBOBJS " in
   *" snprintf.$ac_objext "* ) ;;
@@ -22476,11 +20739,10 @@ fi
     fi
 fi
 ac_fn_c_check_func "$LINENO" "strlcat" "ac_cv_func_strlcat"
-if test "x$ac_cv_func_strlcat" = xyes
-then :
-  printf "%s\n" "#define HAVE_STRLCAT 1" >>confdefs.h
+if test "x$ac_cv_func_strlcat" = xyes; then :
+  $as_echo "#define HAVE_STRLCAT 1" >>confdefs.h
 
-else $as_nop
+else
   case " $LIBOBJS " in
   *" strlcat.$ac_objext "* ) ;;
   *) LIBOBJS="$LIBOBJS strlcat.$ac_objext"
@@ -22489,12 +20751,12 @@ esac
 
 fi
 
-ac_fn_c_check_func "$LINENO" "strlcpy" "ac_cv_func_strlcpy"
-if test "x$ac_cv_func_strlcpy" = xyes
-then :
-  printf "%s\n" "#define HAVE_STRLCPY 1" >>confdefs.h
 
-else $as_nop
+ac_fn_c_check_func "$LINENO" "strlcpy" "ac_cv_func_strlcpy"
+if test "x$ac_cv_func_strlcpy" = xyes; then :
+  $as_echo "#define HAVE_STRLCPY 1" >>confdefs.h
+
+else
   case " $LIBOBJS " in
   *" strlcpy.$ac_objext "* ) ;;
   *) LIBOBJS="$LIBOBJS strlcpy.$ac_objext"
@@ -22503,12 +20765,12 @@ esac
 
 fi
 
-ac_fn_c_check_func "$LINENO" "memmove" "ac_cv_func_memmove"
-if test "x$ac_cv_func_memmove" = xyes
-then :
-  printf "%s\n" "#define HAVE_MEMMOVE 1" >>confdefs.h
 
-else $as_nop
+ac_fn_c_check_func "$LINENO" "memmove" "ac_cv_func_memmove"
+if test "x$ac_cv_func_memmove" = xyes; then :
+  $as_echo "#define HAVE_MEMMOVE 1" >>confdefs.h
+
+else
   case " $LIBOBJS " in
   *" memmove.$ac_objext "* ) ;;
   *) LIBOBJS="$LIBOBJS memmove.$ac_objext"
@@ -22517,12 +20779,12 @@ esac
 
 fi
 
-ac_fn_c_check_func "$LINENO" "gmtime_r" "ac_cv_func_gmtime_r"
-if test "x$ac_cv_func_gmtime_r" = xyes
-then :
-  printf "%s\n" "#define HAVE_GMTIME_R 1" >>confdefs.h
 
-else $as_nop
+ac_fn_c_check_func "$LINENO" "gmtime_r" "ac_cv_func_gmtime_r"
+if test "x$ac_cv_func_gmtime_r" = xyes; then :
+  $as_echo "#define HAVE_GMTIME_R 1" >>confdefs.h
+
+else
   case " $LIBOBJS " in
   *" gmtime_r.$ac_objext "* ) ;;
   *) LIBOBJS="$LIBOBJS gmtime_r.$ac_objext"
@@ -22531,12 +20793,12 @@ esac
 
 fi
 
-ac_fn_c_check_func "$LINENO" "isblank" "ac_cv_func_isblank"
-if test "x$ac_cv_func_isblank" = xyes
-then :
-  printf "%s\n" "#define HAVE_ISBLANK 1" >>confdefs.h
 
-else $as_nop
+ac_fn_c_check_func "$LINENO" "isblank" "ac_cv_func_isblank"
+if test "x$ac_cv_func_isblank" = xyes; then :
+  $as_echo "#define HAVE_ISBLANK 1" >>confdefs.h
+
+else
   case " $LIBOBJS " in
   *" isblank.$ac_objext "* ) ;;
   *) LIBOBJS="$LIBOBJS isblank.$ac_objext"
@@ -22545,12 +20807,12 @@ esac
 
 fi
 
-ac_fn_c_check_func "$LINENO" "explicit_bzero" "ac_cv_func_explicit_bzero"
-if test "x$ac_cv_func_explicit_bzero" = xyes
-then :
-  printf "%s\n" "#define HAVE_EXPLICIT_BZERO 1" >>confdefs.h
 
-else $as_nop
+ac_fn_c_check_func "$LINENO" "explicit_bzero" "ac_cv_func_explicit_bzero"
+if test "x$ac_cv_func_explicit_bzero" = xyes; then :
+  $as_echo "#define HAVE_EXPLICIT_BZERO 1" >>confdefs.h
+
+else
   case " $LIBOBJS " in
   *" explicit_bzero.$ac_objext "* ) ;;
   *) LIBOBJS="$LIBOBJS explicit_bzero.$ac_objext"
@@ -22559,10 +20821,11 @@ esac
 
 fi
 
+
 LIBOBJ_WITHOUT_CTIMEARC4="$LIBOBJS"
 
-{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for reallocarray" >&5
-printf %s "checking for reallocarray... " >&6; }
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for reallocarray" >&5
+$as_echo_n "checking for reallocarray... " >&6; }
 cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 /* end confdefs.h.  */
 $ac_includes_default
@@ -22578,18 +20841,17 @@ int main(void) {
 }
 
 _ACEOF
-if ac_fn_c_try_link "$LINENO"
-then :
-  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: yes" >&5
-printf "%s\n" "yes" >&6; }
+if ac_fn_c_try_link "$LINENO"; then :
+  { $as_echo "$as_me:${as_lineno-$LINENO}: result: yes" >&5
+$as_echo "yes" >&6; }
 
-printf "%s\n" "#define HAVE_REALLOCARRAY 1" >>confdefs.h
+$as_echo "#define HAVE_REALLOCARRAY 1" >>confdefs.h
 
 
-else $as_nop
+else
 
-	{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: no" >&5
-printf "%s\n" "no" >&6; }
+	{ $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
+$as_echo "no" >&6; }
 	case " $LIBOBJS " in
   *" reallocarray.$ac_objext "* ) ;;
   *) LIBOBJS="$LIBOBJS reallocarray.$ac_objext"
@@ -22598,24 +20860,25 @@ esac
 
 
 fi
-rm -f core conftest.err conftest.$ac_objext conftest.beam \
+rm -f core conftest.err conftest.$ac_objext \
     conftest$ac_exeext conftest.$ac_ext
-ac_fn_check_decl "$LINENO" "reallocarray" "ac_cv_have_decl_reallocarray" "$ac_includes_default" "$ac_c_undeclared_builtin_options" "CFLAGS"
-if test "x$ac_cv_have_decl_reallocarray" = xyes
-then :
+ac_fn_c_check_decl "$LINENO" "reallocarray" "ac_cv_have_decl_reallocarray" "$ac_includes_default"
+if test "x$ac_cv_have_decl_reallocarray" = xyes; then :
   ac_have_decl=1
-else $as_nop
+else
   ac_have_decl=0
 fi
-printf "%s\n" "#define HAVE_DECL_REALLOCARRAY $ac_have_decl" >>confdefs.h
+
+cat >>confdefs.h <<_ACEOF
+#define HAVE_DECL_REALLOCARRAY $ac_have_decl
+_ACEOF
 
 if test "$USE_NSS" = "no"; then
 	ac_fn_c_check_func "$LINENO" "arc4random" "ac_cv_func_arc4random"
-if test "x$ac_cv_func_arc4random" = xyes
-then :
-  printf "%s\n" "#define HAVE_ARC4RANDOM 1" >>confdefs.h
+if test "x$ac_cv_func_arc4random" = xyes; then :
+  $as_echo "#define HAVE_ARC4RANDOM 1" >>confdefs.h
 
-else $as_nop
+else
   case " $LIBOBJS " in
   *" arc4random.$ac_objext "* ) ;;
   *) LIBOBJS="$LIBOBJS arc4random.$ac_objext"
@@ -22624,12 +20887,12 @@ esac
 
 fi
 
-	ac_fn_c_check_func "$LINENO" "arc4random_uniform" "ac_cv_func_arc4random_uniform"
-if test "x$ac_cv_func_arc4random_uniform" = xyes
-then :
-  printf "%s\n" "#define HAVE_ARC4RANDOM_UNIFORM 1" >>confdefs.h
 
-else $as_nop
+	ac_fn_c_check_func "$LINENO" "arc4random_uniform" "ac_cv_func_arc4random_uniform"
+if test "x$ac_cv_func_arc4random_uniform" = xyes; then :
+  $as_echo "#define HAVE_ARC4RANDOM_UNIFORM 1" >>confdefs.h
+
+else
   case " $LIBOBJS " in
   *" arc4random_uniform.$ac_objext "* ) ;;
   *) LIBOBJS="$LIBOBJS arc4random_uniform.$ac_objext"
@@ -22638,6 +20901,7 @@ esac
 
 fi
 
+
 	if test "$ac_cv_func_arc4random" = "no"; then
 		case " $LIBOBJS " in
   *" arc4_lock.$ac_objext "* ) ;;
@@ -22645,15 +20909,15 @@ fi
  ;;
 esac
 
-
-  for ac_func in getentropy
+		for ac_func in getentropy
 do :
   ac_fn_c_check_func "$LINENO" "getentropy" "ac_cv_func_getentropy"
-if test "x$ac_cv_func_getentropy" = xyes
-then :
-  printf "%s\n" "#define HAVE_GETENTROPY 1" >>confdefs.h
+if test "x$ac_cv_func_getentropy" = xyes; then :
+  cat >>confdefs.h <<_ACEOF
+#define HAVE_GETENTROPY 1
+_ACEOF
 
-else $as_nop
+else
 
 		    if test "$USE_WINSOCK" = 1; then
 			case " $LIBOBJS " in
@@ -22679,25 +20943,26 @@ esac
  ;;
 esac
 
-				       for ac_header in sys/sha2.h
+				for ac_header in sys/sha2.h
 do :
   ac_fn_c_check_header_compile "$LINENO" "sys/sha2.h" "ac_cv_header_sys_sha2_h" "$ac_includes_default
 "
-if test "x$ac_cv_header_sys_sha2_h" = xyes
-then :
-  printf "%s\n" "#define HAVE_SYS_SHA2_H 1" >>confdefs.h
+if test "x$ac_cv_header_sys_sha2_h" = xyes; then :
+  cat >>confdefs.h <<_ACEOF
+#define HAVE_SYS_SHA2_H 1
+_ACEOF
 
-else $as_nop
+else
 
-
-  for ac_func in SHA512_Update
+					for ac_func in SHA512_Update
 do :
   ac_fn_c_check_func "$LINENO" "SHA512_Update" "ac_cv_func_SHA512_Update"
-if test "x$ac_cv_func_SHA512_Update" = xyes
-then :
-  printf "%s\n" "#define HAVE_SHA512_UPDATE 1" >>confdefs.h
+if test "x$ac_cv_func_SHA512_Update" = xyes; then :
+  cat >>confdefs.h <<_ACEOF
+#define HAVE_SHA512_UPDATE 1
+_ACEOF
 
-else $as_nop
+else
 
 						case " $LIBOBJS " in
   *" sha512.$ac_objext "* ) ;;
@@ -22707,22 +20972,22 @@ esac
 
 
 fi
-
 done
+
 
 fi
 
 done
+
 				if test "$ac_cv_header_sys_sha2_h" = "yes"; then
 					# this lib needed for sha2 on solaris
 					LIBS="$LIBS -lmd"
 				fi
-				{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for library containing clock_gettime" >&5
-printf %s "checking for library containing clock_gettime... " >&6; }
-if test ${ac_cv_search_clock_gettime+y}
-then :
-  printf %s "(cached) " >&6
-else $as_nop
+				{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for library containing clock_gettime" >&5
+$as_echo_n "checking for library containing clock_gettime... " >&6; }
+if ${ac_cv_search_clock_gettime+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
   ac_func_search_save_LIBS=$LIBS
 cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 /* end confdefs.h.  */
@@ -22730,48 +20995,46 @@ cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 /* Override any GCC internal prototype to avoid an error.
    Use char because int might match the return type of a GCC
    builtin and then its argument prototype would still apply.  */
+#ifdef __cplusplus
+extern "C"
+#endif
 char clock_gettime ();
 int
-main (void)
+main ()
 {
 return clock_gettime ();
   ;
   return 0;
 }
 _ACEOF
-for ac_lib in '' rt
-do
+for ac_lib in '' rt; do
   if test -z "$ac_lib"; then
     ac_res="none required"
   else
     ac_res=-l$ac_lib
     LIBS="-l$ac_lib  $ac_func_search_save_LIBS"
   fi
-  if ac_fn_c_try_link "$LINENO"
-then :
+  if ac_fn_c_try_link "$LINENO"; then :
   ac_cv_search_clock_gettime=$ac_res
 fi
-rm -f core conftest.err conftest.$ac_objext conftest.beam \
+rm -f core conftest.err conftest.$ac_objext \
     conftest$ac_exeext
-  if test ${ac_cv_search_clock_gettime+y}
-then :
+  if ${ac_cv_search_clock_gettime+:} false; then :
   break
 fi
 done
-if test ${ac_cv_search_clock_gettime+y}
-then :
+if ${ac_cv_search_clock_gettime+:} false; then :
 
-else $as_nop
+else
   ac_cv_search_clock_gettime=no
 fi
 rm conftest.$ac_ext
 LIBS=$ac_func_search_save_LIBS
 fi
-{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $ac_cv_search_clock_gettime" >&5
-printf "%s\n" "$ac_cv_search_clock_gettime" >&6; }
+{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_search_clock_gettime" >&5
+$as_echo "$ac_cv_search_clock_gettime" >&6; }
 ac_res=$ac_cv_search_clock_gettime
-if test "$ac_res" != no
-then :
+if test "$ac_res" != no; then :
   test "$ac_res" = "none required" || LIBS="$ac_res $LIBS"
 
 fi
@@ -22792,18 +21055,18 @@ esac
  ;;
 esac
 
-
-  for ac_func in SHA512_Update
+				for ac_func in SHA512_Update
 do :
   ac_fn_c_check_func "$LINENO" "SHA512_Update" "ac_cv_func_SHA512_Update"
-if test "x$ac_cv_func_SHA512_Update" = xyes
-then :
-  printf "%s\n" "#define HAVE_SHA512_UPDATE 1" >>confdefs.h
+if test "x$ac_cv_func_SHA512_Update" = xyes; then :
+  cat >>confdefs.h <<_ACEOF
+#define HAVE_SHA512_UPDATE 1
+_ACEOF
 
-else $as_nop
+else
 
 
-printf "%s\n" "#define COMPAT_SHA512 1" >>confdefs.h
+$as_echo "#define COMPAT_SHA512 1" >>confdefs.h
 
 					case " $LIBOBJS " in
   *" sha512.$ac_objext "* ) ;;
@@ -22813,29 +21076,37 @@ esac
 
 
 fi
+done
+
+				for ac_header in sys/sysctl.h
+do :
+  ac_fn_c_check_header_compile "$LINENO" "sys/sysctl.h" "ac_cv_header_sys_sysctl_h" "$ac_includes_default
+"
+if test "x$ac_cv_header_sys_sysctl_h" = xyes; then :
+  cat >>confdefs.h <<_ACEOF
+#define HAVE_SYS_SYSCTL_H 1
+_ACEOF
+
+fi
 
 done
-				ac_fn_c_check_header_compile "$LINENO" "sys/sysctl.h" "ac_cv_header_sys_sysctl_h" "$ac_includes_default
-"
-if test "x$ac_cv_header_sys_sysctl_h" = xyes
-then :
-  printf "%s\n" "#define HAVE_SYS_SYSCTL_H 1" >>confdefs.h
+
+				for ac_func in getauxval
+do :
+  ac_fn_c_check_func "$LINENO" "getauxval" "ac_cv_func_getauxval"
+if test "x$ac_cv_func_getauxval" = xyes; then :
+  cat >>confdefs.h <<_ACEOF
+#define HAVE_GETAUXVAL 1
+_ACEOF
 
 fi
+done
 
-				ac_fn_c_check_func "$LINENO" "getauxval" "ac_cv_func_getauxval"
-if test "x$ac_cv_func_getauxval" = xyes
-then :
-  printf "%s\n" "#define HAVE_GETAUXVAL 1" >>confdefs.h
-
-fi
-
-				{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for library containing clock_gettime" >&5
-printf %s "checking for library containing clock_gettime... " >&6; }
-if test ${ac_cv_search_clock_gettime+y}
-then :
-  printf %s "(cached) " >&6
-else $as_nop
+				{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for library containing clock_gettime" >&5
+$as_echo_n "checking for library containing clock_gettime... " >&6; }
+if ${ac_cv_search_clock_gettime+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
   ac_func_search_save_LIBS=$LIBS
 cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 /* end confdefs.h.  */
@@ -22843,48 +21114,46 @@ cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 /* Override any GCC internal prototype to avoid an error.
    Use char because int might match the return type of a GCC
    builtin and then its argument prototype would still apply.  */
+#ifdef __cplusplus
+extern "C"
+#endif
 char clock_gettime ();
 int
-main (void)
+main ()
 {
 return clock_gettime ();
   ;
   return 0;
 }
 _ACEOF
-for ac_lib in '' rt
-do
+for ac_lib in '' rt; do
   if test -z "$ac_lib"; then
     ac_res="none required"
   else
     ac_res=-l$ac_lib
     LIBS="-l$ac_lib  $ac_func_search_save_LIBS"
   fi
-  if ac_fn_c_try_link "$LINENO"
-then :
+  if ac_fn_c_try_link "$LINENO"; then :
   ac_cv_search_clock_gettime=$ac_res
 fi
-rm -f core conftest.err conftest.$ac_objext conftest.beam \
+rm -f core conftest.err conftest.$ac_objext \
     conftest$ac_exeext
-  if test ${ac_cv_search_clock_gettime+y}
-then :
+  if ${ac_cv_search_clock_gettime+:} false; then :
   break
 fi
 done
-if test ${ac_cv_search_clock_gettime+y}
-then :
+if ${ac_cv_search_clock_gettime+:} false; then :
 
-else $as_nop
+else
   ac_cv_search_clock_gettime=no
 fi
 rm conftest.$ac_ext
 LIBS=$ac_func_search_save_LIBS
 fi
-{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $ac_cv_search_clock_gettime" >&5
-printf "%s\n" "$ac_cv_search_clock_gettime" >&6; }
+{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_search_clock_gettime" >&5
+$as_echo "$ac_cv_search_clock_gettime" >&6; }
 ac_res=$ac_cv_search_clock_gettime
-if test "$ac_res" != no
-then :
+if test "$ac_res" != no; then :
   test "$ac_res" = "none required" || LIBS="$ac_res $LIBS"
 
 fi
@@ -22894,18 +21163,17 @@ fi
 		    fi
 
 fi
-
 done
+
 	fi
 fi
 LIBOBJ_WITHOUT_CTIME="$LIBOBJS"
 
 ac_fn_c_check_func "$LINENO" "ctime_r" "ac_cv_func_ctime_r"
-if test "x$ac_cv_func_ctime_r" = xyes
-then :
-  printf "%s\n" "#define HAVE_CTIME_R 1" >>confdefs.h
+if test "x$ac_cv_func_ctime_r" = xyes; then :
+  $as_echo "#define HAVE_CTIME_R 1" >>confdefs.h
 
-else $as_nop
+else
   case " $LIBOBJS " in
   *" ctime_r.$ac_objext "* ) ;;
   *) LIBOBJS="$LIBOBJS ctime_r.$ac_objext"
@@ -22914,12 +21182,12 @@ esac
 
 fi
 
-ac_fn_c_check_func "$LINENO" "strsep" "ac_cv_func_strsep"
-if test "x$ac_cv_func_strsep" = xyes
-then :
-  printf "%s\n" "#define HAVE_STRSEP 1" >>confdefs.h
 
-else $as_nop
+ac_fn_c_check_func "$LINENO" "strsep" "ac_cv_func_strsep"
+if test "x$ac_cv_func_strsep" = xyes; then :
+  $as_echo "#define HAVE_STRSEP 1" >>confdefs.h
+
+else
   case " $LIBOBJS " in
   *" strsep.$ac_objext "* ) ;;
   *) LIBOBJS="$LIBOBJS strsep.$ac_objext"
@@ -22929,9 +21197,9 @@ esac
 fi
 
 
+
 # Check whether --enable-allsymbols was given.
-if test ${enable_allsymbols+y}
-then :
+if test "${enable_allsymbols+set}" = set; then :
   enableval=$enable_allsymbols;
 fi
 
@@ -22941,7 +21209,7 @@ case "$enable_allsymbols" in
 	UBSYMS=""
 	EXTRALINK="libunbound.la"
 
-printf "%s\n" "#define EXPORT_ALL_SYMBOLS 1" >>confdefs.h
+$as_echo "#define EXPORT_ALL_SYMBOLS 1" >>confdefs.h
 
 	;;
 	no|*)
@@ -22971,20 +21239,18 @@ fi
 # check for dnstap if requested
 
   # Check whether --enable-dnstap was given.
-if test ${enable_dnstap+y}
-then :
+if test "${enable_dnstap+set}" = set; then :
   enableval=$enable_dnstap; opt_dnstap=$enableval
-else $as_nop
+else
   opt_dnstap=no
 fi
 
 
 
 # Check whether --with-dnstap-socket-path was given.
-if test ${with_dnstap_socket_path+y}
-then :
+if test "${with_dnstap_socket_path+set}" = set; then :
   withval=$with_dnstap_socket_path; opt_dnstap_socket_path=$withval
-else $as_nop
+else
   opt_dnstap_socket_path="$UNBOUND_RUN_DIR/dnstap.sock"
 fi
 
@@ -22992,12 +21258,11 @@ fi
   if test "x$opt_dnstap" != "xno"; then
     # Extract the first word of "protoc-c", so it can be a program name with args.
 set dummy protoc-c; ac_word=$2
-{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for $ac_word" >&5
-printf %s "checking for $ac_word... " >&6; }
-if test ${ac_cv_path_PROTOC_C+y}
-then :
-  printf %s "(cached) " >&6
-else $as_nop
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for $ac_word" >&5
+$as_echo_n "checking for $ac_word... " >&6; }
+if ${ac_cv_path_PROTOC_C+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
   case $PROTOC_C in
   [\\/]* | ?:[\\/]*)
   ac_cv_path_PROTOC_C="$PROTOC_C" # Let the user override the test with a path.
@@ -23007,15 +21272,11 @@ else $as_nop
 for as_dir in $PATH
 do
   IFS=$as_save_IFS
-  case $as_dir in #(((
-    '') as_dir=./ ;;
-    */) ;;
-    *) as_dir=$as_dir/ ;;
-  esac
+  test -z "$as_dir" && as_dir=.
     for ac_exec_ext in '' $ac_executable_extensions; do
-  if as_fn_executable_p "$as_dir$ac_word$ac_exec_ext"; then
-    ac_cv_path_PROTOC_C="$as_dir$ac_word$ac_exec_ext"
-    printf "%s\n" "$as_me:${as_lineno-$LINENO}: found $as_dir$ac_word$ac_exec_ext" >&5
+  if as_fn_executable_p "$as_dir/$ac_word$ac_exec_ext"; then
+    ac_cv_path_PROTOC_C="$as_dir/$ac_word$ac_exec_ext"
+    $as_echo "$as_me:${as_lineno-$LINENO}: found $as_dir/$ac_word$ac_exec_ext" >&5
     break 2
   fi
 done
@@ -23027,11 +21288,11 @@ esac
 fi
 PROTOC_C=$ac_cv_path_PROTOC_C
 if test -n "$PROTOC_C"; then
-  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $PROTOC_C" >&5
-printf "%s\n" "$PROTOC_C" >&6; }
+  { $as_echo "$as_me:${as_lineno-$LINENO}: result: $PROTOC_C" >&5
+$as_echo "$PROTOC_C" >&6; }
 else
-  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: no" >&5
-printf "%s\n" "no" >&6; }
+  { $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
+$as_echo "no" >&6; }
 fi
 
 
@@ -23040,8 +21301,7 @@ fi
     fi
 
 # Check whether --with-protobuf-c was given.
-if test ${with_protobuf_c+y}
-then :
+if test "${with_protobuf_c+set}" = set; then :
   withval=$with_protobuf_c;
 	  # workaround for protobuf-c includes at old dir before protobuf-c-1.0.0
 	  if test -f $withval/include/google/protobuf-c/protobuf-c.h; then
@@ -23051,7 +21311,7 @@ then :
 	  fi
 	  LDFLAGS="$LDFLAGS -L$withval/lib"
 
-else $as_nop
+else
 
 	  # workaround for protobuf-c includes at old dir before protobuf-c-1.0.0
 	  if test -f /usr/include/google/protobuf-c/protobuf-c.h; then
@@ -23065,12 +21325,11 @@ else $as_nop
 
 fi
 
-    { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for library containing protobuf_c_message_pack" >&5
-printf %s "checking for library containing protobuf_c_message_pack... " >&6; }
-if test ${ac_cv_search_protobuf_c_message_pack+y}
-then :
-  printf %s "(cached) " >&6
-else $as_nop
+    { $as_echo "$as_me:${as_lineno-$LINENO}: checking for library containing protobuf_c_message_pack" >&5
+$as_echo_n "checking for library containing protobuf_c_message_pack... " >&6; }
+if ${ac_cv_search_protobuf_c_message_pack+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
   ac_func_search_save_LIBS=$LIBS
 cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 /* end confdefs.h.  */
@@ -23078,57 +21337,55 @@ cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 /* Override any GCC internal prototype to avoid an error.
    Use char because int might match the return type of a GCC
    builtin and then its argument prototype would still apply.  */
+#ifdef __cplusplus
+extern "C"
+#endif
 char protobuf_c_message_pack ();
 int
-main (void)
+main ()
 {
 return protobuf_c_message_pack ();
   ;
   return 0;
 }
 _ACEOF
-for ac_lib in '' protobuf-c
-do
+for ac_lib in '' protobuf-c; do
   if test -z "$ac_lib"; then
     ac_res="none required"
   else
     ac_res=-l$ac_lib
     LIBS="-l$ac_lib  $ac_func_search_save_LIBS"
   fi
-  if ac_fn_c_try_link "$LINENO"
-then :
+  if ac_fn_c_try_link "$LINENO"; then :
   ac_cv_search_protobuf_c_message_pack=$ac_res
 fi
-rm -f core conftest.err conftest.$ac_objext conftest.beam \
+rm -f core conftest.err conftest.$ac_objext \
     conftest$ac_exeext
-  if test ${ac_cv_search_protobuf_c_message_pack+y}
-then :
+  if ${ac_cv_search_protobuf_c_message_pack+:} false; then :
   break
 fi
 done
-if test ${ac_cv_search_protobuf_c_message_pack+y}
-then :
+if ${ac_cv_search_protobuf_c_message_pack+:} false; then :
 
-else $as_nop
+else
   ac_cv_search_protobuf_c_message_pack=no
 fi
 rm conftest.$ac_ext
 LIBS=$ac_func_search_save_LIBS
 fi
-{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $ac_cv_search_protobuf_c_message_pack" >&5
-printf "%s\n" "$ac_cv_search_protobuf_c_message_pack" >&6; }
+{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_search_protobuf_c_message_pack" >&5
+$as_echo "$ac_cv_search_protobuf_c_message_pack" >&6; }
 ac_res=$ac_cv_search_protobuf_c_message_pack
-if test "$ac_res" != no
-then :
+if test "$ac_res" != no; then :
   test "$ac_res" = "none required" || LIBS="$ac_res $LIBS"
 
-else $as_nop
+else
   as_fn_error $? "The protobuf-c library was not found. Please install protobuf-c!" "$LINENO" 5
 fi
 
 
 
-printf "%s\n" "#define USE_DNSTAP 1" >>confdefs.h
+$as_echo "#define USE_DNSTAP 1" >>confdefs.h
 
         ENABLE_DNSTAP=1
 
@@ -23137,7 +21394,9 @@ printf "%s\n" "#define USE_DNSTAP 1" >>confdefs.h
         hdr_dnstap_socket_path="`echo $opt_dnstap_socket_path | sed -e 's/\\\\/\\\\\\\\/g'`"
 
 
-printf "%s\n" "#define DNSTAP_SOCKET_PATH \"$hdr_dnstap_socket_path\"" >>confdefs.h
+cat >>confdefs.h <<_ACEOF
+#define DNSTAP_SOCKET_PATH "$hdr_dnstap_socket_path"
+_ACEOF
 
 	DNSTAP_SOCKET_PATH="$hdr_dnstap_socket_path"
 
@@ -23160,10 +21419,9 @@ printf "%s\n" "#define DNSTAP_SOCKET_PATH \"$hdr_dnstap_socket_path\"" >>confdef
 # check for dnscrypt if requested
 
   # Check whether --enable-dnscrypt was given.
-if test ${enable_dnscrypt+y}
-then :
+if test "${enable_dnscrypt+set}" = set; then :
   enableval=$enable_dnscrypt; opt_dnscrypt=$enableval
-else $as_nop
+else
   opt_dnscrypt=no
 fi
 
@@ -23171,20 +21429,18 @@ fi
   if test "x$opt_dnscrypt" != "xno"; then
 
 # Check whether --with-libsodium was given.
-if test ${with_libsodium+y}
-then :
+if test "${with_libsodium+set}" = set; then :
   withval=$with_libsodium;
 	CFLAGS="$CFLAGS -I$withval/include"
 	LDFLAGS="$LDFLAGS -L$withval/lib"
 
 fi
 
-    { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for library containing sodium_init" >&5
-printf %s "checking for library containing sodium_init... " >&6; }
-if test ${ac_cv_search_sodium_init+y}
-then :
-  printf %s "(cached) " >&6
-else $as_nop
+    { $as_echo "$as_me:${as_lineno-$LINENO}: checking for library containing sodium_init" >&5
+$as_echo_n "checking for library containing sodium_init... " >&6; }
+if ${ac_cv_search_sodium_init+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
   ac_func_search_save_LIBS=$LIBS
 cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 /* end confdefs.h.  */
@@ -23192,60 +21448,57 @@ cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 /* Override any GCC internal prototype to avoid an error.
    Use char because int might match the return type of a GCC
    builtin and then its argument prototype would still apply.  */
+#ifdef __cplusplus
+extern "C"
+#endif
 char sodium_init ();
 int
-main (void)
+main ()
 {
 return sodium_init ();
   ;
   return 0;
 }
 _ACEOF
-for ac_lib in '' sodium
-do
+for ac_lib in '' sodium; do
   if test -z "$ac_lib"; then
     ac_res="none required"
   else
     ac_res=-l$ac_lib
     LIBS="-l$ac_lib  $ac_func_search_save_LIBS"
   fi
-  if ac_fn_c_try_link "$LINENO"
-then :
+  if ac_fn_c_try_link "$LINENO"; then :
   ac_cv_search_sodium_init=$ac_res
 fi
-rm -f core conftest.err conftest.$ac_objext conftest.beam \
+rm -f core conftest.err conftest.$ac_objext \
     conftest$ac_exeext
-  if test ${ac_cv_search_sodium_init+y}
-then :
+  if ${ac_cv_search_sodium_init+:} false; then :
   break
 fi
 done
-if test ${ac_cv_search_sodium_init+y}
-then :
+if ${ac_cv_search_sodium_init+:} false; then :
 
-else $as_nop
+else
   ac_cv_search_sodium_init=no
 fi
 rm conftest.$ac_ext
 LIBS=$ac_func_search_save_LIBS
 fi
-{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $ac_cv_search_sodium_init" >&5
-printf "%s\n" "$ac_cv_search_sodium_init" >&6; }
+{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_search_sodium_init" >&5
+$as_echo "$ac_cv_search_sodium_init" >&6; }
 ac_res=$ac_cv_search_sodium_init
-if test "$ac_res" != no
-then :
+if test "$ac_res" != no; then :
   test "$ac_res" = "none required" || LIBS="$ac_res $LIBS"
 
-else $as_nop
+else
   as_fn_error $? "The sodium library was not found. Please install sodium!" "$LINENO" 5
 fi
 
-    { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for library containing crypto_box_curve25519xchacha20poly1305_beforenm" >&5
-printf %s "checking for library containing crypto_box_curve25519xchacha20poly1305_beforenm... " >&6; }
-if test ${ac_cv_search_crypto_box_curve25519xchacha20poly1305_beforenm+y}
-then :
-  printf %s "(cached) " >&6
-else $as_nop
+    { $as_echo "$as_me:${as_lineno-$LINENO}: checking for library containing crypto_box_curve25519xchacha20poly1305_beforenm" >&5
+$as_echo_n "checking for library containing crypto_box_curve25519xchacha20poly1305_beforenm... " >&6; }
+if ${ac_cv_search_crypto_box_curve25519xchacha20poly1305_beforenm+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
   ac_func_search_save_LIBS=$LIBS
 cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 /* end confdefs.h.  */
@@ -23253,69 +21506,66 @@ cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 /* Override any GCC internal prototype to avoid an error.
    Use char because int might match the return type of a GCC
    builtin and then its argument prototype would still apply.  */
+#ifdef __cplusplus
+extern "C"
+#endif
 char crypto_box_curve25519xchacha20poly1305_beforenm ();
 int
-main (void)
+main ()
 {
 return crypto_box_curve25519xchacha20poly1305_beforenm ();
   ;
   return 0;
 }
 _ACEOF
-for ac_lib in '' sodium
-do
+for ac_lib in '' sodium; do
   if test -z "$ac_lib"; then
     ac_res="none required"
   else
     ac_res=-l$ac_lib
     LIBS="-l$ac_lib  $ac_func_search_save_LIBS"
   fi
-  if ac_fn_c_try_link "$LINENO"
-then :
+  if ac_fn_c_try_link "$LINENO"; then :
   ac_cv_search_crypto_box_curve25519xchacha20poly1305_beforenm=$ac_res
 fi
-rm -f core conftest.err conftest.$ac_objext conftest.beam \
+rm -f core conftest.err conftest.$ac_objext \
     conftest$ac_exeext
-  if test ${ac_cv_search_crypto_box_curve25519xchacha20poly1305_beforenm+y}
-then :
+  if ${ac_cv_search_crypto_box_curve25519xchacha20poly1305_beforenm+:} false; then :
   break
 fi
 done
-if test ${ac_cv_search_crypto_box_curve25519xchacha20poly1305_beforenm+y}
-then :
+if ${ac_cv_search_crypto_box_curve25519xchacha20poly1305_beforenm+:} false; then :
 
-else $as_nop
+else
   ac_cv_search_crypto_box_curve25519xchacha20poly1305_beforenm=no
 fi
 rm conftest.$ac_ext
 LIBS=$ac_func_search_save_LIBS
 fi
-{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $ac_cv_search_crypto_box_curve25519xchacha20poly1305_beforenm" >&5
-printf "%s\n" "$ac_cv_search_crypto_box_curve25519xchacha20poly1305_beforenm" >&6; }
+{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_search_crypto_box_curve25519xchacha20poly1305_beforenm" >&5
+$as_echo "$ac_cv_search_crypto_box_curve25519xchacha20poly1305_beforenm" >&6; }
 ac_res=$ac_cv_search_crypto_box_curve25519xchacha20poly1305_beforenm
-if test "$ac_res" != no
-then :
+if test "$ac_res" != no; then :
   test "$ac_res" = "none required" || LIBS="$ac_res $LIBS"
 
             ENABLE_DNSCRYPT_XCHACHA20=1
 
 
-printf "%s\n" "#define USE_DNSCRYPT_XCHACHA20 1" >>confdefs.h
+$as_echo "#define USE_DNSCRYPT_XCHACHA20 1" >>confdefs.h
 
 
-else $as_nop
+else
 
             ENABLE_DNSCRYPT_XCHACHA20=0
 
 
 fi
 
-    { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for library containing sodium_set_misuse_handler" >&5
-printf %s "checking for library containing sodium_set_misuse_handler... " >&6; }
-if test ${ac_cv_search_sodium_set_misuse_handler+y}
-then :
-  printf %s "(cached) " >&6
-else $as_nop
+    { $as_echo "$as_me:${as_lineno-$LINENO}: checking for library containing sodium_set_misuse_handler" >&5
+$as_echo_n "checking for library containing sodium_set_misuse_handler... " >&6; }
+if ${ac_cv_search_sodium_set_misuse_handler+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
   ac_func_search_save_LIBS=$LIBS
 cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 /* end confdefs.h.  */
@@ -23323,59 +21573,57 @@ cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 /* Override any GCC internal prototype to avoid an error.
    Use char because int might match the return type of a GCC
    builtin and then its argument prototype would still apply.  */
+#ifdef __cplusplus
+extern "C"
+#endif
 char sodium_set_misuse_handler ();
 int
-main (void)
+main ()
 {
 return sodium_set_misuse_handler ();
   ;
   return 0;
 }
 _ACEOF
-for ac_lib in '' sodium
-do
+for ac_lib in '' sodium; do
   if test -z "$ac_lib"; then
     ac_res="none required"
   else
     ac_res=-l$ac_lib
     LIBS="-l$ac_lib  $ac_func_search_save_LIBS"
   fi
-  if ac_fn_c_try_link "$LINENO"
-then :
+  if ac_fn_c_try_link "$LINENO"; then :
   ac_cv_search_sodium_set_misuse_handler=$ac_res
 fi
-rm -f core conftest.err conftest.$ac_objext conftest.beam \
+rm -f core conftest.err conftest.$ac_objext \
     conftest$ac_exeext
-  if test ${ac_cv_search_sodium_set_misuse_handler+y}
-then :
+  if ${ac_cv_search_sodium_set_misuse_handler+:} false; then :
   break
 fi
 done
-if test ${ac_cv_search_sodium_set_misuse_handler+y}
-then :
+if ${ac_cv_search_sodium_set_misuse_handler+:} false; then :
 
-else $as_nop
+else
   ac_cv_search_sodium_set_misuse_handler=no
 fi
 rm conftest.$ac_ext
 LIBS=$ac_func_search_save_LIBS
 fi
-{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $ac_cv_search_sodium_set_misuse_handler" >&5
-printf "%s\n" "$ac_cv_search_sodium_set_misuse_handler" >&6; }
+{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_search_sodium_set_misuse_handler" >&5
+$as_echo "$ac_cv_search_sodium_set_misuse_handler" >&6; }
 ac_res=$ac_cv_search_sodium_set_misuse_handler
-if test "$ac_res" != no
-then :
+if test "$ac_res" != no; then :
   test "$ac_res" = "none required" || LIBS="$ac_res $LIBS"
 
 
-printf "%s\n" "#define SODIUM_MISUSE_HANDLER 1" >>confdefs.h
+$as_echo "#define SODIUM_MISUSE_HANDLER 1" >>confdefs.h
 
 
 fi
 
 
 
-printf "%s\n" "#define USE_DNSCRYPT 1" >>confdefs.h
+$as_echo "#define USE_DNSCRYPT 1" >>confdefs.h
 
         ENABLE_DNSCRYPT=1
 
@@ -23398,8 +21646,7 @@ printf "%s\n" "#define USE_DNSCRYPT 1" >>confdefs.h
 
 # check for cachedb if requested
 # Check whether --enable-cachedb was given.
-if test ${enable_cachedb+y}
-then :
+if test "${enable_cachedb+set}" = set; then :
   enableval=$enable_cachedb;
 fi
 
@@ -23408,7 +21655,7 @@ if test "$found_libhiredis" = "yes"; then enable_cachedb="yes"; fi
 case "$enable_cachedb" in
     yes)
 
-printf "%s\n" "#define USE_CACHEDB 1" >>confdefs.h
+$as_echo "#define USE_CACHEDB 1" >>confdefs.h
 
 	CACHEDB_SRC="cachedb/cachedb.c cachedb/redis.c"
 
@@ -23422,15 +21669,14 @@ esac
 
 # check for ipsecmod if requested
 # Check whether --enable-ipsecmod was given.
-if test ${enable_ipsecmod+y}
-then :
+if test "${enable_ipsecmod+set}" = set; then :
   enableval=$enable_ipsecmod;
 fi
 
 case "$enable_ipsecmod" in
 	yes)
 
-printf "%s\n" "#define USE_IPSECMOD 1" >>confdefs.h
+$as_echo "#define USE_IPSECMOD 1" >>confdefs.h
 
 		IPSECMOD_OBJ="ipsecmod.lo ipsecmod-whitelist.lo"
 
@@ -23444,15 +21690,14 @@ esac
 
 # check for ipset if requested
 # Check whether --enable-ipset was given.
-if test ${enable_ipset+y}
-then :
+if test "${enable_ipset+set}" = set; then :
   enableval=$enable_ipset;
 fi
 
 case "$enable_ipset" in
     yes)
 
-printf "%s\n" "#define USE_IPSET 1" >>confdefs.h
+$as_echo "#define USE_IPSET 1" >>confdefs.h
 
 		IPSET_SRC="ipset/ipset.c"
 
@@ -23462,16 +21707,15 @@ printf "%s\n" "#define USE_IPSET 1" >>confdefs.h
 		# mnl
 
 # Check whether --with-libmnl was given.
-if test ${with_libmnl+y}
-then :
+if test "${with_libmnl+set}" = set; then :
   withval=$with_libmnl;
-else $as_nop
+else
    withval="yes"
 fi
 
 		found_libmnl="no"
-		{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for libmnl" >&5
-printf %s "checking for libmnl... " >&6; }
+		{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for libmnl" >&5
+$as_echo_n "checking for libmnl... " >&6; }
 		if test x_$withval = x_ -o x_$withval = x_yes; then
 			withval="/usr/local /opt/local /usr/lib /usr/pkg /usr/sfw /usr"
 		fi
@@ -23482,8 +21726,8 @@ printf %s "checking for libmnl... " >&6; }
 					CPPFLAGS="$CPPFLAGS -I$dir/include"
 					LDFLAGS="$LDFLAGS -L$dir/lib"
 				fi
-				{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: found in $dir" >&5
-printf "%s\n" "found in $dir" >&6; }
+				{ $as_echo "$as_me:${as_lineno-$LINENO}: result: found in $dir" >&5
+$as_echo "found in $dir" >&6; }
 				LIBS="$LIBS -lmnl"
 				break;
 			fi
@@ -23497,15 +21741,14 @@ printf "%s\n" "found in $dir" >&6; }
 		;;
 esac
 # Check whether --enable-explicit-port-randomisation was given.
-if test ${enable_explicit_port_randomisation+y}
-then :
+if test "${enable_explicit_port_randomisation+set}" = set; then :
   enableval=$enable_explicit_port_randomisation;
 fi
 
 case "$enable_explicit_port_randomisation" in
 	no)
 
-printf "%s\n" "#define DISABLE_EXPLICIT_PORT_RANDOMISATION 1" >>confdefs.h
+$as_echo "#define DISABLE_EXPLICIT_PORT_RANDOMISATION 1" >>confdefs.h
 
 		;;
 	yes|*)
@@ -23514,15 +21757,14 @@ esac
 
 if echo "$host" | $GREP -i -e linux >/dev/null; then
 	# Check whether --enable-linux-ip-local-port-range was given.
-if test ${enable_linux_ip_local_port_range+y}
-then :
+if test "${enable_linux_ip_local_port_range+set}" = set; then :
   enableval=$enable_linux_ip_local_port_range;
 fi
 
 	case "$enable_linux_ip_local_port_range" in
 		yes)
 
-printf "%s\n" "#define USE_LINUX_IP_LOCAL_PORT_RANGE 1" >>confdefs.h
+$as_echo "#define USE_LINUX_IP_LOCAL_PORT_RANGE 1" >>confdefs.h
 
 			;;
 		no|*)
@@ -23531,8 +21773,8 @@ printf "%s\n" "#define USE_LINUX_IP_LOCAL_PORT_RANGE 1" >>confdefs.h
 fi
 
 
-{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking if ${MAKE:-make} supports $< with implicit rule in scope" >&5
-printf %s "checking if ${MAKE:-make} supports $< with implicit rule in scope... " >&6; }
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking if ${MAKE:-make} supports $< with implicit rule in scope" >&5
+$as_echo_n "checking if ${MAKE:-make} supports $< with implicit rule in scope... " >&6; }
 # on openBSD, the implicit rule make $< work.
 # on Solaris, it does not work ($? is changed sources, $^ lists dependencies).
 # gmake works.
@@ -23555,13 +21797,13 @@ ${MAKE:-make} -f conftest.make >/dev/null
 rm -f conftest.make conftest.c conftest.dir/conftest.c
 rm -rf conftest.dir
 if test ! -f conftest.lo; then
-	{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: no" >&5
-printf "%s\n" "no" >&6; }
+	{ $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
+$as_echo "no" >&6; }
 	SOURCEDETERMINE='echo "$^" | awk "-F " "{print \$$1;}" > .source'
 	SOURCEFILE='`cat .source`'
 else
-	{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: yes" >&5
-printf "%s\n" "yes" >&6; }
+	{ $as_echo "$as_me:${as_lineno-$LINENO}: result: yes" >&5
+$as_echo "yes" >&6; }
 	SOURCEDETERMINE=':'
 	SOURCEFILE='$<'
 fi
@@ -23574,8 +21816,7 @@ ALLTARGET="alltargets"
 INSTALLTARGET="install-all"
 
 # Check whether --with-libunbound-only was given.
-if test ${with_libunbound_only+y}
-then :
+if test "${with_libunbound_only+set}" = set; then :
   withval=$with_libunbound_only;
 	if test "$withval" = "yes"; then
 		ALLTARGET="lib"
@@ -23597,13 +21838,13 @@ fi
 
 
 
-  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: Stripping extension flags..." >&5
-printf "%s\n" "$as_me: Stripping extension flags..." >&6;}
+  { $as_echo "$as_me:${as_lineno-$LINENO}: Stripping extension flags..." >&5
+$as_echo "$as_me: Stripping extension flags..." >&6;}
 
   if echo $CFLAGS | grep " -D_GNU_SOURCE" >/dev/null 2>&1; then
     CFLAGS="`echo $CFLAGS | sed -e 's/ -D_GNU_SOURCE//g'`"
 
-printf "%s\n" "#define OMITTED__D_GNU_SOURCE 1" >>confdefs.h
+$as_echo "#define OMITTED__D_GNU_SOURCE 1" >>confdefs.h
 
   fi
 
@@ -23611,7 +21852,7 @@ printf "%s\n" "#define OMITTED__D_GNU_SOURCE 1" >>confdefs.h
   if echo $CFLAGS | grep " -D_BSD_SOURCE" >/dev/null 2>&1; then
     CFLAGS="`echo $CFLAGS | sed -e 's/ -D_BSD_SOURCE//g'`"
 
-printf "%s\n" "#define OMITTED__D_BSD_SOURCE 1" >>confdefs.h
+$as_echo "#define OMITTED__D_BSD_SOURCE 1" >>confdefs.h
 
   fi
 
@@ -23619,7 +21860,7 @@ printf "%s\n" "#define OMITTED__D_BSD_SOURCE 1" >>confdefs.h
   if echo $CFLAGS | grep " -D_DEFAULT_SOURCE" >/dev/null 2>&1; then
     CFLAGS="`echo $CFLAGS | sed -e 's/ -D_DEFAULT_SOURCE//g'`"
 
-printf "%s\n" "#define OMITTED__D_DEFAULT_SOURCE 1" >>confdefs.h
+$as_echo "#define OMITTED__D_DEFAULT_SOURCE 1" >>confdefs.h
 
   fi
 
@@ -23627,7 +21868,7 @@ printf "%s\n" "#define OMITTED__D_DEFAULT_SOURCE 1" >>confdefs.h
   if echo $CFLAGS | grep " -D__EXTENSIONS__" >/dev/null 2>&1; then
     CFLAGS="`echo $CFLAGS | sed -e 's/ -D__EXTENSIONS__//g'`"
 
-printf "%s\n" "#define OMITTED__D__EXTENSIONS__ 1" >>confdefs.h
+$as_echo "#define OMITTED__D__EXTENSIONS__ 1" >>confdefs.h
 
   fi
 
@@ -23635,7 +21876,7 @@ printf "%s\n" "#define OMITTED__D__EXTENSIONS__ 1" >>confdefs.h
   if echo $CFLAGS | grep " -D_POSIX_C_SOURCE=200112" >/dev/null 2>&1; then
     CFLAGS="`echo $CFLAGS | sed -e 's/ -D_POSIX_C_SOURCE=200112//g'`"
 
-printf "%s\n" "#define OMITTED__D_POSIX_C_SOURCE_200112 1" >>confdefs.h
+$as_echo "#define OMITTED__D_POSIX_C_SOURCE_200112 1" >>confdefs.h
 
   fi
 
@@ -23643,7 +21884,7 @@ printf "%s\n" "#define OMITTED__D_POSIX_C_SOURCE_200112 1" >>confdefs.h
   if echo $CFLAGS | grep " -D_XOPEN_SOURCE=600" >/dev/null 2>&1; then
     CFLAGS="`echo $CFLAGS | sed -e 's/ -D_XOPEN_SOURCE=600//g'`"
 
-printf "%s\n" "#define OMITTED__D_XOPEN_SOURCE_600 1" >>confdefs.h
+$as_echo "#define OMITTED__D_XOPEN_SOURCE_600 1" >>confdefs.h
 
   fi
 
@@ -23651,7 +21892,7 @@ printf "%s\n" "#define OMITTED__D_XOPEN_SOURCE_600 1" >>confdefs.h
   if echo $CFLAGS | grep " -D_XOPEN_SOURCE_EXTENDED=1" >/dev/null 2>&1; then
     CFLAGS="`echo $CFLAGS | sed -e 's/ -D_XOPEN_SOURCE_EXTENDED=1//g'`"
 
-printf "%s\n" "#define OMITTED__D_XOPEN_SOURCE_EXTENDED_1 1" >>confdefs.h
+$as_echo "#define OMITTED__D_XOPEN_SOURCE_EXTENDED_1 1" >>confdefs.h
 
   fi
 
@@ -23659,7 +21900,7 @@ printf "%s\n" "#define OMITTED__D_XOPEN_SOURCE_EXTENDED_1 1" >>confdefs.h
   if echo $CFLAGS | grep " -D_ALL_SOURCE" >/dev/null 2>&1; then
     CFLAGS="`echo $CFLAGS | sed -e 's/ -D_ALL_SOURCE//g'`"
 
-printf "%s\n" "#define OMITTED__D_ALL_SOURCE 1" >>confdefs.h
+$as_echo "#define OMITTED__D_ALL_SOURCE 1" >>confdefs.h
 
   fi
 
@@ -23667,7 +21908,7 @@ printf "%s\n" "#define OMITTED__D_ALL_SOURCE 1" >>confdefs.h
   if echo $CFLAGS | grep " -D_LARGEFILE_SOURCE=1" >/dev/null 2>&1; then
     CFLAGS="`echo $CFLAGS | sed -e 's/ -D_LARGEFILE_SOURCE=1//g'`"
 
-printf "%s\n" "#define OMITTED__D_LARGEFILE_SOURCE_1 1" >>confdefs.h
+$as_echo "#define OMITTED__D_LARGEFILE_SOURCE_1 1" >>confdefs.h
 
   fi
 
@@ -23680,7 +21921,9 @@ LDFLAGS=`echo "$LDFLAGS"|sed -e 's/^ *//'`
 LIBS=`echo "$LIBS"|sed -e 's/^ *//'`
 
 
-printf "%s\n" "#define MAXSYSLOGMSGLEN 10240" >>confdefs.h
+cat >>confdefs.h <<_ACEOF
+#define MAXSYSLOGMSGLEN 10240
+_ACEOF
 
 
 
@@ -23721,8 +21964,8 @@ _ACEOF
     case $ac_val in #(
     *${as_nl}*)
       case $ac_var in #(
-      *_cv_*) { printf "%s\n" "$as_me:${as_lineno-$LINENO}: WARNING: cache variable $ac_var contains a newline" >&5
-printf "%s\n" "$as_me: WARNING: cache variable $ac_var contains a newline" >&2;} ;;
+      *_cv_*) { $as_echo "$as_me:${as_lineno-$LINENO}: WARNING: cache variable $ac_var contains a newline" >&5
+$as_echo "$as_me: WARNING: cache variable $ac_var contains a newline" >&2;} ;;
       esac
       case $ac_var in #(
       _ | IFS | as_nl) ;; #(
@@ -23752,15 +21995,15 @@ printf "%s\n" "$as_me: WARNING: cache variable $ac_var contains a newline" >&2;}
      /^ac_cv_env_/b end
      t clear
      :clear
-     s/^\([^=]*\)=\(.*[{}].*\)$/test ${\1+y} || &/
+     s/^\([^=]*\)=\(.*[{}].*\)$/test "${\1+set}" = set || &/
      t end
      s/^\([^=]*\)=\(.*\)$/\1=${\1=\2}/
      :end' >>confcache
 if diff "$cache_file" confcache >/dev/null 2>&1; then :; else
   if test -w "$cache_file"; then
     if test "x$cache_file" != "x/dev/null"; then
-      { printf "%s\n" "$as_me:${as_lineno-$LINENO}: updating cache $cache_file" >&5
-printf "%s\n" "$as_me: updating cache $cache_file" >&6;}
+      { $as_echo "$as_me:${as_lineno-$LINENO}: updating cache $cache_file" >&5
+$as_echo "$as_me: updating cache $cache_file" >&6;}
       if test ! -f "$cache_file" || test -h "$cache_file"; then
 	cat confcache >"$cache_file"
       else
@@ -23774,8 +22017,8 @@ printf "%s\n" "$as_me: updating cache $cache_file" >&6;}
       fi
     fi
   else
-    { printf "%s\n" "$as_me:${as_lineno-$LINENO}: not updating unwritable cache $cache_file" >&5
-printf "%s\n" "$as_me: not updating unwritable cache $cache_file" >&6;}
+    { $as_echo "$as_me:${as_lineno-$LINENO}: not updating unwritable cache $cache_file" >&5
+$as_echo "$as_me: not updating unwritable cache $cache_file" >&6;}
   fi
 fi
 rm -f confcache
@@ -23792,7 +22035,7 @@ U=
 for ac_i in : $LIBOBJS; do test "x$ac_i" = x: && continue
   # 1. Remove the extension, and $U if already installed.
   ac_script='s/\$U\././;s/\.o$//;s/\.obj$//'
-  ac_i=`printf "%s\n" "$ac_i" | sed "$ac_script"`
+  ac_i=`$as_echo "$ac_i" | sed "$ac_script"`
   # 2. Prepend LIBOBJDIR.  When used with automake>=1.10 LIBOBJDIR
   #    will be set to the directory where LIBOBJS objects are built.
   as_fn_append ac_libobjs " \${LIBOBJDIR}$ac_i\$U.$ac_objext"
@@ -23812,8 +22055,8 @@ fi
 ac_write_fail=0
 ac_clean_files_save=$ac_clean_files
 ac_clean_files="$ac_clean_files $CONFIG_STATUS"
-{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: creating $CONFIG_STATUS" >&5
-printf "%s\n" "$as_me: creating $CONFIG_STATUS" >&6;}
+{ $as_echo "$as_me:${as_lineno-$LINENO}: creating $CONFIG_STATUS" >&5
+$as_echo "$as_me: creating $CONFIG_STATUS" >&6;}
 as_write_fail=0
 cat >$CONFIG_STATUS <<_ASEOF || as_write_fail=1
 #! $SHELL
@@ -23836,16 +22079,14 @@ cat >>$CONFIG_STATUS <<\_ASEOF || as_write_fail=1
 
 # Be more Bourne compatible
 DUALCASE=1; export DUALCASE # for MKS sh
-as_nop=:
-if test ${ZSH_VERSION+y} && (emulate sh) >/dev/null 2>&1
-then :
+if test -n "${ZSH_VERSION+set}" && (emulate sh) >/dev/null 2>&1; then :
   emulate sh
   NULLCMD=:
   # Pre-4.2 versions of Zsh do word splitting on ${1+"$@"}, which
   # is contrary to our usage.  Disable this feature.
   alias -g '${1+"$@"}'='"$@"'
   setopt NO_GLOB_SUBST
-else $as_nop
+else
   case `(set -o) 2>/dev/null` in #(
   *posix*) :
     set -o posix ;; #(
@@ -23855,46 +22096,46 @@ esac
 fi
 
 
-
-# Reset variables that may have inherited troublesome values from
-# the environment.
-
-# IFS needs to be set, to space, tab, and newline, in precisely that order.
-# (If _AS_PATH_WALK were called with IFS unset, it would have the
-# side effect of setting IFS to empty, thus disabling word splitting.)
-# Quoting is to prevent editors from complaining about space-tab.
 as_nl='
 '
 export as_nl
-IFS=" ""	$as_nl"
-
-PS1='$ '
-PS2='> '
-PS4='+ '
-
-# Ensure predictable behavior from utilities with locale-dependent output.
-LC_ALL=C
-export LC_ALL
-LANGUAGE=C
-export LANGUAGE
-
-# We cannot yet rely on "unset" to work, but we need these variables
-# to be unset--not just set to an empty or harmless value--now, to
-# avoid bugs in old shells (e.g. pre-3.0 UWIN ksh).  This construct
-# also avoids known problems related to "unset" and subshell syntax
-# in other old shells (e.g. bash 2.01 and pdksh 5.2.14).
-for as_var in BASH_ENV ENV MAIL MAILPATH CDPATH
-do eval test \${$as_var+y} \
-  && ( (unset $as_var) || exit 1) >/dev/null 2>&1 && unset $as_var || :
-done
-
-# Ensure that fds 0, 1, and 2 are open.
-if (exec 3>&0) 2>/dev/null; then :; else exec 0</dev/null; fi
-if (exec 3>&1) 2>/dev/null; then :; else exec 1>/dev/null; fi
-if (exec 3>&2)            ; then :; else exec 2>/dev/null; fi
+# Printing a long string crashes Solaris 7 /usr/bin/printf.
+as_echo='\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\'
+as_echo=$as_echo$as_echo$as_echo$as_echo$as_echo
+as_echo=$as_echo$as_echo$as_echo$as_echo$as_echo$as_echo
+# Prefer a ksh shell builtin over an external printf program on Solaris,
+# but without wasting forks for bash or zsh.
+if test -z "$BASH_VERSION$ZSH_VERSION" \
+    && (test "X`print -r -- $as_echo`" = "X$as_echo") 2>/dev/null; then
+  as_echo='print -r --'
+  as_echo_n='print -rn --'
+elif (test "X`printf %s $as_echo`" = "X$as_echo") 2>/dev/null; then
+  as_echo='printf %s\n'
+  as_echo_n='printf %s'
+else
+  if test "X`(/usr/ucb/echo -n -n $as_echo) 2>/dev/null`" = "X-n $as_echo"; then
+    as_echo_body='eval /usr/ucb/echo -n "$1$as_nl"'
+    as_echo_n='/usr/ucb/echo -n'
+  else
+    as_echo_body='eval expr "X$1" : "X\\(.*\\)"'
+    as_echo_n_body='eval
+      arg=$1;
+      case $arg in #(
+      *"$as_nl"*)
+	expr "X$arg" : "X\\(.*\\)$as_nl";
+	arg=`expr "X$arg" : ".*$as_nl\\(.*\\)"`;;
+      esac;
+      expr "X$arg" : "X\\(.*\\)" | tr -d "$as_nl"
+    '
+    export as_echo_n_body
+    as_echo_n='sh -c $as_echo_n_body as_echo'
+  fi
+  export as_echo_body
+  as_echo='sh -c $as_echo_body as_echo'
+fi
 
 # The user is always right.
-if ${PATH_SEPARATOR+false} :; then
+if test "${PATH_SEPARATOR+set}" != set; then
   PATH_SEPARATOR=:
   (PATH='/bin;/bin'; FPATH=$PATH; sh -c :) >/dev/null 2>&1 && {
     (PATH='/bin:/bin'; FPATH=$PATH; sh -c :) >/dev/null 2>&1 ||
@@ -23902,6 +22143,13 @@ if ${PATH_SEPARATOR+false} :; then
   }
 fi
 
+
+# IFS
+# We need space, tab and new line, in precisely that order.  Quoting is
+# there to prevent editors from complaining about space-tab.
+# (If _AS_PATH_WALK were called with IFS unset, it would disable word
+# splitting by setting IFS to empty value.)
+IFS=" ""	$as_nl"
 
 # Find who we are.  Look in the path if we contain no directory separator.
 as_myself=
@@ -23911,12 +22159,8 @@ case $0 in #((
 for as_dir in $PATH
 do
   IFS=$as_save_IFS
-  case $as_dir in #(((
-    '') as_dir=./ ;;
-    */) ;;
-    *) as_dir=$as_dir/ ;;
-  esac
-    test -r "$as_dir$0" && as_myself=$as_dir$0 && break
+  test -z "$as_dir" && as_dir=.
+    test -r "$as_dir/$0" && as_myself=$as_dir/$0 && break
   done
 IFS=$as_save_IFS
 
@@ -23928,10 +22172,30 @@ if test "x$as_myself" = x; then
   as_myself=$0
 fi
 if test ! -f "$as_myself"; then
-  printf "%s\n" "$as_myself: error: cannot find myself; rerun with an absolute file name" >&2
+  $as_echo "$as_myself: error: cannot find myself; rerun with an absolute file name" >&2
   exit 1
 fi
 
+# Unset variables that we do not need and which cause bugs (e.g. in
+# pre-3.0 UWIN ksh).  But do not cause bugs in bash 2.01; the "|| exit 1"
+# suppresses any "Segmentation fault" message there.  '((' could
+# trigger a bug in pdksh 5.2.14.
+for as_var in BASH_ENV ENV MAIL MAILPATH
+do eval test x\${$as_var+set} = xset \
+  && ( (unset $as_var) || exit 1) >/dev/null 2>&1 && unset $as_var || :
+done
+PS1='$ '
+PS2='> '
+PS4='+ '
+
+# NLS nuisances.
+LC_ALL=C
+export LC_ALL
+LANGUAGE=C
+export LANGUAGE
+
+# CDPATH.
+(unset CDPATH) >/dev/null 2>&1 && unset CDPATH
 
 
 # as_fn_error STATUS ERROR [LINENO LOG_FD]
@@ -23944,12 +22208,11 @@ as_fn_error ()
   as_status=$1; test $as_status -eq 0 && as_status=1
   if test "$4"; then
     as_lineno=${as_lineno-"$3"} as_lineno_stack=as_lineno_stack=$as_lineno_stack
-    printf "%s\n" "$as_me:${as_lineno-$LINENO}: error: $2" >&$4
+    $as_echo "$as_me:${as_lineno-$LINENO}: error: $2" >&$4
   fi
-  printf "%s\n" "$as_me: error: $2" >&2
+  $as_echo "$as_me: error: $2" >&2
   as_fn_exit $as_status
 } # as_fn_error
-
 
 
 # as_fn_set_status STATUS
@@ -23978,20 +22241,18 @@ as_fn_unset ()
   { eval $1=; unset $1;}
 }
 as_unset=as_fn_unset
-
 # as_fn_append VAR VALUE
 # ----------------------
 # Append the text in VALUE to the end of the definition contained in VAR. Take
 # advantage of any shell optimizations that allow amortized linear growth over
 # repeated appends, instead of the typical quadratic growth present in naive
 # implementations.
-if (eval "as_var=1; as_var+=2; test x\$as_var = x12") 2>/dev/null
-then :
+if (eval "as_var=1; as_var+=2; test x\$as_var = x12") 2>/dev/null; then :
   eval 'as_fn_append ()
   {
     eval $1+=\$2
   }'
-else $as_nop
+else
   as_fn_append ()
   {
     eval $1=\$$1\$2
@@ -24003,13 +22264,12 @@ fi # as_fn_append
 # Perform arithmetic evaluation on the ARGs, and store the result in the
 # global $as_val. Take advantage of shells that can avoid forks. The arguments
 # must be portable across $(()) and expr.
-if (eval "test \$(( 1 + 1 )) = 2") 2>/dev/null
-then :
+if (eval "test \$(( 1 + 1 )) = 2") 2>/dev/null; then :
   eval 'as_fn_arith ()
   {
     as_val=$(( $* ))
   }'
-else $as_nop
+else
   as_fn_arith ()
   {
     as_val=`expr "$@" || test $? -eq 1`
@@ -24040,7 +22300,7 @@ as_me=`$as_basename -- "$0" ||
 $as_expr X/"$0" : '.*/\([^/][^/]*\)/*$' \| \
 	 X"$0" : 'X\(//\)$' \| \
 	 X"$0" : 'X\(/\)' \| . 2>/dev/null ||
-printf "%s\n" X/"$0" |
+$as_echo X/"$0" |
     sed '/^.*\/\([^/][^/]*\)\/*$/{
 	    s//\1/
 	    q
@@ -24062,10 +22322,6 @@ as_cr_Letters=$as_cr_letters$as_cr_LETTERS
 as_cr_digits='0123456789'
 as_cr_alnum=$as_cr_Letters$as_cr_digits
 
-
-# Determine whether it's possible to make 'echo' print without a newline.
-# These variables are no longer used directly by Autoconf, but are AC_SUBSTed
-# for compatibility with existing Makefiles.
 ECHO_C= ECHO_N= ECHO_T=
 case `echo -n x` in #(((((
 -n*)
@@ -24078,12 +22334,6 @@ case `echo -n x` in #(((((
 *)
   ECHO_N='-n';;
 esac
-
-# For backward compatibility with old third-party macros, we provide
-# the shell variables $as_echo and $as_echo_n.  New code should use
-# AS_ECHO(["message"]) and AS_ECHO_N(["message"]), respectively.
-as_echo='printf %s\n'
-as_echo_n='printf %s'
 
 rm -f conf$$ conf$$.exe conf$$.file
 if test -d conf$$.dir; then
@@ -24126,7 +22376,7 @@ as_fn_mkdir_p ()
     as_dirs=
     while :; do
       case $as_dir in #(
-      *\'*) as_qdir=`printf "%s\n" "$as_dir" | sed "s/'/'\\\\\\\\''/g"`;; #'(
+      *\'*) as_qdir=`$as_echo "$as_dir" | sed "s/'/'\\\\\\\\''/g"`;; #'(
       *) as_qdir=$as_dir;;
       esac
       as_dirs="'$as_qdir' $as_dirs"
@@ -24135,7 +22385,7 @@ $as_expr X"$as_dir" : 'X\(.*[^/]\)//*[^/][^/]*/*$' \| \
 	 X"$as_dir" : 'X\(//\)[^/]' \| \
 	 X"$as_dir" : 'X\(//\)$' \| \
 	 X"$as_dir" : 'X\(/\)' \| . 2>/dev/null ||
-printf "%s\n" X"$as_dir" |
+$as_echo X"$as_dir" |
     sed '/^X\(.*[^/]\)\/\/*[^/][^/]*\/*$/{
 	    s//\1/
 	    q
@@ -24260,16 +22510,14 @@ $config_commands
 Report bugs to <unbound-bugs@nlnetlabs.nl or https://github.com/NLnetLabs/unbound/issues>."
 
 _ACEOF
-ac_cs_config=`printf "%s\n" "$ac_configure_args" | sed "$ac_safe_unquote"`
-ac_cs_config_escaped=`printf "%s\n" "$ac_cs_config" | sed "s/^ //; s/'/'\\\\\\\\''/g"`
 cat >>$CONFIG_STATUS <<_ACEOF || ac_write_fail=1
-ac_cs_config='$ac_cs_config_escaped'
+ac_cs_config="`$as_echo "$ac_configure_args" | sed 's/^ //; s/[\\""\`\$]/\\\\&/g'`"
 ac_cs_version="\\
 unbound config.status 1.15.1
 configured by $0, generated by GNU Autoconf 2.69,
   with options \\"\$ac_cs_config\\"
 
-Copyright (C) 2021 Free Software Foundation, Inc.
+Copyright (C) 2012 Free Software Foundation, Inc.
 This config.status script is free software; the Free Software Foundation
 gives unlimited permission to copy, distribute and modify it."
 
@@ -24307,15 +22555,15 @@ do
   -recheck | --recheck | --rechec | --reche | --rech | --rec | --re | --r)
     ac_cs_recheck=: ;;
   --version | --versio | --versi | --vers | --ver | --ve | --v | -V )
-    printf "%s\n" "$ac_cs_version"; exit ;;
+    $as_echo "$ac_cs_version"; exit ;;
   --config | --confi | --conf | --con | --co | --c )
-    printf "%s\n" "$ac_cs_config"; exit ;;
+    $as_echo "$ac_cs_config"; exit ;;
   --debug | --debu | --deb | --de | --d | -d )
     debug=: ;;
   --file | --fil | --fi | --f )
     $ac_shift
     case $ac_optarg in
-    *\'*) ac_optarg=`printf "%s\n" "$ac_optarg" | sed "s/'/'\\\\\\\\''/g"` ;;
+    *\'*) ac_optarg=`$as_echo "$ac_optarg" | sed "s/'/'\\\\\\\\''/g"` ;;
     '') as_fn_error $? "missing file argument" ;;
     esac
     as_fn_append CONFIG_FILES " '$ac_optarg'"
@@ -24323,7 +22571,7 @@ do
   --header | --heade | --head | --hea )
     $ac_shift
     case $ac_optarg in
-    *\'*) ac_optarg=`printf "%s\n" "$ac_optarg" | sed "s/'/'\\\\\\\\''/g"` ;;
+    *\'*) ac_optarg=`$as_echo "$ac_optarg" | sed "s/'/'\\\\\\\\''/g"` ;;
     esac
     as_fn_append CONFIG_HEADERS " '$ac_optarg'"
     ac_need_defaults=false;;
@@ -24332,7 +22580,7 @@ do
     as_fn_error $? "ambiguous option: \`$1'
 Try \`$0 --help' for more information.";;
   --help | --hel | -h )
-    printf "%s\n" "$ac_cs_usage"; exit ;;
+    $as_echo "$ac_cs_usage"; exit ;;
   -q | -quiet | --quiet | --quie | --qui | --qu | --q \
   | -silent | --silent | --silen | --sile | --sil | --si | --s)
     ac_cs_silent=: ;;
@@ -24360,7 +22608,7 @@ cat >>$CONFIG_STATUS <<_ACEOF || ac_write_fail=1
 if \$ac_cs_recheck; then
   set X $SHELL '$0' $ac_configure_args \$ac_configure_extra_args --no-create --no-recursion
   shift
-  \printf "%s\n" "running CONFIG_SHELL=$SHELL \$*" >&6
+  \$as_echo "running CONFIG_SHELL=$SHELL \$*" >&6
   CONFIG_SHELL='$SHELL'
   export CONFIG_SHELL
   exec "\$@"
@@ -24374,7 +22622,7 @@ exec 5>>config.log
   sed 'h;s/./-/g;s/^.../## /;s/...$/ ##/;p;x;p;x' <<_ASBOX
 ## Running $as_me. ##
 _ASBOX
-  printf "%s\n" "$ac_log"
+  $as_echo "$ac_log"
 } >&5
 
 _ACEOF
@@ -24704,9 +22952,9 @@ done
 # We use the long form for the default assignment because of an extremely
 # bizarre bug on SunOS 4.1.3.
 if $ac_need_defaults; then
-  test ${CONFIG_FILES+y} || CONFIG_FILES=$config_files
-  test ${CONFIG_HEADERS+y} || CONFIG_HEADERS=$config_headers
-  test ${CONFIG_COMMANDS+y} || CONFIG_COMMANDS=$config_commands
+  test "${CONFIG_FILES+set}" = set || CONFIG_FILES=$config_files
+  test "${CONFIG_HEADERS+set}" = set || CONFIG_HEADERS=$config_headers
+  test "${CONFIG_COMMANDS+set}" = set || CONFIG_COMMANDS=$config_commands
 fi
 
 # Have a temporary directory for convenience.  Make it in the build tree
@@ -25042,7 +23290,7 @@ do
 	   esac ||
 	   as_fn_error 1 "cannot find input file: \`$ac_f'" "$LINENO" 5;;
       esac
-      case $ac_f in *\'*) ac_f=`printf "%s\n" "$ac_f" | sed "s/'/'\\\\\\\\''/g"`;; esac
+      case $ac_f in *\'*) ac_f=`$as_echo "$ac_f" | sed "s/'/'\\\\\\\\''/g"`;; esac
       as_fn_append ac_file_inputs " '$ac_f'"
     done
 
@@ -25050,17 +23298,17 @@ do
     # use $as_me), people would be surprised to read:
     #    /* config.h.  Generated by config.status.  */
     configure_input='Generated from '`
-	  printf "%s\n" "$*" | sed 's|^[^:]*/||;s|:[^:]*/|, |g'
+	  $as_echo "$*" | sed 's|^[^:]*/||;s|:[^:]*/|, |g'
 	`' by configure.'
     if test x"$ac_file" != x-; then
       configure_input="$ac_file.  $configure_input"
-      { printf "%s\n" "$as_me:${as_lineno-$LINENO}: creating $ac_file" >&5
-printf "%s\n" "$as_me: creating $ac_file" >&6;}
+      { $as_echo "$as_me:${as_lineno-$LINENO}: creating $ac_file" >&5
+$as_echo "$as_me: creating $ac_file" >&6;}
     fi
     # Neutralize special characters interpreted by sed in replacement strings.
     case $configure_input in #(
     *\&* | *\|* | *\\* )
-       ac_sed_conf_input=`printf "%s\n" "$configure_input" |
+       ac_sed_conf_input=`$as_echo "$configure_input" |
        sed 's/[\\\\&|]/\\\\&/g'`;; #(
     *) ac_sed_conf_input=$configure_input;;
     esac
@@ -25077,7 +23325,7 @@ $as_expr X"$ac_file" : 'X\(.*[^/]\)//*[^/][^/]*/*$' \| \
 	 X"$ac_file" : 'X\(//\)[^/]' \| \
 	 X"$ac_file" : 'X\(//\)$' \| \
 	 X"$ac_file" : 'X\(/\)' \| . 2>/dev/null ||
-printf "%s\n" X"$ac_file" |
+$as_echo X"$ac_file" |
     sed '/^X\(.*[^/]\)\/\/*[^/][^/]*\/*$/{
 	    s//\1/
 	    q
@@ -25101,9 +23349,9 @@ printf "%s\n" X"$ac_file" |
 case "$ac_dir" in
 .) ac_dir_suffix= ac_top_builddir_sub=. ac_top_build_prefix= ;;
 *)
-  ac_dir_suffix=/`printf "%s\n" "$ac_dir" | sed 's|^\.[\\/]||'`
+  ac_dir_suffix=/`$as_echo "$ac_dir" | sed 's|^\.[\\/]||'`
   # A ".." for each directory in $ac_dir_suffix.
-  ac_top_builddir_sub=`printf "%s\n" "$ac_dir_suffix" | sed 's|/[^\\/]*|/..|g;s|/||'`
+  ac_top_builddir_sub=`$as_echo "$ac_dir_suffix" | sed 's|/[^\\/]*|/..|g;s|/||'`
   case $ac_top_builddir_sub in
   "") ac_top_builddir_sub=. ac_top_build_prefix= ;;
   *)  ac_top_build_prefix=$ac_top_builddir_sub/ ;;
@@ -25156,8 +23404,8 @@ ac_sed_dataroot='
 case `eval "sed -n \"\$ac_sed_dataroot\" $ac_file_inputs"` in
 *datarootdir*) ac_datarootdir_seen=yes;;
 *@datadir@*|*@docdir@*|*@infodir@*|*@localedir@*|*@mandir@*)
-  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: WARNING: $ac_file_inputs seems to ignore the --datarootdir setting" >&5
-printf "%s\n" "$as_me: WARNING: $ac_file_inputs seems to ignore the --datarootdir setting" >&2;}
+  { $as_echo "$as_me:${as_lineno-$LINENO}: WARNING: $ac_file_inputs seems to ignore the --datarootdir setting" >&5
+$as_echo "$as_me: WARNING: $ac_file_inputs seems to ignore the --datarootdir setting" >&2;}
 _ACEOF
 cat >>$CONFIG_STATUS <<_ACEOF || ac_write_fail=1
   ac_datarootdir_hack='
@@ -25199,9 +23447,9 @@ test -z "$ac_datarootdir_hack$ac_datarootdir_seen" &&
   { ac_out=`sed -n '/\${datarootdir}/p' "$ac_tmp/out"`; test -n "$ac_out"; } &&
   { ac_out=`sed -n '/^[	 ]*datarootdir[	 ]*:*=/p' \
       "$ac_tmp/out"`; test -z "$ac_out"; } &&
-  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: WARNING: $ac_file contains a reference to the variable \`datarootdir'
+  { $as_echo "$as_me:${as_lineno-$LINENO}: WARNING: $ac_file contains a reference to the variable \`datarootdir'
 which seems to be undefined.  Please make sure it is defined" >&5
-printf "%s\n" "$as_me: WARNING: $ac_file contains a reference to the variable \`datarootdir'
+$as_echo "$as_me: WARNING: $ac_file contains a reference to the variable \`datarootdir'
 which seems to be undefined.  Please make sure it is defined" >&2;}
 
   rm -f "$ac_tmp/stdin"
@@ -25217,27 +23465,27 @@ which seems to be undefined.  Please make sure it is defined" >&2;}
   #
   if test x"$ac_file" != x-; then
     {
-      printf "%s\n" "/* $configure_input  */" >&1 \
+      $as_echo "/* $configure_input  */" \
       && eval '$AWK -f "$ac_tmp/defines.awk"' "$ac_file_inputs"
     } >"$ac_tmp/config.h" \
       || as_fn_error $? "could not create $ac_file" "$LINENO" 5
     if diff "$ac_file" "$ac_tmp/config.h" >/dev/null 2>&1; then
-      { printf "%s\n" "$as_me:${as_lineno-$LINENO}: $ac_file is unchanged" >&5
-printf "%s\n" "$as_me: $ac_file is unchanged" >&6;}
+      { $as_echo "$as_me:${as_lineno-$LINENO}: $ac_file is unchanged" >&5
+$as_echo "$as_me: $ac_file is unchanged" >&6;}
     else
       rm -f "$ac_file"
       mv "$ac_tmp/config.h" "$ac_file" \
 	|| as_fn_error $? "could not create $ac_file" "$LINENO" 5
     fi
   else
-    printf "%s\n" "/* $configure_input  */" >&1 \
+    $as_echo "/* $configure_input  */" \
       && eval '$AWK -f "$ac_tmp/defines.awk"' "$ac_file_inputs" \
       || as_fn_error $? "could not create -" "$LINENO" 5
   fi
  ;;
 
-  :C)  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: executing $ac_file commands" >&5
-printf "%s\n" "$as_me: executing $ac_file commands" >&6;}
+  :C)  { $as_echo "$as_me:${as_lineno-$LINENO}: executing $ac_file commands" >&5
+$as_echo "$as_me: executing $ac_file commands" >&6;}
  ;;
   esac
 
@@ -25771,7 +24019,6 @@ _LT_EOF
   esac
 
 
-
 ltmain=$ac_aux_dir/ltmain.sh
 
 
@@ -25828,8 +24075,7 @@ if test "$no_create" != yes; then
   $ac_cs_success || as_fn_exit 1
 fi
 if test -n "$ac_unrecognized_opts" && test "$enable_option_checking" != no; then
-  { printf "%s\n" "$as_me:${as_lineno-$LINENO}: WARNING: unrecognized options: $ac_unrecognized_opts" >&5
-printf "%s\n" "$as_me: WARNING: unrecognized options: $ac_unrecognized_opts" >&2;}
+  { $as_echo "$as_me:${as_lineno-$LINENO}: WARNING: unrecognized options: $ac_unrecognized_opts" >&5
+$as_echo "$as_me: WARNING: unrecognized options: $ac_unrecognized_opts" >&2;}
 fi
-
 

--- a/configure.ac
+++ b/configure.ac
@@ -906,7 +906,7 @@ else
 	AC_MSG_RESULT([no])
 fi
 AC_CHECK_HEADERS([openssl/conf.h openssl/engine.h openssl/bn.h openssl/dh.h openssl/dsa.h openssl/rsa.h openssl/core_names.h openssl/param_build.h],,, [AC_INCLUDES_DEFAULT])
-AC_CHECK_FUNCS([OPENSSL_config EVP_sha1 EVP_sha256 EVP_sha512 FIPS_mode EVP_MD_CTX_new OpenSSL_add_all_digests OPENSSL_init_crypto EVP_cleanup ENGINE_cleanup ERR_load_crypto_strings CRYPTO_cleanup_all_ex_data ERR_free_strings RAND_cleanup DSA_SIG_set0 EVP_dss1 EVP_DigestVerify EVP_aes_256_cbc EVP_EncryptInit_ex HMAC_Init_ex CRYPTO_THREADID_set_callback EVP_MAC_CTX_set_params OSSL_PARAM_BLD_new BIO_set_callback_ex])
+AC_CHECK_FUNCS([OPENSSL_config EVP_sha1 EVP_sha256 EVP_sha512 FIPS_mode EVP_default_properties_is_fips_enabled EVP_MD_CTX_new OpenSSL_add_all_digests OPENSSL_init_crypto EVP_cleanup ENGINE_cleanup ERR_load_crypto_strings CRYPTO_cleanup_all_ex_data ERR_free_strings RAND_cleanup DSA_SIG_set0 EVP_dss1 EVP_DigestVerify EVP_aes_256_cbc EVP_EncryptInit_ex HMAC_Init_ex CRYPTO_THREADID_set_callback EVP_MAC_CTX_set_params OSSL_PARAM_BLD_new BIO_set_callback_ex])
 
 # these check_funcs need -lssl
 BAKLIBS="$LIBS"


### PR DESCRIPTION
Both crypto functions are not allowed by FIPS 140-3. Use openssl 3.0
function to check FIPS mode presence and use it to make those algorithms
unsupported.

Would allow flawless fallback to insecure results for ED25519, ED448 and also SHA-1 algorithms.