### PR TITLE
Added new static zone type block_a to suppress all A queries for specific zones

### DIFF
--- a/doc/example.conf.in
+++ b/doc/example.conf.in
@@ -810,6 +810,8 @@ server:
 	# o always_transparent, always_refuse, always_nxdomain, always_nodata,
 	#   always_deny resolve in that way but ignore local data for
 	#   that name
+	# o block_a resolves all records normally but returns
+	#   NODATA for A queries and ignores local data for that name
 	# o always_null returns 0.0.0.0 or ::0 for any name in the zone.
 	# o noview breaks out of that view towards global local-zones.
 	#

--- a/doc/unbound.conf.5.in
+++ b/doc/unbound.conf.5.in
@@ -1391,10 +1391,10 @@ address space are not validated.  This is usually required whenever
 Configure a local zone. The type determines the answer to give if
 there is no match from local\-data. The types are deny, refuse, static,
 transparent, redirect, nodefault, typetransparent, inform, inform_deny,
-inform_redirect, always_transparent, always_refuse, always_nxdomain, always_null, noview,
-and are explained below. After that the default settings are listed. Use
-local\-data: to enter data into the local zone. Answers for local zones
-are authoritative DNS answers. By default the zones are class IN.
+inform_redirect, always_transparent, block_a, always_refuse, always_nxdomain,
+always_null, noview, and are explained below. After that the default settings
+are listed. Use local\-data: to enter data into the local zone. Answers for
+local zones are authoritative DNS answers. By default the zones are class IN.
 .IP
 If you need more complicated authoritative data, with referrals, wildcards,
 CNAME/DNAME support, or DNSSEC authoritative service, setup a stub\-zone for
@@ -1468,6 +1468,12 @@ Ie. answer queries with fixed data and also log the machines that ask.
 .TP 10
 \h'5'\fIalways_transparent\fR
 Like transparent, but ignores local data and resolves normally.
+.TP 10
+\h'5'\fIblock_a\fR
+Like transparent, but ignores local data and resolves normally all query
+types excluding A. For A queries it unconditionally returns NODATA.
+Useful in cases when there is a need to explicitly force all apps to use
+IPv6 protocol and avoid any queries to IPv4.
 .TP 10
 \h'5'\fIalways_refuse\fR
 Like refuse, but ignores local data and refuses the query.

