### PR TITLE
Fix spelling mistake in comments

### DIFF
--- a/validator/validator.h
+++ b/validator/validator.h
@@ -159,7 +159,7 @@ struct val_qstate {
 	 * The query restart count
 	 */
 	int restart_count;
-	/** The blacklist saved for chainoftrust elements */
+	/** The blacklist saved for chain of trust elements */
 	struct sock_list* chain_blacklist;
 
 	/**


### PR DESCRIPTION
I noticed a spelling mistake in the comments. The term “chain of trust” was incorrectly written as “chainoftrust”. This change corrects the spelling to “chain of trust” which is the correct term used in English.