### PR TITLE
fix: remove the auth_zones lock and count up/down queries in a common way

### DIFF
--- a/daemon/stats.c
+++ b/daemon/stats.c
@@ -325,20 +325,11 @@ server_stats_compile(struct worker* worker, struct ub_stats_info* s, int reset)
 	s->svr.num_query_dnscrypt_replay = 0;
 #endif /* USE_DNSCRYPT */
 	if(worker->env.auth_zones) {
-		if(reset && !worker->env.cfg->stat_cumulative) {
-			lock_rw_wrlock(&worker->env.auth_zones->lock);
-		} else {
-			lock_rw_rdlock(&worker->env.auth_zones->lock);
-		}
-		s->svr.num_query_authzone_up = (long long)worker->env.
-			auth_zones->num_query_up;
-		s->svr.num_query_authzone_down = (long long)worker->env.
-			auth_zones->num_query_down;
-		if(reset && !worker->env.cfg->stat_cumulative) {
-			worker->env.auth_zones->num_query_up = 0;
-			worker->env.auth_zones->num_query_down = 0;
-		}
-		lock_rw_unlock(&worker->env.auth_zones->lock);
+		s->svr.num_query_authzone_up = (long long)worker->stats.num_query_authzone_up;
+		s->svr.num_query_authzone_down = (long long)worker->stats.num_query_authzone_down;
+	} else {
+		s->svr.num_query_authzone_up = 0;
+		s->svr.num_query_authzone_down = 0;
 	}
 	s->svr.mem_stream_wait =
 		(long long)tcp_req_info_get_stream_buffer_size();
@@ -454,6 +445,8 @@ void server_stats_add(struct ub_stats_info* total, struct ub_stats_info* a)
 	total->svr.num_queries_missed_cache += a->svr.num_queries_missed_cache;
 	total->svr.num_queries_prefetch += a->svr.num_queries_prefetch;
 	total->svr.num_queries_timed_out += a->svr.num_queries_timed_out;
+	total->svr.num_query_authzone_up += a->svr.num_query_authzone_up;
+	total->svr.num_query_authzone_down += a->svr.num_query_authzone_down;
 	if (total->svr.max_query_time_us < a->svr.max_query_time_us)
 		total->svr.max_query_time_us = a->svr.max_query_time_us;
 	total->svr.sum_query_list_size += a->svr.sum_query_list_size;

