### PR TITLE
fix 'WARNING: Message has 41 extra bytes at end'

### DIFF
--- a/daemon/worker.c
+++ b/daemon/worker.c
@@ -1095,6 +1095,7 @@ deny_refuse(struct comm_point* c, enum acl_access acl,
 			LDNS_QR_SET(sldns_buffer_begin(c->buffer));
 			LDNS_RCODE_SET(sldns_buffer_begin(c->buffer),
 				LDNS_RCODE_REFUSED);
+			sldns_buffer_set_position(c->buffer, LDNS_HEADER_SIZE);
 			sldns_buffer_flip(c->buffer);
 			return 1;
 		}


### PR DESCRIPTION
Without this fix we have `WARNING: Message has 41 extra bytes at end` in 
```
dig -b _non_local_address_ @127.0.0.1 non-existent-domain.com
; <<>> DiG 9.16.1-Ubuntu <<>> -b _non_local_address_ @127.0.0.1  non-existent-domain.com
; (1 server found)
;; global options: +cmd
;; Got answer:
;; ->>HEADER<<- opcode: QUERY, status: REFUSED, id: 14481
;; flags: qr rd ad; QUERY: 0, ANSWER: 0, AUTHORITY: 0, ADDITIONAL: 0
;; WARNING: recursion requested but not available
;; WARNING: Message has 28 extra bytes at end

;; Query time: 1 msec
;; SERVER: 127.0.0.1#53(127.0.0.1)
;; WHEN: Monday Dec 04 17:51:26 UTC 2023
;; MSG SIZE  rcvd: 40
```
configuration:
```
server:
        root-hints: "named.root"
        directory: "/"
        pidfile: "/unbound.pid"
        chroot: ""
        port: 5353
        interface-automatic: "yes"
        interface: ::1
        interface: 127.0.0.1
        ip-freebind: "yes"
        do-daemonize: "no"
        num-threads: 1
        num-queries-per-thread: 10
        prefer-ip6: "yes"
        access-control: 0.0.0.0/0 refuse_non_local
        access-control: ::0/0 refuse_non_local
        module-config: "iterator"
```

version:
```
/unbound/unbound -V
Version 1.19.0-trunk
Configure line: --disable-static --prefix=/var/empty/unbound-1.19.0 --bindir=/var/empty/tmp/out/bin --sbindir=/var/empty/tmp/out/sbin --includedir=/var/empty/tmp/out/include --oldincludedir=/var/empty/tmp/out/include --mandir=/var/empty/tmp/out/share/man --infodir=/var/empty/tmp/out/share/info --docdir=/var/empty/tmp/out/share/doc/unbound --libdir=/var/empty/tmp/out/lib --libexecdir=/var/empty/tmp/out/libexec --localedir=/var/empty/tmp/out/share/locale --disable-rpath --enable-dnstap --enable-dnscrypt --enable-subnet --enable-systemd --libdir=/usr/lib --prefix= --with-libevent=/var/empty/libevent-2.1.12-dev --with-pidfile=/run/unbound.pid --with-rootkey-file=/var/lib/unbound/root.key --with-ssl=/var/empty/openssl-1.1.1o-dev --with-username= --with-libnghttp2=/var/empty/nghttp2-1.47.0-dev
Linked libs: libevent 2.1.12-stable (it uses epoll), OpenSSL 1.1.1t  7 Feb 2023
Linked modules: dns64 subnetcache respip validator iterator
DNSCrypt feature available
```