### PR TITLE
Exclude EDE before other EDNS options when there isn't enough space

### DIFF
--- a/util/data/msgencode.h
+++ b/util/data/msgencode.h
@@ -109,6 +109,14 @@ void qinfo_query_encode(struct sldns_buffer* pkt, struct query_info* qinfo);
 uint16_t calc_edns_field_size(struct edns_data* edns);
 
 /**
+ * Calculate the size of a specific EDNS option in packet.
+ * @param edns: edns data or NULL.
+ * @param code: the opt code to get the size of.
+ * @return octets the option will take up.
+ */
+uint16_t calc_edns_option_size(struct edns_data* edns, uint16_t code);
+
+/**
  * Attach EDNS record to buffer. Buffer has complete packet. There must
  * be enough room left for the EDNS record.
  * @param pkt: packet added to.


### PR DESCRIPTION
This change drops any EDE options from a response packet when there is not enough space for them but there is still enough space for the rest of the OPT record. This matches with the behavior specified in RFC 8914, which says "When the response grows beyond the requestor's UDP payload size, servers SHOULD truncate messages by dropping EDE options before dropping other data from packets".

In the function reply_info_answer_encode, I made the following changes:
- Instead of reserving space for the entire edns record, space is reserved for the size the record would be without any ede options.
- After the rest of the reply is added, if there is enough space for the entire edns record, it is added to the response.
- Otherwise, if there would be enough space without ede options, they are removed and the edns record is added without them.

In order to do this, I added a function calc_edns_option_size that calculates the size of an edns option. This function is similar to the existing function calc_edns_field_size, except it only finds the size for one option code.

The function error_encode was also changed so that if there is not enough space for all of the edns data, then any ede options are removed. Then, if there is enough space for the rest of the edns data, it is added, otherwise it is left out.