### PR TITLE
Draft: Provide ability to set forward-*-upstream from remote

### DIFF
--- a/daemon/remote.c
+++ b/daemon/remote.c
@@ -2095,6 +2095,7 @@ parse_fs_args(RES* ssl, char* args, uint8_t** nm, struct delegpt** dp,
 	char* rest;
 	size_t nmlen;
 	int nmlabs;
+	uint8_t ssl_upstream = 0, tcp_upstream = 0;
 	/* parse all -x args */
 	while(args[0] == '+') {
 		if(!find_arg2(ssl, args, &rest))
@@ -2104,6 +2105,10 @@ parse_fs_args(RES* ssl, char* args, uint8_t** nm, struct delegpt** dp,
 				*insecure = 1;
 			else if(*args == 'p' && prime)
 				*prime = 1;
+			else if(*args == 't')
+				tcp_upstream = 1;
+			else if(*args == 's')
+				ssl_upstream = 1;
 			else {
 				(void)ssl_printf(ssl, "error: unknown option %s\n", args);
 				return 0;
@@ -2127,6 +2132,8 @@ parse_fs_args(RES* ssl, char* args, uint8_t** nm, struct delegpt** dp,
 			free(*nm);
 			return 0;
 		}
+		(*dp)->tcp_upstream = tcp_upstream;
+		(*dp)->ssl_upstream = ssl_upstream;
 	}
 	return 1;
 }

--- a/doc/unbound-control.8.in
+++ b/doc/unbound-control.8.in
@@ -239,10 +239,12 @@ still be bogus, use \fBflush_zone\fR to remove it), does not affect the config f
 .B insecure_remove \fIzone
 Removes domain\-insecure for the given zone.
 .TP
-.B forward_add \fR[\fI+i\fR] \fIzone addr ...
+.B forward_add \fR[\fI+ist\fR] \fIzone addr ...
 Add a new forward zone to running Unbound.  With +i option also adds a
 \fIdomain\-insecure\fR for the zone (so it can resolve insecurely if you have
 a DNSSEC root trust anchor configured for other names).
+With +s option it will use \fIforward-tls-upstream yes\fR for this forwarder.
+With +t option it will use \fIforward-tcp-upstream yes\fR for this forwarder.
 The addr can be IP4, IP6 or nameserver names, like \fIforward-zone\fR config
 in unbound.conf.
 .TP


### PR DESCRIPTION
Dnssec-trigger toggles global ssl-upstream and tcp-upstream options when changing forwarders. It would be nice if it were possible to do that also without configuration file change. Add support for +s and +t parameters to forward_add in unbound-control.

Similar to insecure flag +i.