### PR TITLE
Fix startup failure on Windows 8.1 due to unsupported IPV6_USER_MTU socket option being set

### DIFF
--- a/services/listen_dnsport.c
+++ b/services/listen_dnsport.c
@@ -511,12 +511,14 @@ create_udp_sock(int family, int socktype, struct sockaddr* addr,
 		 * instead which is writable; IPV6_MTU is readonly there. */
 		if (setsockopt(s, IPPROTO_IPV6, IPV6_USER_MTU,
 			(void*)&mtu, (socklen_t)sizeof(mtu)) < 0) {
-			log_err("setsockopt(..., IPV6_USER_MTU, ...) failed: %s",
-				wsa_strerror(WSAGetLastError()));
-			sock_close(s);
-			*noproto = 0;
-			*inuse = 0;
-			return -1;
+			if (WSAGetLastError() != WSAENOPROTOOPT) {
+				log_err("setsockopt(..., IPV6_USER_MTU, ...) failed: %s",
+					wsa_strerror(WSAGetLastError()));
+				sock_close(s);
+				*noproto = 0;
+				*inuse = 0;
+				return -1;
+			}
 		}
 #   endif /* USE_WINSOCK */
 # endif /* IPv6 MTU */


### PR DESCRIPTION
Newer mingw-w64 (starting from 8.0.1) introduces support for `IPV6_USER_MTU` socket option [1], which is not supported on Windows 8.1 and older [2]. As there is no way to avoid this socket option from being picked at compile time when targeting older versions of Windows, check for `setsockopt(..., IPV6_USER_MTU, ...)` failures at runtime in order to avoid startup failure on those versions of Windows where the `IPV6_USER_MTU` socket option is unsupported.

Fixes #729

[1] : mirror/mingw-w64@e30bff4
[2] : `WSAGetLastError()` returns `WSAENOPROTOOPT` (`Bad protocol option`) error code

See also:
https://sourceforge.net/p/uftp-multicast/discussion/general/thread/257f3c21/
https://stackoverflow.com/questions/49982697/