### PR TITLE
Replace the obsolescent fgrep with grep -F in tests

### DIFF
--- a/testdata/01-doc.tdir/01-doc.test
+++ b/testdata/01-doc.tdir/01-doc.test
@@ -24,21 +24,21 @@ fi
 (cd $PRE; find . -name "*.h" -print) >hlist
 (cd $PRE; find . -name "*.c" -print) >>hlist
 # filter out config.h
-fgrep -v -e "config.h" hlist > ilist; mv ilist hlist
-fgrep -v -e "util/configparser" hlist > ilist; mv ilist hlist
-fgrep -v -e "util/configlexer" hlist > ilist; mv ilist hlist
-fgrep -v -e "util/configyyrename" hlist > ilist; mv ilist hlist
-fgrep -v -e "util/locks.h" hlist > ilist; mv ilist hlist
-fgrep -v -e "util/storage/lookup3.c" hlist > ilist; mv ilist hlist
-fgrep -v -e "ldns-src/" hlist > ilist; mv ilist hlist
-fgrep -v -e "libunbound/python/libunbound_wrap.c" hlist > ilist; mv ilist hlist
-fgrep -v -e "pythonmod/interface.h" hlist > ilist; mv ilist hlist
-fgrep -v -e "dnstap" hlist > ilist; mv ilist hlist
-fgrep -v -e "util/siphash.c" hlist > ilist; mv ilist hlist
+grep -F -v -e "config.h" hlist > ilist; mv ilist hlist
+grep -F -v -e "util/configparser" hlist > ilist; mv ilist hlist
+grep -F -v -e "util/configlexer" hlist > ilist; mv ilist hlist
+grep -F -v -e "util/configyyrename" hlist > ilist; mv ilist hlist
+grep -F -v -e "util/locks.h" hlist > ilist; mv ilist hlist
+grep -F -v -e "util/storage/lookup3.c" hlist > ilist; mv ilist hlist
+grep -F -v -e "ldns-src/" hlist > ilist; mv ilist hlist
+grep -F -v -e "libunbound/python/libunbound_wrap.c" hlist > ilist; mv ilist hlist
+grep -F -v -e "pythonmod/interface.h" hlist > ilist; mv ilist hlist
+grep -F -v -e "dnstap" hlist > ilist; mv ilist hlist
+grep -F -v -e "util/siphash.c" hlist > ilist; mv ilist hlist
 # filter out compat
-fgrep -v -e "compat/" hlist > ilist; mv ilist hlist
+grep -F -v -e "compat/" hlist > ilist; mv ilist hlist
 for h in `cat hlist`; do
-	if fgrep "`basename $h`" $PRE/doc/html/files.html >/dev/null; then
+	if grep -F "`basename $h`" $PRE/doc/html/files.html >/dev/null; then
 		: # ok
 	else
 		echo "Warning: $h has no documentation."

