### PR TITLE
config_read: no cfg file provided is an error condition

### DIFF
--- a/util/config_file.c
+++ b/util/config_file.c
@@ -1377,7 +1377,7 @@ config_read(struct config_file* cfg, const char* filename, const char* chroot)
 	int r, flags;
 #endif
 	if(!fname)
-		return 1;
+		return 0;
 
 	/* check for wildcards */
 #ifdef HAVE_GLOB


### PR DESCRIPTION
The logic here doesn't seem correct. If `filename` is not specified (which would be a programmer error), the result of `config_read` should not be 1 (success), but rather 0 (error).