### PR TITLE
Use TCP_NODELAY on TLS sockets to speed up the TLS handshake.

### DIFF
--- a/services/outside_network.h
+++ b/services/outside_network.h
@@ -743,9 +743,11 @@ void reuse_write_wait_remove(struct reuse_tcp* reuse, struct waiting_tcp* w);
 void reuse_write_wait_push_back(struct reuse_tcp* reuse, struct waiting_tcp* w);
 
 /** get TCP file descriptor for address, returns -1 on failure,
- * tcp_mss is 0 or maxseg size to set for TCP packets. */
+ * tcp_mss is 0 or maxseg size to set for TCP packets,
+ * nodelay (TCP_NODELAY) should be set for TLS connections to speed up the TLS
+ * handshake.*/
 int outnet_get_tcp_fd(struct sockaddr_storage* addr, socklen_t addrlen,
-	int tcp_mss, int dscp);
+	int tcp_mss, int dscp, int nodelay);
 
 /**
  * Create udp commpoint suitable for sending packets to the destination.

--- a/testcode/fake_event.c
+++ b/testcode/fake_event.c
@@ -1938,7 +1938,8 @@ int comm_point_send_udp_msg(struct comm_point *c, sldns_buffer* packet,
 }
 
 int outnet_get_tcp_fd(struct sockaddr_storage* ATTR_UNUSED(addr),
-	socklen_t ATTR_UNUSED(addrlen), int ATTR_UNUSED(tcp_mss), int ATTR_UNUSED(dscp))
+	socklen_t ATTR_UNUSED(addrlen), int ATTR_UNUSED(tcp_mss),
+	int ATTR_UNUSED(dscp), int ATTR_UNUSED(nodelay))
 {
 	log_assert(0);
 	return -1;

--- a/util/config_file.c
+++ b/util/config_file.c
@@ -2796,6 +2796,26 @@ int cfg_has_https(struct config_file* cfg)
 	return 0;
 }
 
+/** see if interface is ssl, its port number == the ssl port number */
+int
+if_is_ssl(const char* ifname, const char* port, int ssl_port,
+	struct config_strlist* tls_additional_port)
+{
+	struct config_strlist* s;
+	char* p = strchr(ifname, '@');
+	if(!p && atoi(port) == ssl_port)
+		return 1;
+	if(p && atoi(p+1) == ssl_port)
+		return 1;
+	for(s = tls_additional_port; s; s = s->next) {
+		if(p && atoi(p+1) == atoi(s->str))
+			return 1;
+		if(!p && atoi(port) == atoi(s->str))
+			return 1;
+	}
+	return 0;
+}
+
 /** see if interface is PROXYv2, its port number == the proxy port number */
 int
 if_is_pp2(const char* ifname, const char* port,

--- a/util/config_file.h
+++ b/util/config_file.h
@@ -1405,6 +1405,10 @@ int if_is_https(const char* ifname, const char* port, int https_port);
  */
 int cfg_has_https(struct config_file* cfg);
 
+/** see if interface is ssl, its port number == the ssl port number */
+int if_is_ssl(const char* ifname, const char* port, int ssl_port,
+	struct config_strlist* tls_additional_port);
+
 /** see if interface is PROXYv2, its port number == the proxy port number */
 int if_is_pp2(const char* ifname, const char* port,
 	struct config_strlist* proxy_protocol_port);


### PR DESCRIPTION
Setting TCP_NODELAY on TLS sockets speeds up the TLS handshake.
Also noted on https://docs.openssl.org/3.4/man3/SSL_connect/#notes.

It was observed that during the handshake the server waits before sending more handshake data for the client ACK (Nagle's algorithm), which is delayed because the client waits for more data before ACKing (delayed ACK).

Old versions of OSes don't seem to experience the handshake delay (e.g., Ubuntu 20.04).
Tested with the same compiled versions of Unbound and OpenSSL across OS versions.
Maybe something changed in the kernel (or the kernel configuration) but couldn't pinpoint anything in particular.

Fixes #1045, #1185, #1202.