### PR TITLE
Improve Windows NSIS installer script (setup.nsi)

### DIFF
--- a/winrc/setup.nsi
+++ b/winrc/setup.nsi
@@ -78,9 +78,17 @@ section "Root anchor - DNSSEC" SectionRootKey
 sectionEnd
 
 section "-hidden.postinstall"
-	# stop unbound service to allow file replacement
-	IfFileExists "$INSTDIR\unbound-service-remove.exe" 0 +2
-	nsExec::ExecToLog '"$INSTDIR\unbound-service-remove.exe" stop'
+	# if Unbund is already installed, ask to stop it to allow file replacement
+	IfFileExists "$INSTDIR\unbound-service-remove.exe" 0 next_label
+	MessageBox MB_YESNO "Should Unbound be stopped to permit the update ?" /SD IDYES IDNO false_label # defaults to yes on silent installations
+		nsExec::ExecToLog '"$INSTDIR\unbound-service-remove.exe" stop'
+		Sleep 1000
+		Goto next_label
+	false_label:
+		SetDetailsView show
+		DetailPrint "Update aborted"
+		Abort
+	next_label:
 	# copy files
 	SetRegView 64
 	setOutPath $INSTDIR

--- a/winrc/setup.nsi
+++ b/winrc/setup.nsi
@@ -78,6 +78,9 @@ section "Root anchor - DNSSEC" SectionRootKey
 sectionEnd
 
 section "-hidden.postinstall"
+	# stop unbound service to allow file replacement
+	IfFileExists "$INSTDIR\unbound-service-remove.exe" 0 +2
+	nsExec::ExecToLog '"$INSTDIR\unbound-service-remove.exe" stop'
 	# copy files
 	SetRegView 64
 	setOutPath $INSTDIR
@@ -134,6 +137,7 @@ section "-hidden.postinstall"
 
 	# register uninstaller
 	WriteRegStr HKLM "Software\Microsoft\Windows\CurrentVersion\Uninstall\Unbound" "DisplayName" "Unbound"
+	WriteRegStr HKLM "Software\Microsoft\Windows\CurrentVersion\Uninstall\Unbound" "DisplayVersion" "${VERSION}"
 	WriteRegStr HKLM "Software\Microsoft\Windows\CurrentVersion\Uninstall\Unbound" "UninstallString" "$\"$INSTDIR\uninst.exe$\""
 	WriteRegStr HKLM "Software\Microsoft\Windows\CurrentVersion\Uninstall\Unbound" "QuietUninstallString" "$\"$INSTDIR\uninst.exe$\" /S"
 	WriteRegDWORD HKLM "Software\Microsoft\Windows\CurrentVersion\Uninstall\Unbound" "NoModify" "1"

--- a/winrc/setup.nsi
+++ b/winrc/setup.nsi
@@ -80,14 +80,12 @@ sectionEnd
 section "-hidden.postinstall"
 	# if Unbund is already installed, ask to stop it to allow file replacement
 	IfFileExists "$INSTDIR\unbound-service-remove.exe" 0 next_label
-	MessageBox MB_YESNO "Should Unbound be stopped to permit the update ?" /SD IDYES IDNO false_label # defaults to yes on silent installations
+	MessageBox MB_YESNO "Unbound is already installed! Would you like to stop the service to continue with the update?" /SD IDYES IDNO false_label # defaults to yes on silent installations
 		nsExec::ExecToLog '"$INSTDIR\unbound-service-remove.exe" stop'
 		Sleep 1000
 		Goto next_label
 	false_label:
-		SetDetailsView show
-		DetailPrint "Update aborted"
-		Abort
+		Quit
 	next_label:
 	# copy files
 	SetRegView 64


### PR DESCRIPTION
Two improvements of installer script :
1. avoid error message when Unbound is running,
2. add "DisplayVersion" in registry thus Windows package manager (Winget) can handle Unbound.

**1. Avoid error message :**

When Unbound is already installed and running, when the installer is used to update Unbund, it displays an error message :

![error](https://user-images.githubusercontent.com/45879018/213291186-58f9e720-0fab-489d-a41f-2368efbb0334.png)

In order to avoid this message, I suggest a modification to stop Unbound service if already installed.


**2. Adding "DisplayVersion" in registry :**

Winget use uninstall parameters in Windows registry to get program versions to be able to compare installed version and last available version to propose update. Without this parameter, Winget can't handle Unbound updates :

![version](https://user-images.githubusercontent.com/45879018/213294196-ad9c968e-9446-40cc-b9ae-f5f0fd76b2b4.png)

This parameter is also used to show program versions in the Windows remove program menu.

I suggest adding this parameter in the installer script.