### PR TITLE
Create the SSL_CTX for QUIC before chroot and privilege drop

### DIFF
--- a/daemon/daemon.c
+++ b/daemon/daemon.c
@@ -957,6 +957,9 @@ daemon_delete(struct daemon* daemon)
 	SSL_CTX_free((SSL_CTX*)daemon->listen_sslctx);
 	SSL_CTX_free((SSL_CTX*)daemon->connect_sslctx);
 #endif
+#ifdef HAVE_NGTCP2
+	SSL_CTX_free((SSL_CTX*)daemon->quic_sslctx);
+#endif
 	free(daemon);
 	/* lex cleanup */
 	ub_c_lex_destroy();

--- a/daemon/daemon.h
+++ b/daemon/daemon.h
@@ -99,6 +99,8 @@ struct daemon {
 	struct daemon_remote* rc;
 	/** ssl context for listening to dnstcp over ssl, and connecting ssl */
 	void* listen_sslctx, *connect_sslctx;
+	/** ssl context for listening to quic */
+	void* quic_sslctx;
 	/** num threads allocated */
 	int num;
 	/** num threads allocated in the previous config or 0 at first */

--- a/daemon/worker.c
+++ b/daemon/worker.c
@@ -2174,9 +2174,9 @@ worker_init(struct worker* worker, struct config_file *cfg,
 		cfg->harden_large_queries, cfg->http_max_streams,
 		cfg->http_endpoint, cfg->http_notls_downstream,
 		worker->daemon->tcl, worker->daemon->listen_sslctx,
+		worker->daemon->quic_sslctx,
 		dtenv, worker->daemon->doq_table, worker->env.rnd,
-		cfg->ssl_service_key, cfg->ssl_service_pem, cfg,
-		worker_handle_request, worker);
+		cfg, worker_handle_request, worker);
 	if(!worker->front) {
 		log_err("could not create listening sockets");
 		worker_delete(worker);

--- a/services/listen_dnsport.c
+++ b/services/listen_dnsport.c
@@ -4602,7 +4602,7 @@ doq_alpn_select_cb(SSL* ATTR_UNUSED(ssl), const unsigned char** out,
 
 void* quic_sslctx_create(char* key, char* pem, char* verifypem)
 {
-#ifdef HAVE_NGHTTP2
+#ifdef HAVE_NGTCP2
 	char* sid_ctx = "unbound server";
 #ifndef HAVE_NGTCP2_CRYPTO_QUICTLS_CONFIGURE_SERVER_CONTEXT
 	SSL_QUIC_METHOD* quic_method;
@@ -4695,10 +4695,10 @@ void* quic_sslctx_create(char* key, char* pem, char* verifypem)
 	SSL_CTX_set_quic_method(ctx, doq_socket->quic_method);
 #endif
 	return ctx;
-#else /* HAVE_NGHTTP2 */
+#else /* HAVE_NGTCP2 */
 	(void)key; (void)pem; (void)verifypem;
 	return NULL;
-#endif /* HAVE_NGHTTP2 */
+#endif /* HAVE_NGTCP2 */
 }
 
 /** Get the ngtcp2_conn from ssl userdata of type ngtcp2_conn_ref */

--- a/services/listen_dnsport.h
+++ b/services/listen_dnsport.h
@@ -195,11 +195,10 @@ int resolve_interface_names(char** ifs, int num_ifs,
  * @param http_notls: no TLS for http downstream
  * @param tcp_conn_limit: TCP connection limit info.
  * @param sslctx: nonNULL if ssl context.
+ * @param quic_sslctx: nonNULL if quic ssl context.
  * @param dtenv: nonNULL if dnstap enabled.
  * @param doq_table: the doq connection table, with shared information.
  * @param rnd: random state.
- * @param ssl_service_key: the SSL service key file.
- * @param ssl_service_pem: the SSL service pem file.
  * @param cfg: config file struct.
  * @param cb: callback function when a request arrives. It is passed
  *	  the packet and user argument. Return true to send a reply.
@@ -211,9 +210,9 @@ listen_create(struct comm_base* base, struct listen_port* ports,
 	size_t bufsize, int tcp_accept_count, int tcp_idle_timeout,
 	int harden_large_queries, uint32_t http_max_streams,
 	char* http_endpoint, int http_notls, struct tcl_list* tcp_conn_limit,
-	void* sslctx, struct dt_env* dtenv, struct doq_table* doq_table,
-	struct ub_randstate* rnd, const char* ssl_service_key,
-	const char* ssl_service_pem, struct config_file* cfg,
+	void* sslctx, void* quic_sslctx, struct dt_env* dtenv,
+	struct doq_table* doq_table,
+	struct ub_randstate* rnd,struct config_file* cfg,
 	comm_point_callback_type* cb, void *cb_arg);
 
 /**
@@ -512,6 +511,15 @@ struct doq_table {
 	size_t current_size;
 };
 
+/**
+ * create SSL context for QUIC
+ * @param key: private key file.
+ * @param pem: public key cert.
+ * @param verifypem: if nonNULL, verifylocation file.
+ * return SSL_CTX* or NULL on failure (logged).
+ */
+void* quic_sslctx_create(char* key, char* pem, char* verifypem);
+
 /** create doq table */
 struct doq_table* doq_table_create(struct config_file* cfg,
 	struct ub_randstate* rnd);
@@ -711,9 +719,6 @@ int doq_timer_cmp(const void* key1, const void* key2);
 
 /** compare function of doq_stream */
 int doq_stream_cmp(const void* key1, const void* key2);
-
-/** setup the doq_socket server tls context */
-int doq_socket_setup_ctx(struct doq_server_socket* doq_socket);
 
 /** setup the doq connection callbacks, and settings. */
 int doq_conn_setup(struct doq_conn* conn, uint8_t* scid, size_t scidlen,

--- a/testcode/fake_event.c
+++ b/testcode/fake_event.c
@@ -938,11 +938,10 @@ listen_create(struct comm_base* base, struct listen_port* ATTR_UNUSED(ports),
 	char* ATTR_UNUSED(http_endpoint),
 	int ATTR_UNUSED(http_notls),
 	struct tcl_list* ATTR_UNUSED(tcp_conn_limit),
-	void* ATTR_UNUSED(sslctx), struct dt_env* ATTR_UNUSED(dtenv),
+	void* ATTR_UNUSED(sslctx), void* ATTR_UNUSED(quic_ssl),
+	struct dt_env* ATTR_UNUSED(dtenv),
 	struct doq_table* ATTR_UNUSED(table),
 	struct ub_randstate* ATTR_UNUSED(rnd),
-	const char* ATTR_UNUSED(ssl_service_key),
-	const char* ATTR_UNUSED(ssl_service_pem),
 	struct config_file* ATTR_UNUSED(cfg),
 	comm_point_callback_type* cb, void *cb_arg)
 {

--- a/testcode/testbound.c
+++ b/testcode/testbound.c
@@ -602,6 +602,12 @@ void listen_desetup_locks(void)
 }
 
 #ifdef HAVE_NGTCP2
+void* quic_sslctx_create(char* ATTR_UNUSED(key), char* ATTR_UNUSED(pem),
+	char* ATTR_UNUSED(verifypem))
+{
+    return NULL;
+}
+
 void comm_point_doq_callback(int ATTR_UNUSED(fd), short ATTR_UNUSED(event),
 	void* ATTR_UNUSED(arg))
 {

--- a/util/net_help.h
+++ b/util/net_help.h
@@ -488,7 +488,7 @@ int listen_sslctx_setup(void* ctxt);
  */
 void listen_sslctx_setup_2(void* ctxt);
 
-/** 
+/**
  * create SSL listen context
  * @param key: private key file.
  * @param pem: public key cert.

--- a/util/netevent.h
+++ b/util/netevent.h
@@ -593,8 +593,7 @@ struct comm_point* comm_point_create_udp_ancil(struct comm_base* base,
  * @param socket: and opened socket properties will be passed to your callback function.
  * @param table: the doq connection table for the host.
  * @param rnd: random generator to use.
- * @param ssl_service_key: the ssl service key file.
- * @param ssl_service_pem: the ssl service pem file.
+ * @param quic_sslctx: the quic ssl context.
  * @param cfg: config file struct.
  * @return: returns the allocated communication point. NULL on error.
  * Sets timeout to NULL. Turns off TCP options.
@@ -603,8 +602,8 @@ struct comm_point* comm_point_create_doq(struct comm_base* base,
 	int fd, struct sldns_buffer* buffer,
 	comm_point_callback_type* callback, void* callback_arg,
 	struct unbound_socket* socket, struct doq_table* table,
-	struct ub_randstate* rnd, const char* ssl_service_key,
-	const char* ssl_service_pem, struct config_file* cfg);
+	struct ub_randstate* rnd, const void* quic_sslctx,
+	struct config_file* cfg);
 
 /**
  * Create a TCP listener comm point. Calls malloc.
@@ -1045,12 +1044,6 @@ struct doq_server_socket {
 	struct ub_randstate* rnd;
 	/** if address validation is enabled */
 	uint8_t validate_addr;
-	/** the ssl service key file */
-	char* ssl_service_key;
-	/** the ssl service pem file */
-	char* ssl_service_pem;
-	/** the ssl verify pem file */
-	char* ssl_verify_pem;
 	/** the server scid length */
 	int sv_scidlen;
 	/** the idle timeout in nanoseconds */

--- a/winrc/win_svc.c
+++ b/winrc/win_svc.c
@@ -366,6 +366,11 @@ service_init(int r, struct daemon** d, struct config_file** c)
 		if(!(daemon->listen_sslctx = listen_sslctx_create(
 			cfg->ssl_service_key, cfg->ssl_service_pem, NULL)))
 			fatal_exit("could not set up listen SSL_CTX");
+#ifdef HAVE_NGTCP2
+		if(!(daemon->quic_sslctx = quic_sslctx_create(
+			cfg->ssl_service_key, cfg->ssl_service_pem, NULL)))
+			fatal_exit("could not set up quic SSL_CTX");
+#endif /* HAVE_NGTCP2 */
 	}
 	if(!(daemon->connect_sslctx = connect_sslctx_create(NULL, NULL,
 		cfg->tls_cert_bundle, cfg->tls_win_cert)))


### PR DESCRIPTION
For behavioral consistency with the other SSL_CTX creations. Fixes #1185.