### PR TITLE
Numeric truncation when parsing TYPEXX and CLASSXX representation

### DIFF
--- a/daemon/remote.c
+++ b/daemon/remote.c
@@ -1581,6 +1581,9 @@ do_flush_type(RES* ssl, struct worker* worker, char* arg)
 	if(!parse_arg_name(ssl, arg, &nm, &nmlen, &nmlabs))
 		return;
 	t = sldns_get_rr_type_by_name(arg2);
+	if(t == 0 && strcmp(arg2, "TYPE0") != 0) {
+		return 0;
+	}
 	do_cache_remove(worker, nm, nmlen, t, LDNS_RR_CLASS_IN);
 
 	free(nm);

--- a/sldns/rrdef.c
+++ b/sldns/rrdef.c
@@ -702,7 +702,11 @@ sldns_get_rr_type_by_name(const char *name)
 
 	/* TYPEXX representation */
 	if (strlen(name) > 4 && strncasecmp(name, "TYPE", 4) == 0) {
-		return atoi(name + 4);
+		unsigned int a = atoi(name + 4);
+		if (a > LDNS_RR_TYPE_LAST) {
+			return (enum sldns_enum_rr_type)0;
+		}
+		return a;
 	}
 
 	/* Normal types */
@@ -740,7 +744,11 @@ sldns_get_rr_class_by_name(const char *name)
 
 	/* CLASSXX representation */
 	if (strlen(name) > 5 && strncasecmp(name, "CLASS", 5) == 0) {
-		return atoi(name + 5);
+		unsigned int a = atoi(name + 5);
+		if (a > LDNS_RR_TYPE_LAST) {
+			return (enum sldns_enum_rr_type)0;
+		}
+		return a;
 	}
 
 	/* Normal types */

--- a/sldns/rrdef.c
+++ b/sldns/rrdef.c
@@ -746,7 +746,7 @@ sldns_get_rr_class_by_name(const char *name)
 	if (strlen(name) > 5 && strncasecmp(name, "CLASS", 5) == 0) {
 		unsigned int a = atoi(name + 5);
 		if (a > LDNS_RR_TYPE_LAST) {
-			return (enum sldns_enum_rr_type)0;
+			return (enum sldns_enum_rr_class)0;
 		}
 		return a;
 	}

--- a/testcode/dohclient.c
+++ b/testcode/dohclient.c
@@ -229,6 +229,10 @@ make_query(char* qname, char* qtype, char* qclass)
 
 	qinfo.qtype = sldns_get_rr_type_by_name(qtype);
 	qinfo.qclass = sldns_get_rr_class_by_name(qclass);
+	if((qinfo.qtype == 0 && strcmp(qtype, "TYPE0") != 0) ||
+	   (qinfo.qclass == 0 && strcmp(qclass, "CLASS0") != 0)) {
+		return 0;
+	}
 	qinfo.local_alias = NULL;
 
 	qinfo_query_encode(buf, &qinfo); /* flips buffer */

--- a/testcode/perf.c
+++ b/testcode/perf.c
@@ -458,9 +458,17 @@ qlist_parse_line(sldns_buffer* buf, char* p)
 	if(strcmp(tp, "IN") == 0 || strcmp(tp, "CH") == 0) {
 		qinfo.qtype = sldns_get_rr_type_by_name(cl);
 		qinfo.qclass = sldns_get_rr_class_by_name(tp);
+		if((qinfo.qtype == 0 && strcmp(cl, "TYPE0") != 0) ||
+		   (qinfo.qclass == 0 && strcmp(tp, "CLASS0") != 0)) {
+			return 0;
+		}
 	} else {
 		qinfo.qtype = sldns_get_rr_type_by_name(tp);
 		qinfo.qclass = sldns_get_rr_class_by_name(cl);
+		if((qinfo.qtype == 0 && strcmp(tp, "TYPE0") != 0) ||
+		   (qinfo.qclass == 0 && strcmp(cl, "CLASS0") != 0)) {
+			return 0;
+		}
 	}
 	if(fl[0] == '+') rec = 1;
 	else if(fl[0] == '-') rec = 0;

--- a/testcode/streamtcp.c
+++ b/testcode/streamtcp.c
@@ -133,6 +133,10 @@ write_q(int fd, int udp, SSL* ssl, sldns_buffer* buf, uint16_t id,
 	/* qtype and qclass */
 	qinfo.qtype = sldns_get_rr_type_by_name(strtype);
 	qinfo.qclass = sldns_get_rr_class_by_name(strclass);
+	if((qinfo.qtype == 0 && strcmp(strtype, "TYPE0") != 0) ||
+	   (qinfo.qclass == 0 && strcmp(strclass, "CLASS0") != 0)) {
+		return 0;
+	}
 
 	/* clear local alias */
 	qinfo.local_alias = NULL;


### PR DESCRIPTION
Hi! We've been fuzzing `unbound` with [sydr-fuzz](https://github.com/ispras/oss-sydr-fuzz) security predicates and we found numeric truncation error in `str2wire.c:1978` and `str2wire.c:2023`.

In function `sldns_str2wire_nsec_buf` on line 2022 variable `t` has type `uint16_t`, function `sldns_get_rr_type_by_name` returns enum type `sldns_rr_type` that have `unsigned int` type value. The same is in `sldns_str2wire_type_buf` on line 2067. This enum has values that >= 65535. Out tool has found input where this function returns `atoi(name + 4)` and its value is bigger than 65535, so the numeric truncation occurs. So we suggest to add an assert checker in `if operator` in function `sldns_get_rr_type_by_name` on `sldns/rrdef.c:704`:
    
    if (strlen(name) > 4 && strncasecmp(name, "TYPE", 4) == 0) {
        unsigned int a = atoi(name + 4);
        assert(a <= LDNS_RR_TYPE_LAST);
        return a;
    }

### Environment

- OS: ubuntu 20.04
- commit: 7240ecbeb00687197a039d7088e8825c58aae018

### How to reproduce this error

1. Build [docker container](https://github.com/ispras/oss-sydr-fuzz/tree/master/projects/unbound):

    ```
    sudo docker build -t oss-sydr-fuzz-unbound .

    ```

2. Run docker container:

    ```
    sudo docker run --privileged --network host -v /etc/localtime:/etc/localtime:ro --rm -it -v $PWD:/fuzz oss-sydr-fuzz-unboud /bin/bash

    ```

3. Run on the following [input](https://github.com/NLnetLabs/unbound/files/12016549/sydr_d1ceff6d6d77ddd69d8ec7b5b6e787ca4ca3ac97_num_trunc_0_signed.txt):


    ```
     /unbound_fuzzers/fuzz_3_fuzzer sydr_d1ceff6d6d77ddd69d8ec7b5b6e787ca4ca3ac97_num_trunc_0_signed.txt

    ```

4. Output:

    ```
    sldns/str2wire.c:2022:16: runtime error: implicit conversion from type 'sldns_rr_type' (aka 'enum sldns_enum_rr_type') of value 4294189519 (32-bit, unsigned) to type 'uint16_t' (aka 'unsigned short') changed the value to 8655 (16-bit, unsigned)
    SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior sldns/str2wire.c:2022:16
 
    sldns/str2wire.c:2067:15: runtime error: implicit conversion from type 'sldns_rr_type' (aka 'enum sldns_enum_rr_type') of value 4294189519 (32-bit, unsigned) to type 'uint16_t' (aka 'unsigned short') changed the value to 8655 (16-bit, unsigned)
    SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior sldns/str2wire.c:2067:15
    ```