### PR TITLE
fix ipset wrong behavior

### DIFF
--- a/ipset/ipset.c
+++ b/ipset/ipset.c
@@ -158,10 +158,10 @@ ipset_check_zones_for_rrset(struct module_env *env, struct ipset_env *ie,
 		qs = NULL;
 		plen = strlen(p->str);
 
-		if (dlen >= plen) {
+		if (dlen == plen || (dlen > plen && dname[dlen - plen - 1] == '.' )) {
 			ds = dname + (dlen - plen);
 		}
-		if (qlen >= plen) {
+		if (qlen == plen || (qlen > plen && qname[qlen - plen - 1] == '.' )) {
 			qs = qname + (qlen - plen);
 		}
 		if ((ds && strncasecmp(p->str, ds, plen) == 0)


### PR DESCRIPTION
  Issue description:

    If local zone directive is assigned as following:

      "local-zone domain.com ipset"

    then any answers for query with names such as
    "anytext1domain.com" or "example2domain.com"
    will be added to ipset.

  This commit fixes this issue.