### PR TITLE
Mention REFUSED has the TC bit set with unmatched allow_cookie acl in the manpage

### DIFF
--- a/doc/unbound.conf.5.in
+++ b/doc/unbound.conf.5.in
@@ -738,7 +738,7 @@ the cache contents (for malicious acts).  However, nonrecursive queries can
 also be a valuable debugging tool (when you want to examine the cache
 contents). In that case use \fIallow_snoop\fR for your administration host.
 .IP
-The \fIallow_cookie\fR action allows access to UDP queries that contain a
+The \fIallow_cookie\fR action allows only access to UDP queries that contain a
 valid DNS Cookie as specified in RFC 7873 and RFC 9018, when the
 \fBanswer\-cookie\fR option is enabled.
 UDP queries containing only a DNS Client Cookie and no Server Cookie, or an
@@ -747,10 +747,8 @@ generated DNS Cookie, allowing clients to retry with that DNS Cookie.
 The \fIallow_cookie\fR action will also accept requests over stateful
 transports, regardless of the presence of an DNS Cookie and regardless of the
 \fBanswer\-cookie\fR setting.
-If \fBip\-ratelimit\fR is used, clients with a valid DNS Cookie will bypass the
-ratelimit.
-If a ratelimit for such clients is still needed, \fBip\-ratelimit\-cookie\fR
-can be used instead.
+The non cookie UDP traffic receives REFUSED responses with the TC flag set,
+that may trigger fall back TCP for those clients.
 .IP
 By default only localhost is \fIallow\fRed, the rest is \fIrefuse\fRd.
 The default is \fIrefuse\fRd, because that is protocol\-friendly. The DNS
@@ -1844,6 +1842,9 @@ The ratelimit is in queries per second that are allowed.  More queries are
 completely dropped and will not receive a reply, SERVFAIL or otherwise.
 IP ratelimiting happens before looking in the cache. This may be useful for
 mitigating amplification attacks.
+Clients with a valid DNS Cookie will bypass the ratelimit.
+If a ratelimit for such clients is still needed, \fBip\-ratelimit\-cookie\fR
+can be used instead.
 Default is 0 (disabled).
 .TP 5
 .B ip\-ratelimit\-cookie: \fI<number or 0>

--- a/doc/unbound.conf.5.in
+++ b/doc/unbound.conf.5.in
@@ -747,7 +747,7 @@ generated DNS Cookie, allowing clients to retry with that DNS Cookie.
 The \fIallow_cookie\fR action will also accept requests over stateful
 transports, regardless of the presence of an DNS Cookie and regardless of the
 \fBanswer\-cookie\fR setting.
-The non cookie UDP traffic receives REFUSED responses with the TC flag set,
+UDP queries without a DNS Cookie receive REFUSED responses with the TC flag set,
 that may trigger fall back to TCP for those clients.
 .IP
 By default only localhost is \fIallow\fRed, the rest is \fIrefuse\fRd.

--- a/doc/unbound.conf.5.in
+++ b/doc/unbound.conf.5.in
@@ -738,7 +738,7 @@ the cache contents (for malicious acts).  However, nonrecursive queries can
 also be a valuable debugging tool (when you want to examine the cache
 contents). In that case use \fIallow_snoop\fR for your administration host.
 .IP
-The \fIallow_cookie\fR action allows only access to UDP queries that contain a
+The \fIallow_cookie\fR action allows access only to UDP queries that contain a
 valid DNS Cookie as specified in RFC 7873 and RFC 9018, when the
 \fBanswer\-cookie\fR option is enabled.
 UDP queries containing only a DNS Client Cookie and no Server Cookie, or an
@@ -748,7 +748,7 @@ The \fIallow_cookie\fR action will also accept requests over stateful
 transports, regardless of the presence of an DNS Cookie and regardless of the
 \fBanswer\-cookie\fR setting.
 The non cookie UDP traffic receives REFUSED responses with the TC flag set,
-that may trigger fall back TCP for those clients.
+that may trigger fall back to TCP for those clients.
 .IP
 By default only localhost is \fIallow\fRed, the rest is \fIrefuse\fRd.
 The default is \fIrefuse\fRd, because that is protocol\-friendly. The DNS


### PR DESCRIPTION
Also moved the part about bypassing ip-ratelimit to the ip-ratelimit description as it will be bypassed with a valid DNS-Cookie regardless of the allow_cookie acl.