### PR TITLE
Fix chroot manpage description

### DIFF
--- a/doc/Changelog
+++ b/doc/Changelog
@@ -1,3 +1,6 @@
+30 October 2024: ?
+	- Fix #1164: Fix default chroot manpage sentence.
+
 25 October 2024: Yorgos
 	- Fix #1163: Typos in unbound.conf documentation.
 

--- a/doc/Changelog
+++ b/doc/Changelog
@@ -1,6 +1,3 @@
-30 October 2024: ?
-	- Fix #1164: Fix default chroot manpage sentence.
-
 25 October 2024: Yorgos
 	- Fix #1163: Typos in unbound.conf documentation.
 

--- a/doc/unbound.conf.5.in
+++ b/doc/unbound.conf.5.in
@@ -902,9 +902,8 @@ outside of the chroot directory.
 Additionally, Unbound may need to access /dev/urandom (for entropy)
 from inside the chroot.
 .IP
-If given a chroot is done to the given directory. By default chroot is
-enabled and the default is "@UNBOUND_CHROOT_DIR@". If you give "" no
-chroot is performed.
+If given a chroot is done to the given directory. The chroot is by default 
+set to "@UNBOUND_CHROOT_DIR@". If you give "" no chroot is performed.
 .TP
 .B username: \fI<name>
 If given, after binding the port the user privileges are dropped. Default is


### PR DESCRIPTION
Rephrase the man page sentence about what the default chroot is set to, which could also be set to: "" by default. In some distributions like Ubuntu and Fedora this is set to "", which means by default disabled.

So you can't say chroot is enabled by default, since that is not always the case.

Fixes: #1164