--- a/daemon/worker.c
+++ b/daemon/worker.c
@@ -2230,6 +2230,7 @@ worker_init(struct worker* worker, struct config_file *cfg,
 	worker->env = *worker->daemon->env;
 	comm_base_timept(worker->base, &worker->env.now, &worker->env.now_tv);
 	worker->env.worker = worker;
+	worker->env.stats = &worker->stats;
 	worker->env.worker_base = worker->base;
 	worker->env.send_query = &worker_send_query;
 	worker->env.alloc = worker->alloc;

--- a/iterator/iterator.c
+++ b/iterator/iterator.c
@@ -1076,15 +1076,12 @@ auth_zone_delegpt(struct module_qstate* qstate, struct iter_qstate* iq,
 		delname = iq->qchase.qname;
 		delnamelen = iq->qchase.qname_len;
 	}
-	lock_rw_rdlock(&qstate->env->auth_zones->lock);
 	z = auth_zones_find_zone(qstate->env->auth_zones, delname, delnamelen,
 		qstate->qinfo.qclass);
 	if(!z) {
-		lock_rw_unlock(&qstate->env->auth_zones->lock);
 		return 1;
 	}
 	lock_rw_rdlock(&z->lock);
-	lock_rw_unlock(&qstate->env->auth_zones->lock);
 	if(z->for_upstream) {
 		if(iq->dp && query_dname_compare(z->name, iq->dp->name) == 0
 			&& iq->dp->auth_dp && qstate->blacklist &&
@@ -2741,9 +2738,7 @@ processQueryTargets(struct module_qstate* qstate, struct iter_qstate* iq,
 		if((iq->chase_flags&BIT_RD) && !(iq->response->rep->flags&BIT_AA)) {
 			verbose(VERB_ALGO, "forwarder, ignoring referral from auth zone");
 		} else {
-			lock_rw_wrlock(&qstate->env->auth_zones->lock);
-			qstate->env->auth_zones->num_query_up++;
-			lock_rw_unlock(&qstate->env->auth_zones->lock);
+			qstate->env->stats->num_query_authzone_up++;
 			iq->num_current_queries++;
 			iq->chase_to_rd = 0;
 			iq->dnssec_lame_query = 0;

--- a/services/authzone.h
+++ b/services/authzone.h
@@ -70,18 +70,12 @@ struct auth_chunk;
  * Authoritative zones, shared.
  */
 struct auth_zones {
-	/** lock on the authzone trees */
-	lock_rw_type lock;
 	/** rbtree of struct auth_zone */
 	rbtree_type ztree;
 	/** rbtree of struct auth_xfer */
 	rbtree_type xtree;
 	/** do we have downstream enabled */
 	int have_downstream;
-	/** number of queries upstream */
-	size_t num_query_up;
-	/** number of queries downstream */
-	size_t num_query_down;
 	/** first auth zone containing rpz item in linked list */
 	struct auth_zone* rpz_first;
 	/** rw lock for rpz linked list, needed when iterating or editing linked

--- a/testcode/unitauth.c
+++ b/testcode/unitauth.c
@@ -663,9 +663,7 @@ authtest_addzone(struct auth_zones* az, const char* name, char* fname)
 	uint8_t* nm = sldns_str2wire_dname(name, &nmlen);
 	struct config_file* cfg;
 	if(!nm) fatal_exit("out of memory");
-	lock_rw_wrlock(&az->lock);
 	z = auth_zone_create(az, nm, nmlen, LDNS_RR_CLASS_IN);
-	lock_rw_unlock(&az->lock);
 	if(!z) fatal_exit("cannot find zone");
 	auth_zone_set_zonefile(z, fname);
 	z->for_upstream = 1;

--- a/util/module.h
+++ b/util/module.h
@@ -153,6 +153,8 @@
 
 #ifndef UTIL_MODULE_H
 #define UTIL_MODULE_H
+/* stats struct */
+#include "libunbound/unbound.h"
 #include "util/storage/lruhash.h"
 #include "util/data/msgreply.h"
 #include "util/data/msgparse.h"
@@ -484,6 +486,8 @@ struct module_env {
 	struct sldns_buffer* scratch_buffer;
 	/** internal data for daemon - worker thread. */
 	struct worker* worker;
+	/** worker's per thread statistics */
+	struct ub_server_stats* stats;
 	/** the worker event base */
 	struct comm_base* worker_base;
 	/** the outside network */


### PR DESCRIPTION
The lock field in the auth_zones struct is used only to protect the up/down query counters. My understanding is that the auth_zones struct is only constructed when there are no other threads, so there are no possibilities for concurrent access. However, concurrent modifications still occur in auth_zones.c, specifically during query counting. By adopting a common approach to tracking up/down queries, similar to that used for other server statistics, we can simplify the codebase and eliminate the need for locking mechanisms.

I benchmarked the performance of this patch using the following configuration to effectively disable cache:

...
        msg-cache-size: 2b
        msg-cache-slabs: 1
        rrset-cache-size: 2b
        rrset-cache-slabs: 1
        key-cache-size: 2b
        key-cache-slabs: 1
        neg-cache-size: 2b
...

Results:
Before

Read 9M.qerires, got 9000000 queries
qps: 137430
...
qps: 137043
overall time: 	15.0001 sec
0(NOERROR): 	2070494 replies
average qps: 	138032

After

Read 9M.qerires, got 9000000 queries
qps: 159759
qps: 161599
...
qps: 166993
qps: 157685
overall time: 	15 sec
0(NOERROR): 	2451661 replies
average qps: 	163444