### PR TITLE
Allow using system certificates not only on Windows

### DIFF
--- a/util/config_file.c
+++ b/util/config_file.c
@@ -546,6 +546,7 @@ int config_set_option(struct config_file* cfg, const char* opt,
 	else S_STR("ssl-cert-bundle:", tls_cert_bundle)
 	else S_STR("tls-cert-bundle:", tls_cert_bundle)
 	else S_YNO("tls-win-cert:", tls_win_cert)
+	else S_YNO("tls-system-cert:", tls_win_cert)
 	else S_STRLIST("additional-ssl-port:", tls_additional_port)
 	else S_STRLIST("additional-tls-port:", tls_additional_port)
 	else S_STRLIST("tls-additional-ports:", tls_additional_port)

--- a/util/net_help.c
+++ b/util/net_help.c
@@ -1271,7 +1271,13 @@ void* connect_sslctx_create(char* key, char* pem, char* verifypem, int wincert)
 			}
 		}
 #else
-		(void)wincert;
+		if(wincert) {
+			if(!SSL_CTX_set_default_verify_paths(ctx)) {
+				log_crypto_err("error in default_verify_paths");
+				SSL_CTX_free(ctx);
+				return NULL;
+			}
+		}
 #endif
 		SSL_CTX_set_verify(ctx, SSL_VERIFY_PEER, NULL);
 	}


### PR DESCRIPTION
OpenSSL has a way to load default file. That file might contain usable
certificates to verify common connections. Allow similar trust as on
windows and leave it on openssl package to provide sane defaults.

Also provide use-system-cert alias, because it is not windows specific
anymore.