### PR TITLE
ci: set persist-credentials: false for actions/checkout per zizmor suggestion

### DIFF
--- a/.github/workflows/analysis_ports.yml
+++ b/.github/workflows/analysis_ports.yml
@@ -193,6 +193,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           submodules: false
+          persist-credentials: false
       - name: test_windows
         if: ${{ matrix.test_windows == 'yes' }}
         shell: bash

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,8 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
+      with:
+        persist-credentials: false
     - name: configure
       run: ./configure --enable-debug
     - name: make


### PR DESCRIPTION
I don't think we currently have anything in CI that needs the (readonly) checkout credentials persisted to .git/config during the run.