### PR TITLE
Makefile.in: fix occasional parallel build failures around bison rule

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -509,9 +509,14 @@ util/configlexer.c:  $(srcdir)/util/configlexer.lex util/configparser.h
 	fi
 	@if test ! -f $@; then echo "No $@ : need flex and bison to compile from source repository"; exit 1; fi
 
-util/configparser.c util/configparser.h:  $(srcdir)/util/configparser.y
+# Builds both util/configparser.c and util/configparser.h.
+# To avoid double-building we split one target out.
+util/configparser.c:  $(srcdir)/util/configparser.y
 	@-if test ! -d util; then $(INSTALL) -d util; fi
 	$(YACC) -d -o util/configparser.c $(srcdir)/util/configparser.y
+
+util/configparser.h: util/configparser.c
+	touch $@
 
 clean:
 	rm -f *.o *.d *.lo *~ tags


### PR DESCRIPTION
Without the change `make -j16 --shuffle` occasinally fails to build as:

    $ make -j16 --shuffle
    ...
    bison -y -d -o util/configparser.c ./util/configparser.y
    ...
    /libtool --tag=CC --mode=compile gcc -I.  -I...-openssl-3.3.2-dev/include -I...-libevent-2.1.12-dev/include -I...-expat-2.6.3-dev/include -DSRCDIR=. -g -O2 -flto -fPIE -pthread  -o configparser.lo -c util/configparser.c
    ...
    util/configparser.c:755:3: error: expected ',' or '}' at end of input
    755 |   YYSYMBOL_server_low_rtt = 626,           /* server_low_rtt  */
        |   ^

The build failure happens due to this `Makefile.in` rule:

    util/configparser.c util/configparser.h:  $(srcdir)/util/configparser.y
        @-if test ! -d util; then $(INSTALL) -d util; fi
        $(YACC) -d -o util/configparser.c $(srcdir)/util/configparser.y

For GNU make that means that each of the targets will attempt the rule execution when the file is missing: one for .c file and another for .h file:

    https://www.gnu.org/software/make/manual/html_node/Multiple-Targets.html

The workaround is to only run $(YACC) for .c target and use .c as a pre-requisite for an .h file.

Before the change the build fails about every 10-th run. After the change no build failures after 100 successful builds.