### PR TITLE
Implement block_aaaa similar to block_a

### DIFF
--- a/doc/example.conf.in
+++ b/doc/example.conf.in
@@ -820,6 +820,8 @@ server:
 	#   that name
 	# o block_a resolves all records normally but returns
 	#   NODATA for A queries and ignores local data for that name
+	# o block_aaaa resolves all records normally but returns
+	#   NODATA for AAAA queries and ignores local data for that name
 	# o always_null returns 0.0.0.0 or ::0 for any name in the zone.
 	# o noview breaks out of that view towards global local-zones.
 	#

--- a/doc/unbound.conf.5.in
+++ b/doc/unbound.conf.5.in
@@ -1406,7 +1406,7 @@ address space are not validated.  This is usually required whenever
 Configure a local zone. The type determines the answer to give if
 there is no match from local\-data. The types are deny, refuse, static,
 transparent, redirect, nodefault, typetransparent, inform, inform_deny,
-inform_redirect, always_transparent, block_a, always_refuse, always_nxdomain,
+inform_redirect, always_transparent, block_a, block_aaaa, always_refuse, always_nxdomain,
 always_null, noview, and are explained below. After that the default settings
 are listed. Use local\-data: to enter data into the local zone. Answers for
 local zones are authoritative DNS answers. By default the zones are class IN.
@@ -1489,6 +1489,12 @@ Like transparent, but ignores local data and resolves normally all query
 types excluding A. For A queries it unconditionally returns NODATA.
 Useful in cases when there is a need to explicitly force all apps to use
 IPv6 protocol and avoid any queries to IPv4.
+.TP 10
+\h'5'\fIblock_aaaa\fR
+Like transparent, but ignores local data and resolves normally all query
+types excluding AAAA. For AAAA queries it unconditionally returns NODATA.
+Useful in cases when there is a need to explicitly force all apps to use
+IPv4 protocol and avoid any queries to IPv6.
 .TP 10
 \h'5'\fIalways_refuse\fR
 Like refuse, but ignores local data and refuses the query.

--- a/services/localzone.h
+++ b/services/localzone.h
@@ -90,6 +90,8 @@ enum localzone_type {
 	local_zone_always_transparent,
 	/** resolve normally, even when there is local data but return NODATA for A queries */
 	local_zone_block_a,
+	/** resolve normally, even when there is local data but return NODATA for AAAA queries */
+	local_zone_block_aaaa,
 	/** answer with error, even when there is local data */	
 	local_zone_always_refuse,
 	/** answer with nxdomain, even when there is local data */

--- a/util/configparser.y
+++ b/util/configparser.y
@@ -2234,6 +2234,7 @@ server_local_zone: VAR_LOCAL_ZONE STRING_ARG STRING_ARG
 		   && strcmp($3, "typetransparent")!=0
 		   && strcmp($3, "always_transparent")!=0
 		   && strcmp($3, "block_a")!=0
+		   && strcmp($3, "block_aaaa")!=0
 		   && strcmp($3, "always_refuse")!=0
 		   && strcmp($3, "always_nxdomain")!=0
 		   && strcmp($3, "always_nodata")!=0


### PR DESCRIPTION
Reason behind this is that certain ancient apps
get confused with IPv6 and stuff, so offer possibility to make them work too.