### PR TITLE
add void to log_ident_revert_to_default declaration

### DIFF
--- a/util/log.c
+++ b/util/log.c
@@ -187,7 +187,7 @@ void log_ident_set_default(const char* id)
 	default_ident = id;
 }
 
-void log_ident_revert_to_default()
+void log_ident_revert_to_default(void)
 {
 	ident = default_ident;
 }


### PR DESCRIPTION
Avoid warning from LLVM 16:

util_log.c:190:33: warning: a function declaration without a prototype is deprecated in all versions of C              [-Wstrict-prototypes]                                                                                                  void log_ident_revert_to_default()                                                                                    
                                ^                                                                                     
                                 void