### PR TITLE
services/authzone.c: remove redundant check

### DIFF
--- a/services/authzone.c
+++ b/services/authzone.c
@@ -7510,7 +7510,7 @@ static void add_rrlist_rrsigs_into_data(struct packed_rrset_data* data,
 		size_t j;
 		if(!rrlist[i])
 			continue;
-		if(rrlist[i] && rrlist[i]->type == LDNS_RR_TYPE_ZONEMD &&
+		if(rrlist[i]->type == LDNS_RR_TYPE_ZONEMD &&
 			query_dname_compare(z->name, node->name)==0) {
 			/* omit RRSIGs over type ZONEMD at apex */
 			continue;


### PR DESCRIPTION
found by cppcheck

services\authzone.c:7513:12: style: Condition 'rrlist[i]' is always true [knownConditionTrueFalse]