--- a/testdata/common.sh
+++ b/testdata/common.sh
@@ -169,7 +169,7 @@ wait_server_up () {
 	local WAIT_THRES=30
 	local try
 	for (( try=0 ; try <= $MAX_UP_TRY ; try++ )) ; do
-		if test -f $1 && fgrep "$2" $1 >/dev/null; then
+		if test -f $1 && grep -F "$2" $1 >/dev/null; then
 			#echo "done on try $try"
 			break;
 		fi
@@ -220,11 +220,11 @@ wait_server_up_or_fail () {
 	local WAIT_THRES=30
 	local try
 	for (( try=0 ; try <= $MAX_UP_TRY ; try++ )) ; do
-		if test -f $1 && fgrep "$2" $1 >/dev/null; then
+		if test -f $1 && grep -F "$2" $1 >/dev/null; then
 			echo "done on try $try"
 			break;
 		fi
-		if test -f $1 && fgrep "$3" $1 >/dev/null; then
+		if test -f $1 && grep -F "$3" $1 >/dev/null; then
 			echo "failed on try $try"
 			break;
 		fi

--- a/testdata/fwd_ancil.tdir/fwd_ancil.post
+++ b/testdata/fwd_ancil.tdir/fwd_ancil.post
@@ -7,10 +7,10 @@
 # do your teardown here
 . ../common.sh
 kill_pid $FWD_PID
-if fgrep "service stopped" unbound.log; then
+if grep -F "service stopped" unbound.log; then
 	exit 0
 fi
-if fgrep "disable interface-automatic" unbound.log; then
+if grep -F "disable interface-automatic" unbound.log; then
 	echo "skip test"
 	exit 0
 fi

--- a/testdata/fwd_ancil.tdir/fwd_ancil.pre
+++ b/testdata/fwd_ancil.tdir/fwd_ancil.pre
@@ -36,7 +36,7 @@ wait_ldns_testns_up fwd.log
 # wait for unbound to come up
 # string 'Start of service' in log.
 wait_server_up_or_fail unbound.log "start of service" "disable interface-automatic"
-if fgrep "disable interface-automatic" unbound.log; then
+if grep -F "disable interface-automatic" unbound.log; then
 	skip_test "skip test"
 fi
 

--- a/testdata/fwd_ancil.tdir/fwd_ancil.test
+++ b/testdata/fwd_ancil.tdir/fwd_ancil.test
@@ -7,7 +7,7 @@
 PRE="../.."
 . ../common.sh
 
-if fgrep "disable interface-automatic" unbound.log; then
+if grep -F "disable interface-automatic" unbound.log; then
 	echo "skip test"
 	exit 0
 fi

--- a/testdata/fwd_oneport.tdir/fwd_oneport.post
+++ b/testdata/fwd_oneport.tdir/fwd_oneport.post
@@ -9,7 +9,7 @@
 kill_pid $FWD_PID
 
 # find all extra forked testns and kill them.
-pidlist=`fgrep "forked pid:" fwd.log | sed -e 's/forked pid: //'`
+pidlist=`grep -F "forked pid:" fwd.log | sed -e 's/forked pid: //'`
 for p in $pidlist; do
 	kill_pid $p
 done

--- a/testdata/fwd_three.tdir/fwd_three.post
+++ b/testdata/fwd_three.tdir/fwd_three.post
@@ -11,7 +11,7 @@
 kill_pid $FWD_PID
 
 # find all extra forked testns and kill them.
-pidlist=`fgrep "forked pid:" fwd.log | sed -e 's/forked pid: //'`
+pidlist=`grep -F "forked pid:" fwd.log | sed -e 's/forked pid: //'`
 for p in $pidlist; do
 	kill_pid $p
 done

--- a/testdata/fwd_three_service.tdir/fwd_three_service.post
+++ b/testdata/fwd_three_service.tdir/fwd_three_service.post
@@ -11,7 +11,7 @@
 kill_pid $FWD_PID
 
 # find all extra forked testns and kill them.
-pidlist=`fgrep "forked pid:" fwd.log | sed -e 's/forked pid: //'`
+pidlist=`grep -F "forked pid:" fwd.log | sed -e 's/forked pid: //'`
 for p in $pidlist; do
 	kill_pid $p
 done

--- a/testdata/fwd_udptmout.tdir/fwd_udptmout.post
+++ b/testdata/fwd_udptmout.tdir/fwd_udptmout.post
@@ -10,7 +10,7 @@
 kill_pid $FWD_PID
 
 # find all extra forked testns and kill them.
-pidlist=`fgrep "forked pid:" fwd.log | sed -e 's/forked pid: //'`
+pidlist=`grep -F "forked pid:" fwd.log | sed -e 's/forked pid: //'`
 for p in $pidlist; do
 	kill_pid $p
 done

--- a/testdata/fwd_waitudp.tdir/fwd_waitudp.post
+++ b/testdata/fwd_waitudp.tdir/fwd_waitudp.post
@@ -11,7 +11,7 @@
 kill_pid $FWD_PID
 
 # find all extra forked testns and kill them.
-pidlist=`fgrep "forked pid:" fwd.log | sed -e 's/forked pid: //'`
+pidlist=`grep -F "forked pid:" fwd.log | sed -e 's/forked pid: //'`
 for p in $pidlist; do
 	kill_pid $p
 done


### PR DESCRIPTION
On newer systems I get the message:
```
fgrep: warning: fgrep is obsolescent; using grep -F
```
Looking around I see that `grep -F` is universally supported
- https://man.freebsd.org/cgi/man.cgi?query=grep&sektion=1
- https://man.openbsd.org/grep
- https://man.netbsd.org/grep.1
- https://www.man7.org/linux/man-pages/man1/grep.1.html
- https://ss64.com/osx/grep.html
- https://docs.oracle.com/cd/E88353_01/html/E37839/grep-1.html