### PR TITLE
dname_str() fixes

### DIFF
--- a/daemon/cachedump.c
+++ b/daemon/cachedump.c
@@ -836,7 +836,7 @@ int print_deleg_lookup(RES* ssl, struct worker* worker, uint8_t* nm,
 	struct delegpt* dp;
 	struct dns_msg* msg;
 	struct regional* region = worker->scratchpad;
-	char b[260];
+	char b[LDNS_MAX_DOMAINLEN];
 	struct query_info qinfo;
 	struct iter_hints_stub* stub;
 	int nolock = 0;

--- a/daemon/remote.c
+++ b/daemon/remote.c
@@ -2141,7 +2141,7 @@ static int
 ssl_print_name_dp(RES* ssl, const char* str, uint8_t* nm, uint16_t dclass,
 	struct delegpt* dp)
 {
-	char buf[257];
+	char buf[LDNS_MAX_DOMAINLEN];
 	struct delegpt_ns* ns;
 	struct delegpt_addr* a;
 	int f = 0;
@@ -2509,7 +2509,7 @@ do_insecure_remove(RES* ssl, struct worker* worker, char* arg)
 static void
 do_insecure_list(RES* ssl, struct worker* worker)
 {
-	char buf[257];
+	char buf[LDNS_MAX_DOMAINLEN];
 	struct trust_anchor* a;
 	if(worker->env.anchors) {
 		RBTREE_FOR(a, struct trust_anchor*, worker->env.anchors->tree) {
@@ -2606,7 +2606,7 @@ get_mesh_status(struct mesh_area* mesh, struct mesh_state* m,
 		}
 	} else if(s == module_wait_subquery) {
 		/* look in subs from mesh state to see what */
-		char nm[257];
+		char nm[LDNS_MAX_DOMAINLEN];
 		struct mesh_state_ref* sub;
 		snprintf(buf, len, "%s wants", modname);
 		l = strlen(buf);
@@ -2636,7 +2636,7 @@ do_dump_requestlist(RES* ssl, struct worker* worker)
 	struct mesh_area* mesh;
 	struct mesh_state* m;
 	int num = 0;
-	char buf[257];
+	char buf[LDNS_MAX_DOMAINLEN];
 	char timebuf[32];
 	char statbuf[10240];
 	if(!ssl_printf(ssl, "thread #%d\n", worker->thread_num))
@@ -2686,7 +2686,7 @@ dump_infra_host(struct lruhash_entry* e, void* arg)
 	struct infra_key* k = (struct infra_key*)e->key;
 	struct infra_data* d = (struct infra_data*)e->data;
 	char ip_str[1024];
-	char name[257];
+	char name[LDNS_MAX_DOMAINLEN];
 	int port;
 	if(a->ssl_failed)
 		return;
@@ -2953,7 +2953,7 @@ static void
 do_list_auth_zones(RES* ssl, struct auth_zones* az)
 {
 	struct auth_zone* z;
-	char buf[257], buf2[256];
+	char buf[LDNS_MAX_DOMAINLEN], buf2[256];
 	lock_rw_rdlock(&az->lock);
 	RBTREE_FOR(z, struct auth_zone*, &az->ztree) {
 		lock_rw_rdlock(&z->lock);
@@ -2983,7 +2983,7 @@ static void
 do_list_local_zones(RES* ssl, struct local_zones* zones)
 {
 	struct local_zone* z;
-	char buf[257];
+	char buf[LDNS_MAX_DOMAINLEN];
 	lock_rw_rdlock(&zones->lock);
 	RBTREE_FOR(z, struct local_zone*, &zones->ztree) {
 		lock_rw_rdlock(&z->lock);
@@ -3094,7 +3094,7 @@ rate_list(struct lruhash_entry* e, void* arg)
 	struct ratelimit_list_arg* a = (struct ratelimit_list_arg*)arg;
 	struct rate_key* k = (struct rate_key*)e->key;
 	struct rate_data* d = (struct rate_data*)e->data;
-	char buf[257];
+	char buf[LDNS_MAX_DOMAINLEN];
 	int lim = infra_find_ratelimit(a->infra, k->name, k->namelen);
 	int max = infra_rate_max(d, a->now, a->backoff);
 	if(a->all == 0) {

--- a/daemon/worker.c
+++ b/daemon/worker.c
@@ -1082,7 +1082,7 @@ answer_notify(struct worker* w, struct query_info* qinfo,
 
 	if(verbosity >= VERB_DETAIL) {
 		char buf[380];
-		char zname[255+1];
+		char zname[LDNS_MAX_DOMAINLEN];
 		char sr[25];
 		dname_str(qinfo->qname, zname);
 		sr[0]=0;
@@ -1413,7 +1413,7 @@ worker_handle_request(struct comm_point* c, void* arg, int error,
 		return 0;
 	}
 	if(c->dnscrypt && !repinfo->is_dnscrypted) {
-		char buf[LDNS_MAX_DOMAINLEN+1];
+		char buf[LDNS_MAX_DOMAINLEN];
 		/* Check if this is unencrypted and asking for certs */
 		worker_check_request(c->buffer, worker, &check_result);
 		if(check_result.value != 0) {

--- a/iterator/iter_delegpt.c
+++ b/iterator/iter_delegpt.c
@@ -278,7 +278,7 @@ delegpt_count_addr(struct delegpt* dp, size_t* numaddr, size_t* numres,
 
 void delegpt_log(enum verbosity_value v, struct delegpt* dp)
 {
-	char buf[LDNS_MAX_DOMAINLEN+1];
+	char buf[LDNS_MAX_DOMAINLEN];
 	struct delegpt_ns* ns;
 	struct delegpt_addr* a;
 	size_t missing=0, numns=0, numaddr=0, numres=0, numavail=0;

--- a/iterator/iter_fwd.c
+++ b/iterator/iter_fwd.c
@@ -129,7 +129,7 @@ forwards_insert_data(struct iter_forwards* fwd, uint16_t c, uint8_t* nm,
 	node->namelabs = nmlabs;
 	node->dp = dp;
 	if(!rbtree_insert(fwd->tree, &node->node)) {
-		char buf[257];
+		char buf[LDNS_MAX_DOMAINLEN];
 		dname_str(nm, buf);
 		log_err("duplicate forward zone %s ignored.", buf);
 		delegpt_free_mlc(dp);

--- a/iterator/iter_hints.c
+++ b/iterator/iter_hints.c
@@ -181,7 +181,7 @@ hints_insert(struct iter_hints* hints, uint16_t c, struct delegpt* dp,
 	node->noprime = (uint8_t)noprime;
 	if(!name_tree_insert(&hints->tree, &node->node, dp->name, dp->namelen,
 		dp->namelabs, c)) {
-		char buf[257];
+		char buf[LDNS_MAX_DOMAINLEN];
 		dname_str(dp->name, buf);
 		log_err("second hints for zone %s ignored.", buf);
 		delegpt_free_mlc(dp);

--- a/iterator/iter_utils.c
+++ b/iterator/iter_utils.c
@@ -1492,8 +1492,8 @@ iter_stub_fwd_no_cache(struct module_qstate *qstate, struct query_info *qinf,
 		int stub_no_cache = stub->dp->no_cache;
 		lock_rw_unlock(&qstate->env->fwds->lock);
 		if(stub_no_cache) {
-			char qname[255+1];
-			char dpname[255+1];
+			char qname[LDNS_MAX_DOMAINLEN];
+			char dpname[LDNS_MAX_DOMAINLEN];
 			dname_str(qinf->qname, qname);
 			dname_str(stub->dp->name, dpname);
 			verbose(VERB_ALGO, "stub for %s %s has no_cache", qname, dpname);
@@ -1520,8 +1520,8 @@ iter_stub_fwd_no_cache(struct module_qstate *qstate, struct query_info *qinf,
 		int dp_no_cache = dp->no_cache;
 		lock_rw_unlock(&qstate->env->hints->lock);
 		if(dp_no_cache) {
-			char qname[255+1];
-			char dpname[255+1];
+			char qname[LDNS_MAX_DOMAINLEN];
+			char dpname[LDNS_MAX_DOMAINLEN];
 			dname_str(qinf->qname, qname);
 			dname_str(dp->name, dpname);
 			verbose(VERB_ALGO, "forward for %s %s has no_cache", qname, dpname);

--- a/iterator/iterator.c
+++ b/iterator/iterator.c
@@ -1092,7 +1092,7 @@ auth_zone_delegpt(struct module_qstate* qstate, struct iter_qstate* iq,
 			/* cache is blacklisted and fallback, and we
 			 * already have an auth_zone dp */
 			if(verbosity>=VERB_ALGO) {
-				char buf[255+1];
+				char buf[LDNS_MAX_DOMAINLEN];
 				dname_str(z->name, buf);
 				verbose(VERB_ALGO, "auth_zone %s "
 				  "fallback because cache blacklisted",
@@ -1109,7 +1109,7 @@ auth_zone_delegpt(struct module_qstate* qstate, struct iter_qstate* iq,
 				 * validation failure, and the zone allows
 				 * fallback to the internet, query there. */
 				if(verbosity>=VERB_ALGO) {
-					char buf[255+1];
+					char buf[LDNS_MAX_DOMAINLEN];
 					dname_str(z->name, buf);
 					verbose(VERB_ALGO, "auth_zone %s "
 					  "fallback because cache blacklisted",
@@ -2033,7 +2033,7 @@ query_for_targets(struct module_qstate* qstate, struct iter_qstate* iq,
 		return 1;
 	if(iq->depth > 0 && iq->target_count &&
 		iq->target_count[TARGET_COUNT_QUERIES] > MAX_TARGET_COUNT) {
-		char s[LDNS_MAX_DOMAINLEN+1];
+		char s[LDNS_MAX_DOMAINLEN];
 		dname_str(qstate->qinfo.qname, s);
 		verbose(VERB_QUERY, "request %s has exceeded the maximum "
 			"number of glue fetches %d", s,
@@ -2041,7 +2041,7 @@ query_for_targets(struct module_qstate* qstate, struct iter_qstate* iq,
 		return 2;
 	}
 	if(iq->dp_target_count > MAX_DP_TARGET_COUNT) {
-		char s[LDNS_MAX_DOMAINLEN+1];
+		char s[LDNS_MAX_DOMAINLEN];
 		dname_str(qstate->qinfo.qname, s);
 		verbose(VERB_QUERY, "request %s has exceeded the maximum "
 			"number of glue fetches %d to a single delegation point",
@@ -2252,7 +2252,7 @@ processLastResort(struct module_qstate* qstate, struct iter_qstate* iq,
 	}
 	if(iq->depth > 0 && iq->target_count &&
 		iq->target_count[TARGET_COUNT_QUERIES] > MAX_TARGET_COUNT) {
-		char s[LDNS_MAX_DOMAINLEN+1];
+		char s[LDNS_MAX_DOMAINLEN];
 		dname_str(qstate->qinfo.qname, s);
 		verbose(VERB_QUERY, "request %s has exceeded the maximum "
 			"number of glue fetches %d", s,
@@ -3044,7 +3044,7 @@ processQueryTargets(struct module_qstate* qstate, struct iter_qstate* iq,
 	target_count_increase_global_quota(iq, 1);
 	if(iq->target_count && iq->target_count[TARGET_COUNT_GLOBAL_QUOTA]
 		> MAX_GLOBAL_QUOTA) {
-		char s[LDNS_MAX_DOMAINLEN+1];
+		char s[LDNS_MAX_DOMAINLEN];
 		dname_str(qstate->qinfo.qname, s);
 		verbose(VERB_QUERY, "request %s has exceeded the maximum "
 			"global quota on number of upstream queries %d", s,

--- a/libunbound/libworker.c
+++ b/libunbound/libworker.c
@@ -423,7 +423,7 @@ int libworker_bg(struct ub_ctx* ctx)
 static int
 fill_canon(struct ub_result* res, uint8_t* s)
 {
-	char buf[255+2];
+	char buf[LDNS_MAX_DOMAINLEN];
 	dname_str(s, buf);
 	res->canonname = strdup(buf);
 	return res->canonname != 0;

--- a/pythonmod/interface.i
+++ b/pythonmod/interface.i
@@ -204,7 +204,7 @@ struct query_info {
 
 %inline %{
    PyObject* dnameAsStr(PyObject* dname) {
-       char buf[LDNS_MAX_DOMAINLEN+1];
+       char buf[LDNS_MAX_DOMAINLEN];
        buf[0] = '\0';
        dname_str((uint8_t*)PyBytes_AsString(dname), buf);
        return PyString_FromString(buf);

--- a/respip/respip.c
+++ b/respip/respip.c
@@ -961,7 +961,7 @@ respip_rewrite_reply(const struct query_info* qinfo,
 						struct sockaddr_storage ss;
 						socklen_t ss_len = 0;
 						char nm[256], ip[256];
-						char qn[255+1];
+						char qn[LDNS_MAX_DOMAINLEN];
 						if(!rdata2sockaddr(rep->rrsets[rrset_id]->entry.data, ntohs(rep->rrsets[rrset_id]->rk.type), rr_id, &ss, &ss_len))
 							snprintf(ip, sizeof(ip), "invalidRRdata");
 						else

--- a/services/authzone.c
+++ b/services/authzone.c
@@ -1578,7 +1578,7 @@ auth_zone_read_zonefile(struct auth_zone* z, struct config_file* cfg)
 		cfg->chrootdir, strlen(cfg->chrootdir)) == 0)
 		zfilename += strlen(cfg->chrootdir);
 	if(verbosity >= VERB_ALGO) {
-		char nm[255+1];
+		char nm[LDNS_MAX_DOMAINLEN];
 		dname_str(z->name, nm);
 		verbose(VERB_ALGO, "read zonefile %s for %s", zfilename, nm);
 	}
@@ -1942,7 +1942,7 @@ static int auth_zone_zonemd_check_hash(struct auth_zone* z,
 					unsupported_reason = *reason;
 				/* continue to check for valid ZONEMD */
 				if(verbosity >= VERB_ALGO) {
-					char zstr[255+1];
+					char zstr[LDNS_MAX_DOMAINLEN];
 					dname_str(z->name, zstr);
 					verbose(VERB_ALGO, "auth-zone %s ZONEMD %d %d is unsupported: %s", zstr, (int)scheme, (int)hashalgo, *reason);
 				}
@@ -1950,7 +1950,7 @@ static int auth_zone_zonemd_check_hash(struct auth_zone* z,
 				continue;
 			}
 			if(verbosity >= VERB_ALGO) {
-				char zstr[255+1];
+				char zstr[LDNS_MAX_DOMAINLEN];
 				dname_str(z->name, zstr);
 				if(!*reason)
 					verbose(VERB_ALGO, "auth-zone %s ZONEMD hash is correct", zstr);
@@ -1973,7 +1973,7 @@ static int auth_zone_zonemd_check_hash(struct auth_zone* z,
 	if(!*reason)
 		*reason = "no ZONEMD records found";
 	if(verbosity >= VERB_ALGO) {
-		char zstr[255+1];
+		char zstr[LDNS_MAX_DOMAINLEN];
 		dname_str(z->name, zstr);
 		verbose(VERB_ALGO, "auth-zone %s ZONEMD failed: %s", zstr, *reason);
 	}
@@ -4799,8 +4799,8 @@ log_rrlist_position(const char* label, struct auth_chunk* rr_chunk,
 {
 	sldns_buffer pkt;
 	size_t dlen;
-	uint8_t buf[256];
-	char str[256];
+	uint8_t buf[LDNS_MAX_DOMAINLEN];
+	char str[LDNS_MAX_DOMAINLEN];
 	char typestr[32];
 	sldns_buffer_init_frm_data(&pkt, rr_chunk->data, rr_chunk->len);
 	sldns_buffer_set_position(&pkt, (size_t)(rr_dname -
@@ -5227,7 +5227,7 @@ xfr_write_after_update(struct auth_xfer* xfr, struct module_env* env)
 		cfg->chrootdir, strlen(cfg->chrootdir)) == 0)
 		zfilename += strlen(cfg->chrootdir);
 	if(verbosity >= VERB_ALGO) {
-		char nm[255+1];
+		char nm[LDNS_MAX_DOMAINLEN];
 		dname_str(z->name, nm);
 		verbose(VERB_ALGO, "write zonefile %s for %s", zfilename, nm);
 	}
@@ -5344,7 +5344,7 @@ xfr_process_chunk_list(struct auth_xfer* xfr, struct module_env* env,
 	/* holding z lock */
 	auth_zone_verify_zonemd(z, env, &env->mesh->mods, NULL, 0, 0);
 	if(z->zone_expired) {
-		char zname[256];
+		char zname[LDNS_MAX_DOMAINLEN];
 		/* ZONEMD must have failed */
 		/* reacquire locks, so we hold xfr lock on exit of routine,
 		 * and both xfr and z again after releasing xfr for potential
@@ -5376,7 +5376,7 @@ xfr_process_chunk_list(struct auth_xfer* xfr, struct module_env* env,
 	lock_rw_unlock(&z->lock);
 
 	if(verbosity >= VERB_QUERY && xfr->have_zone) {
-		char zname[256];
+		char zname[LDNS_MAX_DOMAINLEN];
 		dname_str(xfr->name, zname);
 		verbose(VERB_QUERY, "auth zone %s updated to serial %u", zname,
 			(unsigned)xfr->serial);
@@ -5438,7 +5438,7 @@ xfr_transfer_lookup_host(struct auth_xfer* xfr, struct module_env* env)
 	qinfo.local_alias = NULL;
 	if(verbosity >= VERB_ALGO) {
 		char buf1[512];
-		char buf2[LDNS_MAX_DOMAINLEN+1];
+		char buf2[LDNS_MAX_DOMAINLEN];
 		dname_str(xfr->name, buf2);
 		snprintf(buf1, sizeof(buf1), "auth zone %s: master lookup"
 			" for task_transfer", buf2);
@@ -5494,7 +5494,7 @@ xfr_transfer_init_fetch(struct auth_xfer* xfr, struct module_env* env)
 			/* the ones that are not in addr format are supposed
 			 * to be looked up.  The lookup has failed however,
 			 * so skip them */
-			char zname[255+1];
+			char zname[LDNS_MAX_DOMAINLEN];
 			dname_str(xfr->name, zname);
 			log_err("%s: failed lookup, cannot transfer from master %s",
 				zname, master->host);
@@ -5533,7 +5533,7 @@ xfr_transfer_init_fetch(struct auth_xfer* xfr, struct module_env* env)
 			&addr, addrlen, -1, master->ssl, master->host,
 			master->file, env->cfg);
 		if(!xfr->task_transfer->cp) {
-			char zname[255+1], as[256];
+			char zname[LDNS_MAX_DOMAINLEN], as[256];
 			dname_str(xfr->name, zname);
 			addr_port_to_str(&addr, addrlen, as, sizeof(as));
 			verbose(VERB_ALGO, "cannot create http cp "
@@ -5542,7 +5542,7 @@ xfr_transfer_init_fetch(struct auth_xfer* xfr, struct module_env* env)
 		}
 		comm_timer_set(xfr->task_transfer->timer, &t);
 		if(verbosity >= VERB_ALGO) {
-			char zname[255+1], as[256];
+			char zname[LDNS_MAX_DOMAINLEN], as[256];
 			dname_str(xfr->name, zname);
 			addr_port_to_str(&addr, addrlen, as, sizeof(as));
 			verbose(VERB_ALGO, "auth zone %s transfer next HTTP fetch from %s started", zname, as);
@@ -5565,7 +5565,7 @@ xfr_transfer_init_fetch(struct auth_xfer* xfr, struct module_env* env)
 		env->scratch_buffer, -1,
 		auth_name != NULL, auth_name);
 	if(!xfr->task_transfer->cp) {
-		char zname[255+1], as[256];
+		char zname[LDNS_MAX_DOMAINLEN], as[256];
  		dname_str(xfr->name, zname);
 		addr_port_to_str(&addr, addrlen, as, sizeof(as));
 		verbose(VERB_ALGO, "cannot create tcp cp connection for "
@@ -5574,7 +5574,7 @@ xfr_transfer_init_fetch(struct auth_xfer* xfr, struct module_env* env)
 	}
 	comm_timer_set(xfr->task_transfer->timer, &t);
 	if(verbosity >= VERB_ALGO) {
-		char zname[255+1], as[256];
+		char zname[LDNS_MAX_DOMAINLEN], as[256];
  		dname_str(xfr->name, zname);
 		addr_port_to_str(&addr, addrlen, as, sizeof(as));
 		verbose(VERB_ALGO, "auth zone %s transfer next %s fetch from %s started", zname, 
@@ -5598,7 +5598,7 @@ xfr_transfer_nexttarget_or_end(struct auth_xfer* xfr, struct module_env* env)
 			 * and that calls the callback just like a full
 			 * lookup and lookup failures also call callback */
 			if(verbosity >= VERB_ALGO) {
-				char zname[255+1];
+				char zname[LDNS_MAX_DOMAINLEN];
 				dname_str(xfr->name, zname);
 				verbose(VERB_ALGO, "auth zone %s transfer next target lookup", zname);
 			}
@@ -5621,7 +5621,7 @@ xfr_transfer_nexttarget_or_end(struct auth_xfer* xfr, struct module_env* env)
 		xfr_transfer_nextmaster(xfr);
 	}
 	if(verbosity >= VERB_ALGO) {
-		char zname[255+1];
+		char zname[LDNS_MAX_DOMAINLEN];
 		dname_str(xfr->name, zname);
 		verbose(VERB_ALGO, "auth zone %s transfer failed, wait", zname);
 	}
@@ -5724,14 +5724,14 @@ void auth_xfer_transfer_lookup_callback(void* arg, int rcode, sldns_buffer* buf,
 					lookup_target, answer, wanted_qtype);
 			} else {
 				if(verbosity >= VERB_ALGO) {
-					char zname[255+1];
+					char zname[LDNS_MAX_DOMAINLEN];
 					dname_str(xfr->name, zname);
 					verbose(VERB_ALGO, "auth zone %s host %s type %s transfer lookup has nodata", zname, xfr->task_transfer->lookup_target->host, (xfr->task_transfer->lookup_aaaa?"AAAA":"A"));
 				}
 			}
 		} else {
 			if(verbosity >= VERB_ALGO) {
-				char zname[255+1];
+				char zname[LDNS_MAX_DOMAINLEN];
 				dname_str(xfr->name, zname);
 				verbose(VERB_ALGO, "auth zone %s host %s type %s transfer lookup has no answer", zname, xfr->task_transfer->lookup_target->host, (xfr->task_transfer->lookup_aaaa?"AAAA":"A"));
 			}
@@ -5739,7 +5739,7 @@ void auth_xfer_transfer_lookup_callback(void* arg, int rcode, sldns_buffer* buf,
 		regional_free_all(temp);
 	} else {
 		if(verbosity >= VERB_ALGO) {
-			char zname[255+1];
+			char zname[LDNS_MAX_DOMAINLEN];
 			dname_str(xfr->name, zname);
 			verbose(VERB_ALGO, "auth zone %s host %s type %s transfer lookup failed", zname, xfr->task_transfer->lookup_target->host, (xfr->task_transfer->lookup_aaaa?"AAAA":"A"));
 		}
@@ -6381,7 +6381,7 @@ xfr_probe_send_probe(struct auth_xfer* xfr, struct module_env* env,
 			/* the ones that are not in addr format are supposed
 			 * to be looked up.  The lookup has failed however,
 			 * so skip them */
-			char zname[255+1];
+			char zname[LDNS_MAX_DOMAINLEN];
 			dname_str(xfr->name, zname);
 			log_err("%s: failed lookup, cannot probe to master %s",
 				zname, master->host);
@@ -6423,7 +6423,7 @@ xfr_probe_send_probe(struct auth_xfer* xfr, struct module_env* env,
 		xfr->task_probe->cp = outnet_comm_point_for_udp(env->outnet,
 			auth_xfer_probe_udp_callback, xfr, &addr, addrlen);
 		if(!xfr->task_probe->cp) {
-			char zname[255+1], as[256];
+			char zname[LDNS_MAX_DOMAINLEN], as[256];
 			dname_str(xfr->name, zname);
 			addr_port_to_str(&addr, addrlen, as, sizeof(as));
 			verbose(VERB_ALGO, "cannot create udp cp for "
@@ -6443,7 +6443,7 @@ xfr_probe_send_probe(struct auth_xfer* xfr, struct module_env* env,
 	/* send udp packet */
 	if(!comm_point_send_udp_msg(xfr->task_probe->cp, env->scratch_buffer,
 		(struct sockaddr*)&addr, addrlen, 0)) {
-		char zname[255+1], as[256];
+		char zname[LDNS_MAX_DOMAINLEN], as[256];
 		dname_str(xfr->name, zname);
 		addr_port_to_str(&addr, addrlen, as, sizeof(as));
 		verbose(VERB_ALGO, "failed to send soa probe for %s to %s",
@@ -6451,7 +6451,7 @@ xfr_probe_send_probe(struct auth_xfer* xfr, struct module_env* env,
 		return 0;
 	}
 	if(verbosity >= VERB_ALGO) {
-		char zname[255+1], as[256];
+		char zname[LDNS_MAX_DOMAINLEN], as[256];
 		dname_str(xfr->name, zname);
 		addr_port_to_str(&addr, addrlen, as, sizeof(as));
 		verbose(VERB_ALGO, "auth zone %s soa probe sent to %s", zname,
@@ -6482,7 +6482,7 @@ auth_xfer_probe_timer_callback(void* arg)
 	}
 
 	if(verbosity >= VERB_ALGO) {
-		char zname[255+1];
+		char zname[LDNS_MAX_DOMAINLEN];
 		dname_str(xfr->name, zname);
 		verbose(VERB_ALGO, "auth zone %s soa probe timeout", zname);
 	}
@@ -6530,7 +6530,7 @@ auth_xfer_probe_udp_callback(struct comm_point* c, void* arg, int err,
 			&serial)) {
 			/* successful lookup */
 			if(verbosity >= VERB_ALGO) {
-				char buf[256];
+				char buf[LDNS_MAX_DOMAINLEN];
 				dname_str(xfr->name, buf);
 				verbose(VERB_ALGO, "auth zone %s: soa probe "
 					"serial is %u", buf, (unsigned)serial);
@@ -6569,14 +6569,14 @@ auth_xfer_probe_udp_callback(struct comm_point* c, void* arg, int err,
 			}
 		} else {
 			if(verbosity >= VERB_ALGO) {
-				char buf[256];
+				char buf[LDNS_MAX_DOMAINLEN];
 				dname_str(xfr->name, buf);
 				verbose(VERB_ALGO, "auth zone %s: bad reply to soa probe", buf);
 			}
 		}
 	} else {
 		if(verbosity >= VERB_ALGO) {
-			char buf[256];
+			char buf[LDNS_MAX_DOMAINLEN];
 			dname_str(xfr->name, buf);
 			verbose(VERB_ALGO, "auth zone %s: soa probe failed", buf);
 		}
@@ -6633,7 +6633,7 @@ xfr_probe_lookup_host(struct auth_xfer* xfr, struct module_env* env)
 	qinfo.local_alias = NULL;
 	if(verbosity >= VERB_ALGO) {
 		char buf1[512];
-		char buf2[LDNS_MAX_DOMAINLEN+1];
+		char buf2[LDNS_MAX_DOMAINLEN];
 		dname_str(xfr->name, buf2);
 		snprintf(buf1, sizeof(buf1), "auth zone %s: master lookup"
 			" for task_probe", buf2);
@@ -6679,7 +6679,7 @@ xfr_probe_send_or_end(struct auth_xfer* xfr, struct module_env* env)
 			 * and that calls the callback just like a full
 			 * lookup and lookup failures also call callback */
 			if(verbosity >= VERB_ALGO) {
-				char zname[255+1];
+				char zname[LDNS_MAX_DOMAINLEN];
 				dname_str(xfr->name, zname);
 				verbose(VERB_ALGO, "auth zone %s probe next target lookup", zname);
 			}
@@ -6692,7 +6692,7 @@ xfr_probe_send_or_end(struct auth_xfer* xfr, struct module_env* env)
 	 * allow_notify addrs */
 	probe_copy_masters_for_allow_notify(xfr);
 	if(verbosity >= VERB_ALGO) {
-		char zname[255+1];
+		char zname[LDNS_MAX_DOMAINLEN];
 		dname_str(xfr->name, zname);
 		verbose(VERB_ALGO, "auth zone %s probe: notify addrs updated", zname);
 	}
@@ -6700,7 +6700,7 @@ xfr_probe_send_or_end(struct auth_xfer* xfr, struct module_env* env)
 		/* only wanted lookups for copy, stop probe and start wait */
 		xfr->task_probe->only_lookup = 0;
 		if(verbosity >= VERB_ALGO) {
-			char zname[255+1];
+			char zname[LDNS_MAX_DOMAINLEN];
 			dname_str(xfr->name, zname);
 			verbose(VERB_ALGO, "auth zone %s probe: finished only_lookup", zname);
 		}
@@ -6726,7 +6726,7 @@ xfr_probe_send_or_end(struct auth_xfer* xfr, struct module_env* env)
 	if(xfr->task_probe->have_new_lease) {
 		/* if zone not updated, start the wait timer again */
 		if(verbosity >= VERB_ALGO) {
-			char zname[255+1];
+			char zname[LDNS_MAX_DOMAINLEN];
 			dname_str(xfr->name, zname);
 			verbose(VERB_ALGO, "auth_zone %s unchanged, new lease, wait", zname);
 		}
@@ -6737,7 +6737,7 @@ xfr_probe_send_or_end(struct auth_xfer* xfr, struct module_env* env)
 			xfr_set_timeout(xfr, env, 0, 0);
 	} else {
 		if(verbosity >= VERB_ALGO) {
-			char zname[255+1];
+			char zname[LDNS_MAX_DOMAINLEN];
 			dname_str(xfr->name, zname);
 			verbose(VERB_ALGO, "auth zone %s soa probe failed, wait to retry", zname);
 		}
@@ -6787,14 +6787,14 @@ void auth_xfer_probe_lookup_callback(void* arg, int rcode, sldns_buffer* buf,
 					lookup_target, answer, wanted_qtype);
 			} else {
 				if(verbosity >= VERB_ALGO) {
-					char zname[255+1];
+					char zname[LDNS_MAX_DOMAINLEN];
 					dname_str(xfr->name, zname);
 					verbose(VERB_ALGO, "auth zone %s host %s type %s probe lookup has nodata", zname, xfr->task_probe->lookup_target->host, (xfr->task_probe->lookup_aaaa?"AAAA":"A"));
 				}
 			}
 		} else {
 			if(verbosity >= VERB_ALGO) {
-				char zname[255+1];
+				char zname[LDNS_MAX_DOMAINLEN];
 				dname_str(xfr->name, zname);
 				verbose(VERB_ALGO, "auth zone %s host %s type %s probe lookup has no address", zname, xfr->task_probe->lookup_target->host, (xfr->task_probe->lookup_aaaa?"AAAA":"A"));
 			}
@@ -6802,7 +6802,7 @@ void auth_xfer_probe_lookup_callback(void* arg, int rcode, sldns_buffer* buf,
 		regional_free_all(temp);
 	} else {
 		if(verbosity >= VERB_ALGO) {
-			char zname[255+1];
+			char zname[LDNS_MAX_DOMAINLEN];
 			dname_str(xfr->name, zname);
 			verbose(VERB_ALGO, "auth zone %s host %s type %s probe lookup failed", zname, xfr->task_probe->lookup_target->host, (xfr->task_probe->lookup_aaaa?"AAAA":"A"));
 		}
@@ -6976,7 +6976,7 @@ xfr_set_timeout(struct auth_xfer* xfr, struct module_env* env,
 		if(!xfr->task_nextprobe->timer) {
 			/* failed to malloc memory. likely zone transfer
 			 * also fails for that. skip the timeout */
-			char zname[255+1];
+			char zname[LDNS_MAX_DOMAINLEN];
 			dname_str(xfr->name, zname);
 			log_err("cannot allocate timer, no refresh for %s",
 				zname);
@@ -6997,7 +6997,7 @@ xfr_set_timeout(struct auth_xfer* xfr, struct module_env* env,
 			xfr->task_probe->only_lookup = 1;
 	}
 	if(verbosity >= VERB_ALGO) {
-		char zname[255+1];
+		char zname[LDNS_MAX_DOMAINLEN];
 		dname_str(xfr->name, zname);
 		verbose(VERB_ALGO, "auth zone %s timeout in %d seconds",
 			zname, (int)tv.tv_sec);
@@ -7784,7 +7784,7 @@ static void auth_zone_log(uint8_t* name, enum verbosity_value level,
 	va_list args;
 	va_start(args, format);
 	if(verbosity >= level) {
-		char str[255+1];
+		char str[LDNS_MAX_DOMAINLEN];
 		char msg[MAXSYSLOGMSGLEN];
 		dname_str(name, str);
 		vsnprintf(msg, sizeof(msg), format, args);
@@ -7986,7 +7986,7 @@ static int zonemd_check_dnssec_soazonemd(struct auth_zone* z,
 static void auth_zone_zonemd_fail(struct auth_zone* z, struct module_env* env,
 	char* reason, char* why_bogus, char** result)
 {
-	char zstr[255+1];
+	char zstr[LDNS_MAX_DOMAINLEN];
 	/* if fail: log reason, and depending on config also take action
 	 * and drop the zone, eg. it is gone from memory, set zone_expired */
 	dname_str(z->name, zstr);
@@ -8432,7 +8432,7 @@ zonemd_lookup_dnskey(struct auth_zone* z, struct module_env* env)
 	qinfo.local_alias = NULL;
 	if(verbosity >= VERB_ALGO) {
 		char buf1[512];
-		char buf2[LDNS_MAX_DOMAINLEN+1];
+		char buf2[LDNS_MAX_DOMAINLEN];
 		dname_str(z->name, buf2);
 		snprintf(buf1, sizeof(buf1), "auth zone %s: lookup %s "
 			"for zonemd verification", buf2,

--- a/services/cache/infra.c
+++ b/services/cache/infra.c
@@ -1081,7 +1081,8 @@ int infra_ratelimit_inc(struct infra_cache* infra, uint8_t* name,
 		lock_rw_unlock(&entry->lock);
 
 		if(premax <= lim && max > lim) {
-			char buf[257], qnm[257], ts[12], cs[12], ip[128];
+			char buf[LDNS_MAX_DOMAINLEN], qnm[LDNS_MAX_DOMAINLEN];
+			char ts[12], cs[12], ip[128];
 			dname_str(name, buf);
 			dname_str(qinfo->qname, qnm);
 			sldns_wire2str_type_buf(qinfo->qtype, ts, sizeof(ts));

--- a/services/localzone.c
+++ b/services/localzone.c
@@ -223,7 +223,7 @@ lz_enter_zone_dname(struct local_zones* zones, uint8_t* nm, size_t len,
 	lock_rw_wrlock(&z->lock);
 	if(!rbtree_insert(&zones->ztree, &z->node)) {
 		struct local_zone* oldz;
-		char str[256];
+		char str[LDNS_MAX_DOMAINLEN];
 		dname_str(nm, str);
 		log_warn("duplicate local-zone %s", str);
 		lock_rw_unlock(&z->lock);
@@ -1765,7 +1765,7 @@ lz_inform_print(struct local_zone* z, struct query_info* qinfo,
 	struct sockaddr_storage* addr, socklen_t addrlen)
 {
 	char ip[128], txt[512];
-	char zname[LDNS_MAX_DOMAINLEN+1];
+	char zname[LDNS_MAX_DOMAINLEN];
 	uint16_t port = ntohs(((struct sockaddr_in*)addr)->sin_port);
 	dname_str(z->name, zname);
 	addr_to_str(addr, addrlen, ip, sizeof(ip));
@@ -1875,7 +1875,7 @@ local_zones_answer(struct local_zones* zones, struct module_env* env,
 			return 0;
 		}
 		if(z && verbosity >= VERB_ALGO) {
-			char zname[255+1];
+			char zname[LDNS_MAX_DOMAINLEN];
 			dname_str(z->name, zname);
 			verbose(VERB_ALGO, "using localzone %s %s from view %s", 
 				zname, local_zone_type2str(lzt), view->name);
@@ -1897,7 +1897,7 @@ local_zones_answer(struct local_zones* zones, struct module_env* env,
 			z->override_tree, &tag, tagname, num_tags);
 		lock_rw_unlock(&zones->lock);
 		if(z && verbosity >= VERB_ALGO) {
-			char zname[255+1];
+			char zname[LDNS_MAX_DOMAINLEN];
 			dname_str(z->name, zname);
 			verbose(VERB_ALGO, "using localzone %s %s", zname,
 				local_zone_type2str(lzt));

--- a/services/outside_network.c
+++ b/services/outside_network.c
@@ -1054,7 +1054,7 @@ reuse_move_writewait_away(struct outside_network* outnet,
 		if(verbosity >= VERB_CLIENT && pend->query->pkt_len > 12+2+2 &&
 			LDNS_QDCOUNT(pend->query->pkt) > 0 &&
 			dname_valid(pend->query->pkt+12, pend->query->pkt_len-12)) {
-			char buf[LDNS_MAX_DOMAINLEN+1];
+			char buf[LDNS_MAX_DOMAINLEN];
 			dname_str(pend->query->pkt+12, buf);
 			verbose(VERB_CLIENT, "reuse_move_writewait_away current %s %d bytes were written",
 				buf, (int)pend->c->tcp_write_byte_count);
@@ -1079,7 +1079,7 @@ reuse_move_writewait_away(struct outside_network* outnet,
 		if(verbosity >= VERB_CLIENT && w->pkt_len > 12+2+2 &&
 			LDNS_QDCOUNT(w->pkt) > 0 &&
 			dname_valid(w->pkt+12, w->pkt_len-12)) {
-			char buf[LDNS_MAX_DOMAINLEN+1];
+			char buf[LDNS_MAX_DOMAINLEN];
 			dname_str(w->pkt+12, buf);
 			verbose(VERB_CLIENT, "reuse_move_writewait_away item %s", buf);
 		}
@@ -2825,7 +2825,7 @@ serviced_perturb_qname(struct ub_randstate* rnd, uint8_t* qbuf, size_t len)
 		lablen = *d++;
 	}
 	if(verbosity >= VERB_ALGO) {
-		char buf[LDNS_MAX_DOMAINLEN+1];
+		char buf[LDNS_MAX_DOMAINLEN];
 		dname_str(qbuf+10, buf);
 		verbose(VERB_ALGO, "qname perturbed to %s", buf);
 	}

--- a/services/rpz.c
+++ b/services/rpz.c
@@ -666,7 +666,7 @@ rpz_insert_local_zones_trigger(struct local_zones* lz, uint8_t* dname,
 	int newzone = 0;
 
 	if(a == RPZ_INVALID_ACTION) {
-		char str[255+1];
+		char str[LDNS_MAX_DOMAINLEN];
 		if(rrtype == LDNS_RR_TYPE_SOA || rrtype == LDNS_RR_TYPE_NS ||
 			rrtype == LDNS_RR_TYPE_DNAME ||
 			rrtype == LDNS_RR_TYPE_DNSKEY ||
@@ -739,7 +739,7 @@ rpz_insert_local_zones_trigger(struct local_zones* lz, uint8_t* dname,
 static void
 rpz_log_dname(char const* msg, uint8_t* dname, size_t dname_len)
 {
-	char buf[LDNS_MAX_DOMAINLEN+1];
+	char buf[LDNS_MAX_DOMAINLEN];
 	(void)dname_len;
 	dname_str(dname, buf);
 	verbose(VERB_ALGO, "rpz: %s: <%s>", msg, buf);
@@ -1062,7 +1062,7 @@ rpz_insert_response_ip_trigger(struct rpz* r, uint8_t* dname, size_t dnamelen,
 
 	if(a == RPZ_INVALID_ACTION ||
 		rpz_action_to_respip_action(a) == respip_invalid) {
-		char str[255+1];
+		char str[LDNS_MAX_DOMAINLEN];
 		dname_str(dname, str);
 		verbose(VERB_ALGO, "rpz: respip trigger, %s skipping unsupported action: %s",
 			str, rpz_action_to_string(a));
@@ -1633,7 +1633,7 @@ log_rpz_apply(char* trigger, uint8_t* dname, struct addr_tree_node* addrnode,
 	struct comm_reply* repinfo, struct module_qstate* ms, char* log_name)
 {
 	char ip[128], txt[512], portstr[32];
-	char dnamestr[LDNS_MAX_DOMAINLEN+1];
+	char dnamestr[LDNS_MAX_DOMAINLEN];
 	uint16_t port = 0;
 	if(dname) {
 		dname_str(dname, dnamestr);
@@ -2427,7 +2427,8 @@ rpz_delegation_point_zone_lookup(struct delegpt* dp, struct local_zones* zones,
 			match->dname = nameserver->name;
 			match->dname_len = nameserver->namelen;
 			if(verbosity >= VERB_ALGO) {
-				char nm[255+1], zn[255+1];
+				char nm[LDNS_MAX_DOMAINLEN];
+				char zn[LDNS_MAX_DOMAINLEN];
 				dname_str(match->dname, nm);
 				dname_str(z->name, zn);
 				if(strcmp(nm, zn) != 0)
@@ -2581,7 +2582,7 @@ struct dns_msg* rpz_callback_from_iterator_cname(struct module_qstate* ms,
 	}
 
 	if(verbosity >= VERB_ALGO) {
-		char nm[255+1], zn[255+1];
+		char nm[LDNS_MAX_DOMAINLEN], zn[LDNS_MAX_DOMAINLEN];
 		dname_str(is->qchase.qname, nm);
 		dname_str(z->name, zn);
 		if(strcmp(zn, nm) != 0)
@@ -2758,7 +2759,7 @@ rpz_callback_from_worker_request(struct auth_zones* az, struct module_env* env,
 	}
 
 	if(verbosity >= VERB_ALGO) {
-		char nm[255+1], zn[255+1];
+		char nm[LDNS_MAX_DOMAINLEN], zn[LDNS_MAX_DOMAINLEN];
 		dname_str(qinfo->qname, nm);
 		dname_str(z->name, zn);
 		if(strcmp(zn, nm) != 0)

--- a/testcode/fake_event.c
+++ b/testcode/fake_event.c
@@ -1264,7 +1264,7 @@ struct serviced_query* outnet_serviced_query(struct outside_network* outnet,
 	struct replay_runtime* runtime = (struct replay_runtime*)outnet->base;
 	struct fake_pending* pend = (struct fake_pending*)calloc(1,
 		sizeof(struct fake_pending));
-	char z[256];
+	char z[LDNS_MAX_DOMAINLEN];
 	log_assert(pend);
 	log_nametypeclass(VERB_OPS, "pending serviced query",
 		qinfo->qname, qinfo->qtype, qinfo->qclass);

--- a/testcode/unitdname.c
+++ b/testcode/unitdname.c
@@ -39,6 +39,7 @@
  */
 
 #include "config.h"
+#include <ctype.h>
 #include "util/log.h"
 #include "testcode/unitmain.h"
 #include "util/data/dname.h"
@@ -858,6 +859,151 @@ dname_setup_bufs(sldns_buffer* loopbuf, sldns_buffer* boundbuf)
 	sldns_buffer_flip(boundbuf);
 }
 
+static void
+dname_test_str(sldns_buffer* buff)
+{
+	char result[LDNS_MAX_DOMAINLEN], expect[LDNS_MAX_DOMAINLEN], *e;
+	size_t i;
+	unit_show_func("util/data/dname.c", "dname_str");
+
+	/* root ; expected OK */
+	sldns_buffer_clear(buff);
+	sldns_buffer_write(buff, "\000", 1);
+	sldns_buffer_flip(buff);
+	unit_assert( sldns_buffer_limit(buff) == 1 );
+	unit_assert( pkt_dname_len(buff) == 1 );
+	dname_str(sldns_buffer_begin(buff), result);
+	unit_assert( strcmp( ".", result) == 0 );
+
+	/* LDNS_MAX_DOMAINLEN - 1 ; expected OK */
+	sldns_buffer_clear(buff);
+	sldns_buffer_write(buff,
+		"\077abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ01234567890"  /*  64 up to here */
+		"\077abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ01234567890"  /* 128 up to here */
+		"\077abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ01234567890"  /* 192 up to here */
+		"\074abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ01234567"     /* 253 up to here */
+		"\000"                                                                 /* 254 up to here */
+		, 254);
+	sldns_buffer_flip(buff);
+	unit_assert( sldns_buffer_limit(buff) == 254 );
+	unit_assert( pkt_dname_len(buff) == 254 );
+	dname_str(sldns_buffer_begin(buff), result);
+	unit_assert( strcmp(
+		"abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ01234567890."
+		"abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ01234567890."
+		"abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ01234567890."
+		"abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ01234567"
+		".", result) == 0 );
+
+	/* LDNS_MAX_DOMAINLEN ; expected OK */
+	sldns_buffer_clear(buff);
+	sldns_buffer_write(buff,
+		"\077abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ01234567890"  /*  64 up to here */
+		"\077abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ01234567890"  /* 128 up to here */
+		"\077abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ01234567890"  /* 192 up to here */
+		"\075abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ012345678"    /* 254 up to here */
+		"\000"                                                                 /* 255 up to here */
+		, 255);
+	sldns_buffer_flip(buff);
+	unit_assert( sldns_buffer_limit(buff) == 255 );
+	unit_assert( pkt_dname_len(buff) == 255 );
+	dname_str(sldns_buffer_begin(buff), result);
+	unit_assert( strcmp(
+		"abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ01234567890."
+		"abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ01234567890."
+		"abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ01234567890."
+		"abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ012345678"
+		".", result) == 0 );
+
+	/* LDNS_MAX_DOMAINLEN + 1 ; expected to fail, output uses '&' on the latest label */
+	sldns_buffer_clear(buff);
+	sldns_buffer_write(buff,
+		"\077abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ01234567890"  /*  64 up to here */
+		"\077abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ01234567890"  /* 128 up to here */
+		"\077abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ01234567890"  /* 192 up to here */
+		"\076abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"   /* 255 up to here */
+		"\000"                                                                 /* 256 up to here */
+		, 256);
+	sldns_buffer_flip(buff);
+	unit_assert( sldns_buffer_limit(buff) == 256 );
+	unit_assert( pkt_dname_len(buff) == 0 );
+	dname_str(sldns_buffer_begin(buff), result);
+	unit_assert( strcmp(
+		"abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ01234567890."
+		"abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ01234567890."
+		"abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ01234567890."
+		"&", result) == 0 );
+
+	/* LDNS_MAX_LABELLEN + 1 ; expected to fail, output uses '#' on the offending label */
+	sldns_buffer_clear(buff);
+	sldns_buffer_write(buff,
+		"\077abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ01234567890"  /*  64 up to here */
+		"\100abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ01234567890a" /* 129 up to here */
+		"\000"                                                                 /* 130 up to here */
+		, 130);
+	sldns_buffer_flip(buff);
+	unit_assert( sldns_buffer_limit(buff) == 130 );
+	unit_assert( pkt_dname_len(buff) == 0 );
+	dname_str(sldns_buffer_begin(buff), result);
+	unit_assert( strcmp(
+		"abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ01234567890."
+		"#", result) == 0 );
+
+	/* LDNS_MAX_DOMAINLEN with single labels; expected OK */
+	sldns_buffer_clear(buff);
+	for(i=0; i<=252; i+=2)
+		sldns_buffer_write(buff, "\001a", 2);
+	sldns_buffer_write_u8(buff, 0);
+	sldns_buffer_flip(buff);
+	unit_assert( sldns_buffer_limit(buff) == 255 );
+	unit_assert( pkt_dname_len(buff) == 255 );
+	dname_str(sldns_buffer_begin(buff), result);
+	e = expect;
+	for(i=0; i<=252; i+=2) {
+		*e++ = 'a';
+		*e++ = '.';
+	}
+	*e = '\0';
+	unit_assert( strcmp(expect, result) == 0 );
+
+	/* LDNS_MAX_DOMAINLEN + 1 with single labels; expected to fail, output uses '&' on the latest label */
+	sldns_buffer_clear(buff);
+	for(i=0; i<=250; i+=2)
+		sldns_buffer_write(buff, "\001a", 2);
+	sldns_buffer_write(buff, "\002ab", 3);
+	sldns_buffer_write_u8(buff, 0);
+	sldns_buffer_flip(buff);
+	unit_assert( sldns_buffer_limit(buff) == 256 );
+	unit_assert( pkt_dname_len(buff) == 0 );
+	dname_str(sldns_buffer_begin(buff), result);
+	e = expect;
+	for(i=0; i<=250; i+=2) {
+		*e++ = 'a';
+		*e++ = '.';
+	}
+	*e++ = '&';
+	*e = '\0';
+	unit_assert( strcmp(expect, result) == 0 );
+
+	/* Only alphas, numericals and '-', '_' and '*' are allowed in the output */
+	for(i=1; i<=255; i++) {
+		if(isalnum(i) || i == '-' || i == '_' || i == '*')
+			continue;
+		sldns_buffer_clear(buff);
+		sldns_buffer_write_u8(buff, 1);
+		sldns_buffer_write_u8(buff, (uint8_t)i);
+		sldns_buffer_write_u8(buff, 0);
+		sldns_buffer_flip(buff);
+		unit_assert( sldns_buffer_limit(buff) == 3 );
+		unit_assert( pkt_dname_len(buff) == 3);
+		dname_str(sldns_buffer_begin(buff), result);
+		if(strcmp( "?.", result) != 0 ) {
+			log_err("ASCII value '0x%lX' allowed in string output", i);
+			unit_assert(0);
+		}
+	}
+}
+
 void dname_test(void)
 {
 	sldns_buffer* loopbuf = sldns_buffer_new(14);
@@ -884,6 +1030,7 @@ void dname_test(void)
 	dname_test_topdomain();
 	dname_test_valid();
 	dname_test_has_label();
+	dname_test_str(buff);
 	sldns_buffer_free(buff);
 	sldns_buffer_free(loopbuf);
 	sldns_buffer_free(boundbuf);

--- a/testcode/unitneg.c
+++ b/testcode/unitneg.c
@@ -53,7 +53,7 @@ static int negverbose = 0;
 /** debug printout of neg cache */
 static void print_neg_cache(struct val_neg_cache* neg)
 {
-	char buf[1024];
+	char buf[LDNS_MAX_DOMAINLEN];
 	struct val_neg_zone* z;
 	struct val_neg_data* d;
 	printf("neg_cache print\n");

--- a/testcode/unitzonemd.c
+++ b/testcode/unitzonemd.c
@@ -111,7 +111,7 @@ static void zonemd_generate_test(const char* zname, char* zfile,
 		digestdup[i] = toupper((unsigned char)digestdup[i]);
 	}
 	if(verbosity >= VERB_ALGO) {
-		char zname[255+1];
+		char zname[LDNS_MAX_DOMAINLEN];
 		dname_str(z->name, zname);
 		printf("zonemd generated for %s in %s with "
 			"scheme=%d hashalgo=%d\n", zname, z->zonefile,

--- a/util/data/dname.c
+++ b/util/data/dname.c
@@ -644,24 +644,24 @@ void dname_str(uint8_t* dname, char* str)
 	if(!dname || !*dname) {
 		*s++ = '.';
 		*s = 0;
-		return;
+		goto out;
 	}
 	lablen = *dname++;
 	while(lablen) {
 		if(lablen > LDNS_MAX_LABELLEN) {
 			*s++ = '#';
 			*s = 0;
-			return;
+			goto out;
 		}
 		len += lablen+1;
 		if(len >= LDNS_MAX_DOMAINLEN) {
 			*s++ = '&';
 			*s = 0;
-			return;
+			goto out;
 		}
 		while(lablen--) {
-			if(isalnum((unsigned char)*dname) 
-				|| *dname == '-' || *dname == '_' 
+			if(isalnum((unsigned char)*dname)
+				|| *dname == '-' || *dname == '_'
 				|| *dname == '*')
 				*s++ = *(char*)dname++;
 			else	{
@@ -673,6 +673,10 @@ void dname_str(uint8_t* dname, char* str)
 		lablen = *dname++;
 	}
 	*s = 0;
+
+out:
+	log_assert(s - str < LDNS_MAX_DOMAINLEN);
+	return;
 }
 
 int 

--- a/util/data/dname.c
+++ b/util/data/dname.c
@@ -654,7 +654,7 @@ void dname_str(uint8_t* dname, char* str)
 			return;
 		}
 		len += lablen+1;
-		if(len >= LDNS_MAX_DOMAINLEN-1) {
+		if(len >= LDNS_MAX_DOMAINLEN) {
 			*s++ = '&';
 			*s = 0;
 			return;

--- a/util/data/dname.h
+++ b/util/data/dname.h
@@ -242,11 +242,12 @@ void dname_print(FILE* out, struct sldns_buffer* pkt, uint8_t* dname);
 
 /** 
  * Debug helper. Print dname to given string buffer (string buffer must
- * be at least 255 chars + 1 for the 0, in printable form.
+ * be at least 255 chars, in printable form.
  * This may lose information (? for nonprintable characters, or & if
  * the name is too long, # for a bad label length).
+ * Upon return, the buffer will always have a terminating \0 value.
  * @param dname: uncompressed wireformat.
- * @param str: buffer of 255+1 length.
+ * @param str: buffer of at least 255 length.
  */
 void dname_str(uint8_t* dname, char* str);
 

--- a/util/data/msgreply.c
+++ b/util/data/msgreply.c
@@ -967,13 +967,9 @@ log_reply_info(enum verbosity_value v, struct query_info *qinf,
 	int cached, struct sldns_buffer *rmsg, struct sockaddr_storage* daddr,
 	enum comm_point_type tp)
 {
-	char qname_buf[LDNS_MAX_DOMAINLEN+1];
 	char clientip_buf[128];
 	char rcode_buf[16];
-	char type_buf[16];
-	char class_buf[16];
 	char dest_buf[160];
-	size_t pktlen;
 	uint16_t rcode = FLAGS_GET_RCODE(sldns_buffer_read_u16_at(rmsg, 2));
 
 	if(verbosity < v)
@@ -1022,6 +1018,10 @@ log_reply_info(enum verbosity_value v, struct query_info *qinf,
 		else	log_info("%s - - - %s - - -%s", clientip_buf,
 				rcode_buf, dest_buf);
 	} else {
+		char qname_buf[LDNS_MAX_DOMAINLEN];
+		char type_buf[16];
+		char class_buf[16];
+		size_t pktlen;
 		if(qinf->qname)
 			dname_str(qinf->qname, qname_buf);
 		else	snprintf(qname_buf, sizeof(qname_buf), "null");

--- a/util/module.c
+++ b/util/module.c
@@ -135,7 +135,7 @@ char* errinf_to_str_bogus(struct module_qstate* qstate, struct regional* region)
 	char* p = buf;
 	size_t left = sizeof(buf);
 	struct errinf_strlist* s;
-	char dname[LDNS_MAX_DOMAINLEN+1];
+	char dname[LDNS_MAX_DOMAINLEN];
 	char t[16], c[16];
 	sldns_wire2str_type_buf(qstate->qinfo.qtype, t, sizeof(t));
 	sldns_wire2str_class_buf(qstate->qinfo.qclass, c, sizeof(c));
@@ -178,7 +178,7 @@ char* errinf_to_str_servfail(struct module_qstate* qstate)
 	char* p = buf;
 	size_t left = sizeof(buf);
 	struct errinf_strlist* s;
-	char dname[LDNS_MAX_DOMAINLEN+1];
+	char dname[LDNS_MAX_DOMAINLEN];
 	char t[16], c[16];
 	sldns_wire2str_type_buf(qstate->qinfo.qtype, t, sizeof(t));
 	sldns_wire2str_class_buf(qstate->qinfo.qclass, c, sizeof(c));
@@ -218,7 +218,7 @@ char* errinf_to_str_misc(struct module_qstate* qstate)
 void errinf_rrset(struct module_qstate* qstate, struct ub_packed_rrset_key *rr)
 {
 	char buf[1024];
-	char dname[LDNS_MAX_DOMAINLEN+1];
+	char dname[LDNS_MAX_DOMAINLEN];
 	char t[16], c[16];
 	if((qstate->env->cfg->val_log_level < 2 && !qstate->env->cfg->log_servfail) || !rr)
 		return;
@@ -232,7 +232,7 @@ void errinf_rrset(struct module_qstate* qstate, struct ub_packed_rrset_key *rr)
 void errinf_dname(struct module_qstate* qstate, const char* str, uint8_t* dname)
 {
 	char b[1024];
-	char buf[LDNS_MAX_DOMAINLEN+1];
+	char buf[LDNS_MAX_DOMAINLEN];
 	if((qstate->env->cfg->val_log_level < 2 && !qstate->env->cfg->log_servfail) || !str || !dname)
 		return;
 	dname_str(dname, buf);

--- a/util/net_help.c
+++ b/util/net_help.c
@@ -544,7 +544,7 @@ void
 log_nametypeclass(enum verbosity_value v, const char* str, uint8_t* name, 
 	uint16_t type, uint16_t dclass)
 {
-	char buf[LDNS_MAX_DOMAINLEN+1];
+	char buf[LDNS_MAX_DOMAINLEN];
 	char t[12], c[12];
 	const char *ts, *cs; 
 	if(verbosity < v)
@@ -575,7 +575,7 @@ log_nametypeclass(enum verbosity_value v, const char* str, uint8_t* name,
 void
 log_query_in(const char* str, uint8_t* name, uint16_t type, uint16_t dclass)
 {
-	char buf[LDNS_MAX_DOMAINLEN+1];
+	char buf[LDNS_MAX_DOMAINLEN];
 	char t[12], c[12];
 	const char *ts, *cs; 
 	dname_str(name, buf);
@@ -608,7 +608,7 @@ void log_name_addr(enum verbosity_value v, const char* str, uint8_t* zone,
 {
 	uint16_t port;
 	const char* family = "unknown_family ";
-	char namebuf[LDNS_MAX_DOMAINLEN+1];
+	char namebuf[LDNS_MAX_DOMAINLEN];
 	char dest[100];
 	int af = (int)((struct sockaddr_in*)addr)->sin_family;
 	void* sinaddr = &((struct sockaddr_in*)addr)->sin_addr;

--- a/validator/autotrust.c
+++ b/validator/autotrust.c
@@ -353,7 +353,7 @@ autr_tp_create(struct val_anchors* anchors, uint8_t* own, size_t own_len,
 
 	lock_basic_lock(&anchors->lock);
 	if(!rbtree_insert(anchors->tree, &tp->node)) {
-		char buf[LDNS_MAX_DOMAINLEN+1];
+		char buf[LDNS_MAX_DOMAINLEN];
 		lock_basic_unlock(&anchors->lock);
 		dname_str(tp->name, buf);
 		log_err("trust anchor for '%s' presented twice", buf);
@@ -363,7 +363,7 @@ autr_tp_create(struct val_anchors* anchors, uint8_t* own, size_t own_len,
 		return NULL;
 	}
 	if(!rbtree_insert(&anchors->autr->probe, &tp->autr->pnode)) {
-		char buf[LDNS_MAX_DOMAINLEN+1];
+		char buf[LDNS_MAX_DOMAINLEN];
 		(void)rbtree_delete(anchors->tree, tp);
 		lock_basic_unlock(&anchors->lock);
 		dname_str(tp->name, buf);
@@ -2288,7 +2288,9 @@ static void
 autr_debug_print_tp(struct trust_anchor* tp)
 {
 	struct autr_ta* ta;
-	char buf[257];
+	/* Note: buf is also used for autr_ctime_r but that only needs a size
+	 *       of 26, so LDNS_MAX_DOMAINLEN is enough. */
+	char buf[LDNS_MAX_DOMAINLEN];
 	if(!tp->autr)
 		return;
 	dname_str(tp->name, buf);

--- a/validator/val_anchor.c
+++ b/validator/val_anchor.c
@@ -1018,7 +1018,7 @@ anchors_assemble_rrsets(struct val_anchors* anchors)
 				ta->name, LDNS_RR_TYPE_DNSKEY, ta->dclass);
 		}
 		if(nods == ta->numDS && nokey == ta->numDNSKEY) {
-			char b[257];
+			char b[LDNS_MAX_DOMAINLEN];
 			dname_str(ta->name, b);
 			log_warn("trust anchor %s has no supported algorithms,"
 				" the anchor is ignored (check if you need to"

--- a/validator/validator.c
+++ b/validator/validator.c
@@ -210,7 +210,7 @@ val_init(struct module_env* env, int id)
 		struct trust_anchor* anchor = anchors_find_any_noninsecure(
 			env->anchors);
 		if(anchor) {
-			char b[LDNS_MAX_DOMAINLEN+2];
+			char b[LDNS_MAX_DOMAINLEN];
 			dname_str(anchor->name, b);
 			log_warn("validator: disable-edns-do is enabled, but there is a trust anchor for '%s'. Since DNSSEC could not work, the disable-edns-do setting is turned off. Continuing without it.", b);
 			lock_basic_unlock(&anchor->lock);


### PR DESCRIPTION
- Incorporates the fix from #1189,
- Adds unit tests, and
- Homogenizes the input buffer size.