### PR TITLE
AddressSanitizer detection in tdir tests and memory leak fixes

### DIFF
--- a/daemon/daemon.c
+++ b/daemon/daemon.c
@@ -503,7 +503,10 @@ daemon_clear_allocs(struct daemon* daemon)
 {
 	int i;
 
-	for(i=0; i<daemon->num; i++) {
+	/* daemon->num may be different during reloads (after configuration
+	 * read). Use old_num which has the correct value used to setup the
+	 * worker_allocs */
+	for(i=0; i<daemon->old_num; i++) {
 		alloc_clear(daemon->worker_allocs[i]);
 		free(daemon->worker_allocs[i]);
 	}

--- a/testcode/mini_tdir.sh
+++ b/testcode/mini_tdir.sh
@@ -127,6 +127,7 @@ dir=$name.$$
 result=result.$name
 done=.done-$name
 skip=.skip-$name
+asan_text="SUMMARY: AddressSanitizer"
 success="no"
 if test -x "`which bash`"; then
 	shell="bash"
@@ -199,6 +200,16 @@ if test -f $name.post -a ! -f ../$skip; then
 	if test $? -ne 0; then
 		echo "Warning: $name.post did not exit successfully"
 	fi
+fi
+# Check if there were any AddressSanitizer errors
+# if compiled with -fsanitize=address
+if grep "$asan_text" $result >/dev/null 2>&1; then
+	if test -f ../$done; then
+		rm ../$done
+	fi
+	echo "$name: FAILED (AddressSanitizer)" >> $result
+	echo "$name: FAILED (AddressSanitizer)"
+	success="no"
 fi
 echo "DateRunEnd: "`date "+%s" 2>/dev/null` >> $result
 

--- a/testdata/02-unittest.tdir/02-unittest.test
+++ b/testdata/02-unittest.tdir/02-unittest.test
@@ -7,7 +7,7 @@
 . ../common.sh
 PRE="../.."
 get_make
-(cd $PRE ; $MAKE unittest; $MAKE lock-verify)
+(cd $PRE ; $MAKE unittest; $MAKE lock-verify; $MAKE unbound-dnstap-socket)
 
 if test -f $PRE/unbound_do_valgrind_in_test; then
 	do_valgrind=yes
@@ -16,11 +16,16 @@ else
 fi
 VALGRIND_FLAGS="--leak-check=full --show-leak-kinds=all"
 
+## START -- Loop over unit tests
+##
+for unit_cmd in "unittest" "unbound-dnstap-socket -c"; do
+
+echo "> testing $unit_cmd"
 if test $do_valgrind = "yes"; then
 	echo "valgrind yes"
 	echo
 	tmpout=/tmp/tmpout.$$
-	if (cd $PRE; valgrind $VALGRIND_FLAGS ./unittest >$tmpout 2>&1); then
+	if (cd $PRE; valgrind $VALGRIND_FLAGS ./$unit_cmd >$tmpout 2>&1); then
 		echo "unit test worked."
 	else
 		echo "unit test failed."
@@ -30,7 +35,7 @@ if test $do_valgrind = "yes"; then
 		:  # clean
 	else
 		cat $tmpout
-		echo "Memory leaked in unittest"
+		echo "Memory leaked in unit test"
 		grep "in use at exit" $tmpout
 		exit 1
 	fi
@@ -38,14 +43,14 @@ if test $do_valgrind = "yes"; then
 		:  # clean
 	else
 		cat $tmpout
-		echo "Errors in unittest"
+		echo "Errors in unit test"
 		grep "ERROR SUMMARY" $tmpout
 		exit 1
 	fi
 	rm -f $tmpout
 else
 	# without valgrind
-	if (cd $PRE; ./unittest); then
+	if (cd $PRE; ./$unit_cmd); then
 		echo "unit test worked."
 	else
 		echo "unit test failed."
@@ -60,4 +65,9 @@ if test -f $PRE/ublocktrace.0; then
 		exit 1
 	fi
 fi
+
+done
+##
+## END -- Loop over unit tests
+
 exit 0

--- a/testdata/02-unittest.tdir/02-unittest.test
+++ b/testdata/02-unittest.tdir/02-unittest.test
@@ -10,64 +10,66 @@ get_make
 (cd $PRE ; $MAKE unittest; $MAKE lock-verify; $MAKE unbound-dnstap-socket)
 
 if test -f $PRE/unbound_do_valgrind_in_test; then
-	do_valgrind=yes
+	DO_VALGRIND=yes
 else
-	do_valgrind=no
+	DO_VALGRIND=no
 fi
 VALGRIND_FLAGS="--leak-check=full --show-leak-kinds=all"
 
-## START -- Loop over unit tests
-##
-for unit_cmd in "unittest" "unbound-dnstap-socket -c"; do
+# Run a unit test; it exits on failure
+# $1: the command to start the unit test
+run_unittest () {
+	unit_cmd=$1
+	echo "> testing $unit_cmd"
+	if test $DO_VALGRIND = "yes"; then
+		echo "valgrind yes"
+		echo
+		tmpout=/tmp/tmpout.$$
+		if (cd $PRE; valgrind $VALGRIND_FLAGS ./$unit_cmd >$tmpout 2>&1); then
+			echo "unit test worked."
+		else
+			echo "unit test failed."
+			exit 1
+		fi
+		if grep "All heap blocks were freed -- no leaks are possible" $tmpout; then
+			:  # clean
+		else
+			cat $tmpout
+			echo "Memory leaked in unit test"
+			grep "in use at exit" $tmpout
+			exit 1
+		fi
+		if grep "ERROR SUMMARY: 0 errors from 0 contexts" $tmpout; then
+			:  # clean
+		else
+			cat $tmpout
+			echo "Errors in unit test"
+			grep "ERROR SUMMARY" $tmpout
+			exit 1
+		fi
+		rm -f $tmpout
+	else
+		# without valgrind
+		if (cd $PRE; ./$unit_cmd); then
+			echo "unit test worked."
+		else
+			echo "unit test failed."
+			exit 1
+		fi
+	fi
+	if test -f $PRE/ublocktrace.0; then
+		if (cd $PRE; ./lock-verify ublocktrace.*); then
+			echo "lock-verify test worked."
+		else
+			echo "lock-verify test failed."
+			exit 1
+		fi
+	fi
+}
 
-echo "> testing $unit_cmd"
-if test $do_valgrind = "yes"; then
-	echo "valgrind yes"
-	echo
-	tmpout=/tmp/tmpout.$$
-	if (cd $PRE; valgrind $VALGRIND_FLAGS ./$unit_cmd >$tmpout 2>&1); then
-		echo "unit test worked."
-	else
-		echo "unit test failed."
-		exit 1
-	fi
-	if grep "All heap blocks were freed -- no leaks are possible" $tmpout; then
-		:  # clean
-	else
-		cat $tmpout
-		echo "Memory leaked in unit test"
-		grep "in use at exit" $tmpout
-		exit 1
-	fi
-	if grep "ERROR SUMMARY: 0 errors from 0 contexts" $tmpout; then
-		:  # clean
-	else
-		cat $tmpout
-		echo "Errors in unit test"
-		grep "ERROR SUMMARY" $tmpout
-		exit 1
-	fi
-	rm -f $tmpout
-else
-	# without valgrind
-	if (cd $PRE; ./$unit_cmd); then
-		echo "unit test worked."
-	else
-		echo "unit test failed."
-		exit 1
-	fi
+run_unittest "unittest"
+if grep "define UNBOUND_DEBUG" $PRE/config.h >/dev/null;  then
+	run_unittest "unbound-dnstap-socket -c"
 fi
-if test -f $PRE/ublocktrace.0; then
-	if (cd $PRE; ./lock-verify ublocktrace.*); then
-		echo "lock-verify test worked."
-	else
-		echo "lock-verify test failed."
-		exit 1
-	fi
-fi
-
-done
-##
-## END -- Loop over unit tests
 
 exit 0


### PR DESCRIPTION
Checks the output of the tdir tests for any Address Sanitizer errors and fails the test.
This will increase visibility of memory leaks on different test cases if compiled with `--fsanitize=address`.

It also fixes a memory leak when `reload_keep_cache` is used **AND** `num-threads` changes for the reload.

It also fixes a memory leak when exiting the test program `unbound-dnstap-socket` that now creates false negatives during testing. For this `unbound-dnstap-socket` introduces a unit test that I run under `02-unittest.tdir`. Not 100% if this place makes sense or it needs to be relocated.