### PR TITLE
Stats for discard-timeout and wait-limit

### DIFF
--- a/daemon/remote.c
+++ b/daemon/remote.c
@@ -707,6 +707,10 @@ print_stats(RES* ssl, const char* nm, struct ub_stats_info* s)
 		(unsigned long)s->svr.num_queries_cookie_client)) return 0;
 	if(!ssl_printf(ssl, "%s.num.queries_cookie_invalid"SQ"%lu\n", nm,
 		(unsigned long)s->svr.num_queries_cookie_invalid)) return 0;
+	if(!ssl_printf(ssl, "%s.num.queries_discard_timeout"SQ"%lu\n", nm,
+		(unsigned long)s->svr.num_queries_discard_timeout)) return 0;
+	if(!ssl_printf(ssl, "%s.num.queries_wait_limit"SQ"%lu\n", nm,
+		(unsigned long)s->svr.num_queries_wait_limit)) return 0;
 	if(!ssl_printf(ssl, "%s.num.cachehits"SQ"%lu\n", nm,
 		(unsigned long)(s->svr.num_queries
 			- s->svr.num_queries_missed_cache))) return 0;

--- a/daemon/stats.c
+++ b/daemon/stats.c
@@ -281,6 +281,10 @@ server_stats_compile(struct worker* worker, struct ub_stats_info* s, int reset)
 		s->svr.rpz_action[i] += (long long)worker->env.mesh->rpz_action[i];
 	timehist_export(worker->env.mesh->histogram, s->svr.hist,
 		NUM_BUCKETS_HIST);
+	s->svr.num_queries_discard_timeout +=
+		(long long)worker->env.mesh->num_queries_discard_timeout;
+	s->svr.num_queries_wait_limit +=
+		(long long)worker->env.mesh->num_queries_wait_limit;
 	/* values from outside network */
 	s->svr.unwanted_replies = (long long)worker->back->unwanted_replies;
 	s->svr.qtcp_outgoing = (long long)worker->back->num_tcp_outgoing;
@@ -498,6 +502,10 @@ void server_stats_add(struct ub_stats_info* total, struct ub_stats_info* a)
 		total->svr.unwanted_replies += a->svr.unwanted_replies;
 		total->svr.unwanted_queries += a->svr.unwanted_queries;
 		total->svr.tcp_accept_usage += a->svr.tcp_accept_usage;
+		total->svr.num_queries_discard_timeout +=
+			a->svr.num_queries_discard_timeout;
+		total->svr.num_queries_wait_limit +=
+			a->svr.num_queries_wait_limit;
 #ifdef USE_CACHEDB
 		total->svr.num_query_cachedb += a->svr.num_query_cachedb;
 #endif

--- a/daemon/stats.c
+++ b/daemon/stats.c
@@ -455,6 +455,9 @@ void server_stats_add(struct ub_stats_info* total, struct ub_stats_info* a)
 	total->svr.num_queries_cookie_valid += a->svr.num_queries_cookie_valid;
 	total->svr.num_queries_cookie_client += a->svr.num_queries_cookie_client;
 	total->svr.num_queries_cookie_invalid += a->svr.num_queries_cookie_invalid;
+	total->svr.num_queries_discard_timeout +=
+		a->svr.num_queries_discard_timeout;
+	total->svr.num_queries_wait_limit += a->svr.num_queries_wait_limit;
 	total->svr.num_queries_missed_cache += a->svr.num_queries_missed_cache;
 	total->svr.num_queries_prefetch += a->svr.num_queries_prefetch;
 	total->svr.num_queries_timed_out += a->svr.num_queries_timed_out;
@@ -502,10 +505,6 @@ void server_stats_add(struct ub_stats_info* total, struct ub_stats_info* a)
 		total->svr.unwanted_replies += a->svr.unwanted_replies;
 		total->svr.unwanted_queries += a->svr.unwanted_queries;
 		total->svr.tcp_accept_usage += a->svr.tcp_accept_usage;
-		total->svr.num_queries_discard_timeout +=
-			a->svr.num_queries_discard_timeout;
-		total->svr.num_queries_wait_limit +=
-			a->svr.num_queries_wait_limit;
 #ifdef USE_CACHEDB
 		total->svr.num_query_cachedb += a->svr.num_query_cachedb;
 #endif

--- a/doc/unbound-control.8.in
+++ b/doc/unbound-control.8.in
@@ -422,6 +422,12 @@ number of queries with a client part only DNS Cookie by thread
 .I threadX.num.queries_cookie_invalid
 number of queries with an invalid DNS Cookie by thread
 .TP
+.I threadX.num.queries_discard_timeout
+number of queries removed due to discard-timeout by thread
+.TP
+.I threadX.num.queries_wait_limit
+number of queries removed due to wait-limit by thread
+.TP
 .I threadX.num.cachehits
 number of queries that were successfully answered using a cache lookup
 .TP
@@ -509,6 +515,12 @@ summed over threads.
 summed over threads.
 .TP
 .I total.num.queries_cookie_invalid
+summed over threads.
+.TP
+.I total.num.queries_discard_timeout
+summed over threads.
+.TP
+.I total.num.queries_wait_limit
 summed over threads.
 .TP
 .I total.num.cachehits

--- a/libunbound/unbound.h
+++ b/libunbound/unbound.h
@@ -849,6 +849,10 @@ struct ub_server_stats {
 	long long mem_quic;
 	/** number of queries over (DNS over) QUIC */
 	long long qquic;
+	/** number of queries removed due to discard-timeout */
+	long long num_queries_discard_timeout;
+	/** number of queries removed due to wait-limit */
+	long long num_queries_wait_limit;
 };
 
 /**

--- a/services/mesh.h
+++ b/services/mesh.h
@@ -132,6 +132,10 @@ struct mesh_area {
 	size_t ans_nodata;
 	/** (extended stats) type of applied RPZ action */
 	size_t rpz_action[UB_STATS_RPZ_ACTION_NUM];
+	/** stats, number of queries removed due to discard-timeout */
+	size_t num_queries_discard_timeout;
+	/** stats, number of queries removed due to wait-limit */
+	size_t num_queries_wait_limit;
 
 	/** backup of query if other operations recurse and need the
 	 * network buffers */

--- a/smallapp/unbound-control.c
+++ b/smallapp/unbound-control.c
@@ -222,6 +222,9 @@ static void pr_stats(const char* nm, struct ub_stats_info* s)
 		s->svr.num_queries_cookie_client);
 	PR_UL_NM("num.queries_cookie_invalid",
 		s->svr.num_queries_cookie_invalid);
+	PR_UL_NM("num.queries_discard_timeout",
+		s->svr.num_queries_discard_timeout);
+	PR_UL_NM("num.queries_wait_limit", s->svr.num_queries_wait_limit);
 	PR_UL_NM("num.cachehits",
 		s->svr.num_queries - s->svr.num_queries_missed_cache);
 	PR_UL_NM("num.cachemiss", s->svr.num_queries_missed_cache);


### PR DESCRIPTION
The new discard-timeout and wait-limit options have been accounted as requestlist_exceeded in the statistics. But this mixes them with the request exceed number. The change makes their own statistics counters for them. The new statistics counters are `num.queries_discard_timeout` and `num.queries_wait_limit`.