### PR TITLE
DoH: reject non-h2 early

### DIFF
--- a/util/netevent.c
+++ b/util/netevent.c
@@ -1748,6 +1748,9 @@ ssl_handshake(struct comm_point* c)
 			/* connection upgraded to HTTP2 */
 			c->tcp_do_toggle_rw = 0;
 			c->use_h2 = 1;
+		} else {
+			verbose(VERB_ALGO, "client doesn't support HTTP/2");
+			return 0;
 		}
 	}
 #endif


### PR DESCRIPTION
Previously, non-h2 connections would be accepted, and then error out with a verbose message "http2: session_recv from ____ failed, error: Received bad client magic byte string". Instead, we can detect absence of h2 support at connection time and reject with a clearer verbose message.

Partial fix for #979