--- a/services/localzone.c
+++ b/services/localzone.c
@@ -1603,7 +1603,7 @@ local_zone_does_not_cover(struct local_zone* z, struct query_info* qinfo,
 	struct local_data key;
 	struct local_data* ld = NULL;
 	struct local_rrset* lr = NULL;
-	if(z->type == local_zone_always_transparent)
+	if(z->type == local_zone_always_transparent || z->type == local_zone_block_a)
 		return 1;
 	if(z->type != local_zone_transparent
 		&& z->type != local_zone_typetransparent
@@ -1679,6 +1679,16 @@ local_zones_zone_answer(struct local_zone* z, struct module_env* env,
 	} else if(lz_type == local_zone_typetransparent
 		|| lz_type == local_zone_always_transparent) {
 		/* no NODATA or NXDOMAINS for this zone type */
+		return 0;
+	} else if(lz_type == local_zone_block_a) {
+		// Return NODATA for all A queries
+		if(qinfo->qtype == LDNS_RR_TYPE_A) {
+			local_error_encode(qinfo, env, edns, repinfo, buf, temp,
+				LDNS_RCODE_NOERROR, (LDNS_RCODE_NOERROR|BIT_AA),
+				LDNS_EDE_NONE, NULL);
+				return 1;
+		}
+
 		return 0;
 	} else if(lz_type == local_zone_always_null) {
 		/* 0.0.0.0 or ::0 or noerror/nodata for this zone type,
@@ -1846,7 +1856,8 @@ local_zones_answer(struct local_zones* zones, struct module_env* env,
 		if(z && (lzt == local_zone_transparent ||
 			lzt == local_zone_typetransparent ||
 			lzt == local_zone_inform ||
-			lzt == local_zone_always_transparent) &&
+			lzt == local_zone_always_transparent ||
+			lzt == local_zone_block_a) &&
 			local_zone_does_not_cover(z, qinfo, labs)) {
 			lock_rw_unlock(&z->lock);
 			z = NULL;
@@ -1894,6 +1905,7 @@ local_zones_answer(struct local_zones* zones, struct module_env* env,
 
 	if(lzt != local_zone_always_refuse
 		&& lzt != local_zone_always_transparent
+		&& lzt != local_zone_block_a
 		&& lzt != local_zone_always_nxdomain
 		&& lzt != local_zone_always_nodata
 		&& lzt != local_zone_always_deny
@@ -1924,6 +1936,7 @@ const char* local_zone_type2str(enum localzone_type t)
 		case local_zone_inform_deny: return "inform_deny";
 		case local_zone_inform_redirect: return "inform_redirect";
 		case local_zone_always_transparent: return "always_transparent";
+		case local_zone_block_a: return "block_a";
 		case local_zone_always_refuse: return "always_refuse";
 		case local_zone_always_nxdomain: return "always_nxdomain";
 		case local_zone_always_nodata: return "always_nodata";
@@ -1958,6 +1971,8 @@ int local_zone_str2type(const char* type, enum localzone_type* t)
 		*t = local_zone_inform_redirect;
 	else if(strcmp(type, "always_transparent") == 0)
 		*t = local_zone_always_transparent;
+	else if(strcmp(type, "block_a") == 0)
+		*t = local_zone_block_a;
 	else if(strcmp(type, "always_refuse") == 0)
 		*t = local_zone_always_refuse;
 	else if(strcmp(type, "always_nxdomain") == 0)

--- a/services/localzone.h
+++ b/services/localzone.h
@@ -88,6 +88,8 @@ enum localzone_type {
 	local_zone_inform_redirect,
 	/** resolve normally, even when there is local data */	
 	local_zone_always_transparent,
+	/** resolve normally, even when there is local data but return NODATA for A queries */
+	local_zone_block_a,
 	/** answer with error, even when there is local data */	
 	local_zone_always_refuse,
 	/** answer with nxdomain, even when there is local data */

--- a/util/configparser.y
+++ b/util/configparser.y
@@ -2206,6 +2206,7 @@ server_local_zone: VAR_LOCAL_ZONE STRING_ARG STRING_ARG
 		   strcmp($3, "transparent")!=0 && strcmp($3, "nodefault")!=0
 		   && strcmp($3, "typetransparent")!=0
 		   && strcmp($3, "always_transparent")!=0
+		   && strcmp($3, "block_a")!=0
 		   && strcmp($3, "always_refuse")!=0
 		   && strcmp($3, "always_nxdomain")!=0
 		   && strcmp($3, "always_nodata")!=0
@@ -2218,7 +2219,7 @@ server_local_zone: VAR_LOCAL_ZONE STRING_ARG STRING_ARG
 			yyerror("local-zone type: expected static, deny, "
 				"refuse, redirect, transparent, "
 				"typetransparent, inform, inform_deny, "
-				"inform_redirect, always_transparent, "
+				"inform_redirect, always_transparent, block_a,"
 				"always_refuse, always_nxdomain, "
 				"always_nodata, always_deny, always_null, "
 				"noview, nodefault or ipset");


### PR DESCRIPTION
Hello!

I hope you're doing great. May I kindly ask to review my proposal to add new type of static zones?

Let me start from the beginning to explain reasons of adding such capability.

IPv6 deployment is one the the relatively hot trends nowadays and it's finally (after 27 years) getting traction due to clear business demands in many countries.

There are multiple vectors behind and I would like to mention few of them:
- Prohibitive cost of IPv4 address space ($40+ USD per IP address)
- Cost of NAT/CGNAT gateways
- General complexity of IPv4 networks 

Considering all these facts I decided to speed up deployment of IPv6 for my home network and my labs and switched it into "IPv6 only mode". 

Unfortunately, pretty large number of services still have no IPv6 addresses but it can be easily addressed with NAT64 gateway and custom DNS running DNS64. 

So I've deployed NAT64 based on TAYGA and Unbound and most of the services just worked perfectly fine without any issues.

The main blocker level issue I faced with Signal messenger. They have really nice support for IPv6 but due to issues in NodeJS / Electron even if IPv6 / AAAA records exists it tries to contact IPv4 address from A record. 

So the only way to fix Signal was to suppress A records completely and keep IPv6 records only. I've created static zone and hardcoded all their IPv6 addresses and it fixed it.

Unfortunately, such approach is not flexible and very unreliable. So I've tried to find way to suppress only A records and keep everything else as-is from their own DNS server.

That's how this implementation was born.

I've mostly copied implementation of transparent-always with very small alterations. I may be wrong in some corner cases and I appreciate careful review for it.

With this patch I have following configuration entries in my Unbound:
```
local-zone: "chat.signal.org." block_a
local-zone: "cdn.signal.org."  block_a
local-zone: "cdn2.signal.org." block_a
local-zone: "cdsi.signal.org." block_a
local-zone: "storage.signal.org." block_a
```

In future this capability may be helpful to test that specific domain can run in IPv6 only mode. 

As future project I think it may be good idea to add global flag which completely blocks A queries from clients like you have for ANY query.

Thank you!