### PR TITLE
Introducing Unbound Guru on Gurubase.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 [![Fuzzing Status](https://oss-fuzz-build-logs.storage.googleapis.com/badges/unbound.svg)](https://bugs.chromium.org/p/oss-fuzz/issues/list?sort=-opened&can=1&q=proj:unbound)
 [![Documentation Status](https://readthedocs.org/projects/unbound/badge/?version=latest)](https://unbound.readthedocs.io/en/latest/?badge=latest)
 [![Mastodon Follow](https://img.shields.io/mastodon/follow/109262826617293067?domain=https%3A%2F%2Ffosstodon.org&style=social)](https://fosstodon.org/@nlnetlabs)
+[![Gurubase](https://img.shields.io/badge/Gurubase-Ask%20Unbound%20Guru-006BFF)](https://gurubase.io/g/unbound)
 
 Unbound is a validating, recursive, caching DNS resolver. It is designed to be
 fast and lean and incorporates modern features based on open standards. If you


### PR DESCRIPTION
Hello team,

I'm the maintainer of [Anteon](https://github.com/getanteon/anteon). We have created Gurubase.io with the mission of building a centralized, open-source tool-focused knowledge base. Essentially, each "guru" is equipped with custom knowledge to answer user questions based on collected data related to that tool.

I wanted to update you that I've manually added the [Unbound Guru](https://gurubase.io/g/unbound) to Gurubase. Unbound Guru uses the data from this repo and data from the [docs](https://unbound.docs.nlnetlabs.nl/en/latest/) to answer questions by leveraging the LLM.

In this PR, I showcased the "Unbound Guru", which highlights that Unbound now has an AI assistant available to help users with their questions. Please let me know your thoughts on this contribution.

Additionally, if you want me to disable Unbound Guru in Gurubase, just let me know that's totally fine.
