### PR TITLE
fix potential memory leaks when errors happen

### DIFF
--- a/smallapp/unbound-host.c
+++ b/smallapp/unbound-host.c
@@ -482,6 +482,7 @@ int main(int argc, char* argv[])
 		case '?':
 		case 'h':
 		default:
+			ub_ctx_delete(ctx);
 			usage();
 		}
 	}
@@ -495,8 +496,10 @@ int main(int argc, char* argv[])
 	}
 	argc -= optind;
 	argv += optind;
-	if(argc != 1)
+	if(argc != 1) {
+		ub_ctx_delete(ctx);
 		usage();
+	}
 
 #ifdef HAVE_SSL
 #ifdef HAVE_ERR_LOAD_CRYPTO_STRINGS

--- a/testcode/streamtcp.c
+++ b/testcode/streamtcp.c
@@ -371,15 +371,19 @@ static void
 send_em(const char* svr, const char* pp2_client, int udp, int usessl,
 	int noanswer, int onarrival, int delay, int num, char** qs)
 {
-	sldns_buffer* buf = sldns_buffer_new(65553);
-	sldns_buffer* proxy_buf = sldns_buffer_new(65553);
 	struct sockaddr_storage svr_addr;
 	socklen_t svr_addrlen;
 	int fd = open_svr(svr, udp, &svr_addr, &svr_addrlen);
 	int i, wait_results = 0, pp2_parsed;
 	SSL_CTX* ctx = NULL;
 	SSL* ssl = NULL;
+	sldns_buffer* buf = sldns_buffer_new(65553);
 	if(!buf) fatal_exit("out of memory");
+	sldns_buffer* proxy_buf = sldns_buffer_new(65553);
+	if(!proxy_buf) {
+		sldns_buffer_free(buf);
+		fatal_exit("out of memory");
+	}
 	pp2_parsed = parse_pp2_client(pp2_client, udp, proxy_buf);
 	if(usessl) {
 		ctx = connect_sslctx_create(NULL, NULL, NULL, 0);


### PR DESCRIPTION
==3709953== HEAP SUMMARY:
==3709953==     in use at exit: 276,541 bytes in 23 blocks
==3709953==   total heap usage: 29 allocs, 6 frees, 280,682 bytes allocated
==3709953==
==3709953== 1 bytes in 1 blocks are still reachable in loss record 1 of 23
==3709953==    at 0x4866EC0: malloc (in /usr/lib64/valgrind/vgpreload_memcheck-arm64-linux.so)
==3709953==    by 0x48E2BC3: ub_initstate (random.c:85)
==3709953==    by 0x489B067: ub_ctx_create_nopipe (libunbound.c:114)
==3709953==    by 0x489B31F: ub_ctx_create (libunbound.c:180)
==3709953==    by 0x10E203: main (unbound-host.c:433)
==3709953==
......
==3709953== 8,192 bytes in 1 blocks are still reachable in loss record 22 of 23
==3709953==    at 0x4866EC0: malloc (in /usr/lib64/valgrind/vgpreload_memcheck-arm64-linux.so)
==3709953==    by 0x48E427B: regional_create_custom (regional.c:94)
==3709953==    by 0x48DEA03: edns_strings_create (edns.c:57)
==3709953==    by 0x489B0F3: ub_ctx_create_nopipe (libunbound.c:157)
==3709953==    by 0x489B31F: ub_ctx_create (libunbound.c:180)
==3709953==    by 0x10E203: main (unbound-host.c:433)
==3709953==
==3709953== 262,144 bytes in 1 blocks are still reachable in loss record 23 of 23
==3709953==    at 0x486933C: calloc (in /usr/lib64/valgrind/vgpreload_memcheck-arm64-linux.so)
==3709953==    by 0x48C826F: config_create (config_file.c:179)
==3709953==    by 0x48C85AF: config_create_forlib (config_file.c:383)
==3709953==    by 0x489B0BB: ub_ctx_create_nopipe (libunbound.c:130)
==3709953==    by 0x489B31F: ub_ctx_create (libunbound.c:180)
==3709953==    by 0x10E203: main (unbound-host.c:433)
==3709953==
==3709953== LEAK SUMMARY:
==3709953==    definitely lost: 0 bytes in 0 blocks
==3709953==    indirectly lost: 0 bytes in 0 blocks
==3709953==      possibly lost: 0 bytes in 0 blocks
==3709953==    still reachable: 276,541 bytes in 23 blocks
==3709953==         suppressed: 0 bytes in 0 blocks
==3709953==
==3709953== For lists of detected and suppressed errors, rerun with: -s
==3709953== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)