### PR TITLE
Implement ECS address override feature

### DIFF
--- a/doc/unbound.conf.5.in
+++ b/doc/unbound.conf.5.in
@@ -2622,6 +2622,16 @@ the client query). If enabled, the address check is skipped when the client
 query contains an ECS record. And the lookup in the regular cache is skipped.
 Default is no.
 .TP
+.B client\-subnet\-address\-override\-ipv4: \fI<IPv4 subnet>\fR
+Override client source address in queries to the provided IPv4 subnet. Only
+applies if the query includes the ECS option and the ECS address family is IPv4.
+Default is to use the actual IPv4 subnet of the original client query.
+.TP
+.B client\-subnet\-address\-override\-ipv6: \fI<IPv6 subnet>\fR
+Override client source address in queries to the provided IPv6 subnet. Only
+applies if the query includes the ECS option and the ECS address family is IPv6.
+Default is to use the actual IPv6 subnet of the original client query.
+.TP
 .B max\-client\-subnet\-ipv6: \fI<number>\fR
 Specifies the maximum prefix length of the client source address we are willing
 to expose to third parties for IPv6.  Defaults to 56.

--- a/edns-subnet/subnetmod.h
+++ b/edns-subnet/subnetmod.h
@@ -59,6 +59,14 @@ struct subnet_env {
 	struct slabhash* subnet_msg_cache;
 	/** access control, which upstream servers we send client address */
 	struct ecs_whitelist* whitelist;
+	/** whether to override client source address for IPv4 */
+	int do_address_override_v4;
+	/** whether to override client source address for IPv6 */
+	int do_address_override_v6;
+	/** overide client source address value for IPv4 */
+	struct sockaddr_storage address_override_v4;
+	/** overide client source address value for IPv6 */
+	struct sockaddr_storage address_override_v6;
 	/** allocation service */
 	struct alloc_cache alloc;
 	lock_rw_type biglock;
@@ -159,5 +167,5 @@ void subnet_ecs_opt_list_append(struct ecs_data* ecs, struct edns_option** list,
 
 /** Create ecs_data from the sockaddr_storage information. */
 void subnet_option_from_ss(struct sockaddr_storage *ss, struct ecs_data* ecs,
-	struct config_file* cfg);
+	struct config_file* cfg, const struct subnet_env* sne);
 #endif /* SUBNETMOD_H */

--- a/util/config_file.c
+++ b/util/config_file.c
@@ -226,6 +226,8 @@ config_create(void)
 	cfg->client_subnet = NULL;
 	cfg->client_subnet_zone = NULL;
 	cfg->client_subnet_opcode = LDNS_EDNS_CLIENT_SUBNET;
+	cfg->client_subnet_address_override_ipv4 = NULL;
+	cfg->client_subnet_address_override_ipv6 = NULL;
 	cfg->client_subnet_always_forward = 0;
 	cfg->max_client_subnet_ipv4 = 24;
 	cfg->max_client_subnet_ipv6 = 56;
@@ -1255,6 +1257,8 @@ config_get_option(struct config_file* cfg, const char* opt,
 #ifdef CLIENT_SUBNET
 	else O_LST(opt, "send-client-subnet", client_subnet)
 	else O_LST(opt, "client-subnet-zone", client_subnet_zone)
+	else O_STR(opt, "client-subnet-address-override-ipv4", client_subnet_address_override_ipv4)
+	else O_STR(opt, "client-subnet-address-override-ipv6", client_subnet_address_override_ipv6)
 	else O_DEC(opt, "max-client-subnet-ipv4", max_client_subnet_ipv4)
 	else O_DEC(opt, "max-client-subnet-ipv6", max_client_subnet_ipv6)
 	else O_DEC(opt, "min-client-subnet-ipv4", min_client_subnet_ipv4)
@@ -1689,6 +1693,8 @@ config_delete(struct config_file* cfg)
 #ifdef CLIENT_SUBNET
 	config_delstrlist(cfg->client_subnet);
 	config_delstrlist(cfg->client_subnet_zone);
+	free(cfg->client_subnet_address_override_ipv4);
+	free(cfg->client_subnet_address_override_ipv6);
 #endif
 	free(cfg->identity);
 	free(cfg->version);

--- a/util/config_file.h
+++ b/util/config_file.h
@@ -267,6 +267,10 @@ struct config_file {
 	struct config_strlist* client_subnet_zone;
 	/** opcode assigned by IANA for edns0-client-subnet option */
 	uint16_t client_subnet_opcode;
+	/** Override the outgoing client subnet source address to this value (IPv4) */
+	char *client_subnet_address_override_ipv4;
+	/** Override the outgoing client subnet source address to this value (IPv6) */
+	char *client_subnet_address_override_ipv6;
 	/** Do not check whitelist if incoming query contains an ECS record */
 	int client_subnet_always_forward;
 	/** Subnet length we are willing to give up privacy for */

--- a/util/configlexer.lex
+++ b/util/configlexer.lex
@@ -376,6 +376,8 @@ send-client-subnet{COLON}	{ YDVAR(1, VAR_SEND_CLIENT_SUBNET) }
 client-subnet-zone{COLON}	{ YDVAR(1, VAR_CLIENT_SUBNET_ZONE) }
 client-subnet-always-forward{COLON} { YDVAR(1, VAR_CLIENT_SUBNET_ALWAYS_FORWARD) }
 client-subnet-opcode{COLON}	{ YDVAR(1, VAR_CLIENT_SUBNET_OPCODE) }
+client-subnet-address-override-ipv4{COLON} { YDVAR(1, VAR_CLIENT_SUBNET_ADDRESS_OVERRIDE_IPV4) }
+client-subnet-address-override-ipv6{COLON} { YDVAR(1, VAR_CLIENT_SUBNET_ADDRESS_OVERRIDE_IPV6) }
 max-client-subnet-ipv4{COLON}	{ YDVAR(1, VAR_MAX_CLIENT_SUBNET_IPV4) }
 max-client-subnet-ipv6{COLON}	{ YDVAR(1, VAR_MAX_CLIENT_SUBNET_IPV6) }
 min-client-subnet-ipv4{COLON}	{ YDVAR(1, VAR_MIN_CLIENT_SUBNET_IPV4) }

--- a/util/configparser.y
+++ b/util/configparser.y
@@ -150,6 +150,8 @@ extern struct config_parser_state* cfg_parser;
 %token VAR_IP_RATELIMIT_BACKOFF VAR_RATELIMIT_BACKOFF
 %token VAR_SEND_CLIENT_SUBNET VAR_CLIENT_SUBNET_ZONE
 %token VAR_CLIENT_SUBNET_ALWAYS_FORWARD VAR_CLIENT_SUBNET_OPCODE
+%token VAR_CLIENT_SUBNET_ADDRESS_OVERRIDE_IPV4
+%token VAR_CLIENT_SUBNET_ADDRESS_OVERRIDE_IPV6
 %token VAR_MAX_CLIENT_SUBNET_IPV4 VAR_MAX_CLIENT_SUBNET_IPV6
 %token VAR_MIN_CLIENT_SUBNET_IPV4 VAR_MIN_CLIENT_SUBNET_IPV6
 %token VAR_MAX_ECS_TREE_SIZE_IPV4 VAR_MAX_ECS_TREE_SIZE_IPV6
@@ -302,6 +304,7 @@ content_server: server_num_threads | server_verbosity | server_port |
 	server_max_sent_count | server_max_query_restarts |
 	server_send_client_subnet | server_client_subnet_zone |
 	server_client_subnet_always_forward | server_client_subnet_opcode |
+	server_client_subnet_address_override_ipv4 | server_client_subnet_address_override_ipv6 |
 	server_max_client_subnet_ipv4 | server_max_client_subnet_ipv6 |
 	server_min_client_subnet_ipv4 | server_min_client_subnet_ipv6 |
 	server_max_ecs_tree_size_ipv4 | server_max_ecs_tree_size_ipv6 |
@@ -691,6 +694,26 @@ server_client_subnet_opcode: VAR_CLIENT_SUBNET_OPCODE STRING_ARG
 		OUTYY(("P(Compiled without edns subnet option, ignoring)\n"));
 	#endif
 		free($2);
+	}
+	;
+server_client_subnet_address_override_ipv4: VAR_CLIENT_SUBNET_ADDRESS_OVERRIDE_IPV4 STRING_ARG
+	{
+	#ifdef CLIENT_SUBNET
+		OUTYY(("P(client_subnet_address_override_ipv4:%s)\n", $2));
+		cfg_parser->cfg->client_subnet_address_override_ipv4 = $2;
+	#else
+		OUTYY(("P(Compiled without edns subnet option, ignoring)\n"));
+	#endif
+	}
+	;
+server_client_subnet_address_override_ipv6: VAR_CLIENT_SUBNET_ADDRESS_OVERRIDE_IPV6 STRING_ARG
+	{
+	#ifdef CLIENT_SUBNET
+		OUTYY(("P(client_subnet_address_override_ipv6:%s)\n", $2));
+		cfg_parser->cfg->client_subnet_address_override_ipv6 = $2;
+	#else
+		OUTYY(("P(Compiled without edns subnet option, ignoring)\n"));
+	#endif
 	}
 	;
 server_max_client_subnet_ipv4: VAR_MAX_CLIENT_SUBNET_IPV4 STRING_ARG


### PR DESCRIPTION
This commit implements an EDNS Client Subnet address override feature. It is controlled by two newly introduced config options `client-subnet-address-override-ipv4` and `client-subnet-address-override-ipv6`. If set, when a query is initiated by Unbound using the ECS option, the override address value specified in the config will be substituted and used instead of the original value calculated from the client's actual source address.

This can be useful in certain situations where the original ECS address value doesn't make sense. E.g., it's generally not useful to send ECS queries to nameservers on the Internet using RFC 1918 subnet address values. Or it may be helpful to spoof the ECS address value to a nearby subnet if an ECS-enabled nameserver has incorrect geolocation data for the real subnet value.

This commit does not include the re-generated flex/bison output files due to the changes to the .lex/.y files. Those changes should be added as a followup if this patch is merged.