### PR TITLE
Py_NoSiteFlag is not needed since Python 3.8

### DIFF
--- a/pythonmod/pythonmod.c
+++ b/pythonmod/pythonmod.c
@@ -356,11 +356,11 @@ int pythonmod_init(struct module_env* env, int id)
 	return 0;
       }
 #endif
-      Py_NoSiteFlag = 1;
 #if PY_MAJOR_VERSION >= 3
       PyImport_AppendInittab(SWIG_name, (void*)SWIG_init);
 #endif
 #if PY_VERSION_HEX < 0x03080000
+      Py_NoSiteFlag = 1;
       Py_Initialize();
 #else
       PyConfig_InitPythonConfig(&config);


### PR DESCRIPTION
Python since 3.12 prints warning about Py_NoSiteFlag is deprecated. It seems that variable is not needed since Python 3.8, since it sets in such cases directly config.site_import variable few moments later. Move using deprecated variable to versions before that flag in config could be used only.

This should fix warning like:

pythonmod/pythonmod.c: In function 'pythonmod_init': pythonmod/pythonmod.c:359:7: warning: 'Py_NoSiteFlag' is deprecated [-Wdeprecated-declarations]
  359 |       Py_NoSiteFlag = 1;
      |       ^~~~~~~~~~~~~
In file included from /usr/include/python3.12/Python.h:48,
                 from pythonmod/pythonmod.c:54:
/usr/include/python3.12/cpython/pydebug.h:14:37: note: declared here
   14 | Py_DEPRECATED(3.12) PyAPI_DATA(int) Py_NoSiteFlag;
      |                                     ^~~~~~~~~~~~~

https://docs.python.org/3/c-api/init.html#c.Py_NoSiteFlag