### PR TITLE
Avoid treat normal hosts as unresponsive servers

### DIFF
--- a/services/cache/infra.c
+++ b/services/cache/infra.c
@@ -721,21 +721,20 @@ infra_get_lame_rtt(struct infra_cache* infra,
 			else	*rtt = USEFUL_SERVER_TOP_TIMEOUT-1000;
 		}
 	}
+	/* expired entry */
 	if(timenow > host->ttl) {
-		/* expired entry */
+		lock_rw_unlock(&e->lock);
+
 		/* see if this can be a re-probe of an unresponsive server */
 		/* minus 1000 because that is outside of the RTTBAND, so
 		 * blacklisted servers stay blacklisted if this is chosen */
-		if(host->rtt.rto >= USEFUL_SERVER_TOP_TIMEOUT ||
-			infra->infra_keep_probing) {
-			lock_rw_unlock(&e->lock);
+		if(host->rtt.rto >= USEFUL_SERVER_TOP_TIMEOUT) {
 			*rtt = USEFUL_SERVER_TOP_TIMEOUT-1000;
 			*lame = 0;
 			*dnsseclame = 0;
 			*reclame = 0;
 			return 1;
 		}
-		lock_rw_unlock(&e->lock);
 		return 0;
 	}
 	/* check lameness first */


### PR DESCRIPTION
This is a fix for issue #713

When infra-keep-probing is on, all hosts with expired entries were treated as
unresponsive servers and thus causing problems (see #713).

This commit change that, so that normal hosts with expired entries are treated
as unknown servers.