### PR TITLE
unbound: fix no-cache feature

### DIFF
--- a/services/mesh.c
+++ b/services/mesh.c
@@ -63,6 +63,7 @@
 #include "util/data/dname.h"
 #include "respip/respip.h"
 #include "services/listen_dnsport.h"
+#include "iterator/iter_utils.h"
 
 #ifdef CLIENT_SUBNET
 #include "edns-subnet/subnetmod.h"
@@ -966,6 +967,10 @@ mesh_state_create(struct module_env* env, struct query_info* qinfo,
 	mstate->s.edns_opts_back_out = NULL;
 	mstate->s.edns_opts_back_in = NULL;
 	mstate->s.edns_opts_front_out = NULL;
+
+	/* Pre-seed no_cache_store based on stub/forward info. */
+	if (iter_stub_fwd_no_cache(&mstate->s, &mstate->s.qinfo, NULL, NULL))
+		mstate->s.no_cache_store = 1;
 
 	return mstate;
 }


### PR DESCRIPTION
Years ago I submitted the no-cache feature to unbound which over time broke. I debugged it down to the point that pre-seeding no_cache_store will fix this with minimal changes and make no-cache work again which remains highly valuable in a lot of environments this got deployed.

Obtained from:	https://reviews.freebsd.org/D38057