### PR TITLE
Fix NLnetLabs#981: dump_cache truncates large records.

### DIFF
--- a/daemon/remote.c
+++ b/daemon/remote.c
@@ -553,7 +553,7 @@ ssl_print_text(RES* res, const char* text)
 static int
 ssl_print_vmsg(RES* ssl, const char* format, va_list args)
 {
-	char msg[1024];
+	char msg[65535];
 	vsnprintf(msg, sizeof(msg), format, args);
 	return ssl_print_text(ssl, msg);
 }

--- a/util/data/packed_rrset.c
+++ b/util/data/packed_rrset.c
@@ -275,6 +275,7 @@ int packed_rr_to_string(struct ub_packed_rrset_key* rrset, size_t i,
 	struct packed_rrset_data* d = (struct packed_rrset_data*)rrset->
 		entry.data;
 	uint8_t rr[65535];
+	size_t wlen;
 	size_t rlen = rrset->rk.dname_len + 2 + 2 + 4 + d->rr_len[i];
 	time_t adjust = 0;
 	log_assert(dest_len > 0 && dest);
@@ -292,7 +293,9 @@ int packed_rr_to_string(struct ub_packed_rrset_key* rrset, size_t i,
 	sldns_write_uint32(rr+rrset->rk.dname_len+4,
 		(uint32_t)(d->rr_ttl[i]-adjust));
 	memmove(rr+rrset->rk.dname_len+8, d->rr_data[i], d->rr_len[i]);
-	if(sldns_wire2str_rr_buf(rr, rlen, dest, dest_len) == -1) {
+	wlen = (size_t)sldns_wire2str_rr_buf(rr, rlen, dest, dest_len);
+	if(wlen >= dest_len) {
+		/* the output string was truncated */
 		log_info("rrbuf failure %d %s", (int)d->rr_len[i], dest);
 		dest[0] = 0;
 		return 0;


### PR DESCRIPTION
The issue lies in the buffer sizes used by two functions: dump_rrset_line, which has a buffer size of 65535 to store a rrset string, and ssl_print_vmsg, which has a buffer size of only 1024 for printing a message. This mismatch is the root cause of the truncation.

To resolve this issue, I increased the output message buffer size from 1024 to 65535 to match the buffer size used for rrset strings. Additionally, I verified if the rrset string is truncated in packed_rr_to_string; if it is, unbound will output "BADRR" instead of printing the truncated message.