### PR TITLE
Support python modules on Windows for MinGW-w64.

### DIFF
--- a/acx_python.m4
+++ b/acx_python.m4
@@ -70,8 +70,13 @@ AC_DEFUN([AC_PYTHON_DEVEL],[
         #
         AC_MSG_CHECKING([for Python library path])
         if test -z "$PYTHON_LDFLAGS"; then
+            if test $on_mingw = "yes"; then
+                PYTHON_LDFLAGS=`$PYTHON -c "from $sysconfig_module import *; \
+                        print('-L'+get_config_var('LIBDIR')+' -L'+get_config_var('LIBDEST')+' '+get_config_var('LIBPYTHON')+'.dll');"`
+            else
                 PYTHON_LDFLAGS=`$PYTHON -c "from $sysconfig_module import *; \
                         print('-L'+get_config_var('LIBDIR')+' -L'+get_config_var('LIBDEST')+' '+get_config_var('BLDLIBRARY'));"`
+            fi
         fi
         AC_MSG_RESULT([$PYTHON_LDFLAGS])
         AC_SUBST([PYTHON_LDFLAGS])

--- a/configure.ac
+++ b/configure.ac
@@ -569,6 +569,10 @@ else
 	fi
 fi
 
+if test "$on_mingw" = "yes"; then
+	LIBS="$LIBS -lntdll"
+fi
+
 # check windows threads (we use them, not pthreads, on windows).
 if test "$on_mingw" = "yes"; then
 # check windows threads


### PR DESCRIPTION
Function fcntl() isn't supported on Windows (even by MSVC), but luckily Unbound uses only F_GETFL which can be emulated using NtQueryInformationFile from ntdll.dll. Changes are in /libunbound/python/file_py3.i and /configure.ac.

Also, MinGW's (or rather MSYS') version of python-devel doesn't have a libpython*.a library returned in sysconfig.get_config_var('BLDLIBRARY'). Instead it has a *.dll.a file, e.g. for my python-devel 3.10.6-1 it's "libpython3.10.dll.a" instead of "libpython3.10.a" returned in "BLDLIBRARY" ("-L. -lpython3.10"). Changes are in /acx_python.m4. Making a copy named "libpython3.10.a" also works.
I'm attaching a full output of sysconfig.get_config_vars() in case someone knows or wants to try and find a better solution.
[sysconfig.get_config_vars.txt](https://github.com/NLnetLabs/unbound/files/9438558/sysconfig.get_config_vars.txt). In this output, paths that begin with C:/Users/PP/ and C:/msys64/ (or /c/Users/PP and /c/msys64/) are mine, all others aren't.