### PR TITLE
Fix the dname_str method to cause conversion errors when the domain name length is 255

### DIFF
--- a/util/data/dname.c
+++ b/util/data/dname.c
@@ -654,7 +654,7 @@ void dname_str(uint8_t* dname, char* str)
 			return;
 		}
 		len += lablen+1;
-		if(len >= LDNS_MAX_DOMAINLEN-1) {
+		if(len >= LDNS_MAX_DOMAINLEN) {
 			*s++ = '&';
 			*s = 0;
 			return;


### PR DESCRIPTION
Fix #1188 