### PR TITLE
WIP: Sha1 runtime unittest

### DIFF
--- a/testcode/unitmain.c
+++ b/testcode/unitmain.c
@@ -863,8 +863,12 @@ main(int argc, char* argv[])
 {
 	checklock_start();
 	log_init(NULL, 0, NULL);
-	if(argc != 1) {
-		printf("usage: %s\n", argv[0]);
+	if (argc == 2 && strcmp(argv[1], "-v") == 0) {
+		verbosity = VERB_ALGO;
+	}
+	if(argc != 1 && verbosity != VERB_ALGO) {
+		printf("usage: [-v] %s\n", argv[0]);
+		printf("-v\tprint verbose logs.\n");
 		printf("\tperforms unit tests.\n");
 		return 1;
 	}

--- a/testcode/unitverify.c
+++ b/testcode/unitverify.c
@@ -193,10 +193,12 @@ verifytest_rrset(struct module_env* env, struct val_env* ve,
 		printf("verify outcome is: %s %s\n", sec_status_to_string(sec),
 			reason?reason:"");
 	}
-	if(should_be_bogus(rrset, qinfo)) {
-		unit_assert(sec == sec_status_bogus);
-	} else {
-		unit_assert(sec == sec_status_secure);
+	if (sec != sec_status_indeterminate) {
+		if(should_be_bogus(rrset, qinfo)) {
+			unit_assert(sec == sec_status_bogus);
+		} else {
+			unit_assert(sec == sec_status_secure);
+		}
 	}
 }
 

--- a/validator/val_secalgo.c
+++ b/validator/val_secalgo.c
@@ -702,16 +702,19 @@ digest_ctx_free(EVP_MD_CTX* ctx, EVP_PKEY *evp_key,
 static enum sec_status
 digest_error_status(const char *str)
 {
-	unsigned long e = ERR_get_error();
+	enum sec_status r = sec_status_unchecked;
+	unsigned long e;
+	while ((e = ERR_get_error()) != 0) {
 #ifdef EVP_R_INVALID_DIGEST
-	if (ERR_GET_LIB(e) == ERR_LIB_EVP &&
-		ERR_GET_REASON(e) == EVP_R_INVALID_DIGEST) {
-		log_crypto_verbose(VERB_ALGO, str, e);
-		return sec_status_indeterminate;
-	}
+		if (ERR_GET_LIB(e) == ERR_LIB_EVP &&
+			ERR_GET_REASON(e) == EVP_R_INVALID_DIGEST) {
+			log_crypto_verbose(VERB_ALGO, str, e);
+			r = sec_status_indeterminate;
+		} else
 #endif
-	log_crypto_verbose(VERB_QUERY, str, e);
-	return sec_status_unchecked;
+		log_crypto_verbose(VERB_QUERY, str, e);
+	}
+	return r;
 }
 
 /**

--- a/validator/val_sigcrypt.c
+++ b/validator/val_sigcrypt.c
@@ -440,8 +440,8 @@ void algo_needs_init_dnskey_add(struct algo_needs* n,
 		algo = (uint8_t)dnskey_get_algo(dnskey, i);
 		if(!dnskey_algo_id_is_supported((int)algo))
 			continue;
-		if(n->needs[algo] == 0) {
-			n->needs[algo] = 1;
+		if(n->needs[algo] == ALG_NEED_SECURE) {
+			n->needs[algo] = ALG_NEED_WAITING;
 			sigalg[total] = algo;
 			total++;
 		}
@@ -455,11 +455,11 @@ void algo_needs_init_list(struct algo_needs* n, uint8_t* sigalg)
 	uint8_t algo;
 	size_t total = 0;
 
-	memset(n->needs, 0, sizeof(uint8_t)*ALGO_NEEDS_MAX);
+	memset(n->needs, 0, sizeof(n->needs));
 	while( (algo=*sigalg++) != 0) {
 		log_assert(dnskey_algo_id_is_supported((int)algo));
-		log_assert(n->needs[algo] == 0);
-		n->needs[algo] = 1;
+		log_assert(n->needs[algo] == ALG_NEED_SECURE);
+		n->needs[algo] = ALG_NEED_WAITING;
 		total++;
 	}
 	n->num = total;
@@ -472,7 +472,7 @@ void algo_needs_init_ds(struct algo_needs* n, struct ub_packed_rrset_key* ds,
 	size_t i, total = 0;
 	size_t num = rrset_get_count(ds);
 
-	memset(n->needs, 0, sizeof(uint8_t)*ALGO_NEEDS_MAX);
+	memset(n->needs, 0, sizeof(n->needs));
 	for(i=0; i<num; i++) {
 		if(ds_get_digest_algo(ds, i) != fav_ds_algo)
 			continue;
@@ -480,8 +480,8 @@ void algo_needs_init_ds(struct algo_needs* n, struct ub_packed_rrset_key* ds,
 		if(!dnskey_algo_id_is_supported((int)algo))
 			continue;
 		log_assert(algo != 0); /* we do not support 0 and is EOS */
-		if(n->needs[algo] == 0) {
-			n->needs[algo] = 1;
+		if(n->needs[algo] == ALG_NEED_SECURE) {
+			n->needs[algo] = ALG_NEED_WAITING;
 			sigalg[total] = algo;		
 			total++;
 		}
@@ -492,8 +492,8 @@ void algo_needs_init_ds(struct algo_needs* n, struct ub_packed_rrset_key* ds,
 
 int algo_needs_set_secure(struct algo_needs* n, uint8_t algo)
 {
-	if(n->needs[algo]) {
-		n->needs[algo] = 0;
+	if(n->needs[algo] >= ALG_NEED_WAITING) {
+		n->needs[algo] = ALG_NEED_SECURE;
 		n->num --;
 		if(n->num == 0) /* done! */
 			return 1;
@@ -501,9 +501,16 @@ int algo_needs_set_secure(struct algo_needs* n, uint8_t algo)
 	return 0;
 }
 
+static void algo_needs_set_indeterminate(struct algo_needs* n, uint8_t algo)
+{
+	if(n->needs[algo] == ALG_NEED_WAITING)
+		n->needs[algo] = ALG_NEED_INDETERMINATE;
+}
+
 void algo_needs_set_bogus(struct algo_needs* n, uint8_t algo)
 {
-	if(n->needs[algo]) n->needs[algo] = 2; /* need it, but bogus */
+	if(n->needs[algo] >= ALG_NEED_WAITING)
+		n->needs[algo] = ALG_NEED_BOGUS; /* need it, but bogus */
 }
 
 size_t algo_needs_num_missing(struct algo_needs* n)
@@ -518,13 +525,26 @@ int algo_needs_missing(struct algo_needs* n)
 	 * check the first missing algo - report that;
 	 * or return 0 */
 	for(i=0; i<ALGO_NEEDS_MAX; i++) {
-		if(n->needs[i] == 2)
+		if(n->needs[i] == ALG_NEED_BOGUS)
 			return 0;
-		if(n->needs[i] == 1 && miss == -1)
+		if(n->needs[i] == ALG_NEED_WAITING && miss == -1)
 			miss = i;
 	}
 	if(miss != -1) return miss;
 	return 0;
+}
+
+static size_t algo_needs_num_indeterminate(struct algo_needs* n)
+{
+	int i, num = 0;
+	/* report number of indeterminate results if not bogus */
+	for(i=0; i<ALGO_NEEDS_MAX; i++) {
+		if(n->needs[i] == ALG_NEED_BOGUS)
+			return 0;
+		if(n->needs[i] == ALG_NEED_INDETERMINATE)
+			num++;
+	}
+	return num;
 }
 
 /**
@@ -648,6 +668,9 @@ dnskeyset_verify_rrset(struct module_env* env, struct val_env* ve,
 			else if(algo_needs_set_secure(&needs,
 				(uint8_t)rrset_get_sig_algo(rrset, i)))
 				return sec; /* done! */
+		} else if(sec == sec_status_indeterminate) {
+			algo_needs_set_indeterminate(&needs,
+				(uint8_t)rrset_get_sig_algo(rrset, i));
 		} else if(sigalg && sec == sec_status_bogus) {
 			algo_needs_set_bogus(&needs,
 				(uint8_t)rrset_get_sig_algo(rrset, i));
@@ -658,6 +681,11 @@ dnskeyset_verify_rrset(struct module_env* env, struct val_env* ve,
 			"no valid signatures for %d algorithms",
 			(int)algo_needs_num_missing(&needs));
 		algo_needs_reason(env, alg, reason, "no signatures");
+	} else if (sigalg && (num=algo_needs_num_indeterminate(&needs)) > 0) {
+		verbose(VERB_ALGO, "rrset failed to verify: "
+			"indeterminate signatures for %d algorithms",
+			(int)num);
+		return sec_status_indeterminate;
 	} else {
 		verbose(VERB_ALGO, "rrset failed to verify: "
 			"no valid signatures");

--- a/validator/val_sigcrypt.h
+++ b/validator/val_sigcrypt.h
@@ -57,14 +57,19 @@ struct sldns_buffer;
 /** number of entries in algorithm needs array */
 #define ALGO_NEEDS_MAX 256
 
+enum algo_needs_types {
+	ALG_NEED_SECURE = 0, /*< not marked */
+	ALG_NEED_WAITING, /*< marked 'necessary but not yet fulfilled' */
+	ALG_NEED_INDETERMINATE,
+	ALG_NEED_BOGUS,   /*< marked bogus */
+};
+
 /**
  * Storage for algorithm needs.  DNSKEY algorithms.
  */
 struct algo_needs {
 	/** the algorithms (8-bit) with each a number.
-	 * 0: not marked.
-	 * 1: marked 'necessary but not yet fulfilled'
-	 * 2: marked bogus.
+	 * contains enum algo_needs_types values.
 	 * Indexed by algorithm number.
 	 */
 	uint8_t needs[ALGO_NEEDS_MAX];


### PR DESCRIPTION
These changes complements PR #660, which added some support into unbound for runtime disabled SHA1 validation. Depending on setting in crypto policy and resulting codes in crypto library, it either considers signature indeterminate. That is roughly equivalent to insecure, but we have some signatures present and no proof about missing DS record.

This fixes unittest to pass on RHEL9, but rpl tests do not yet pass.