### PR TITLE
Draft: Update path to tls-cert-bundle on reload

### DIFF
--- a/daemon/unbound.c
+++ b/daemon/unbound.c
@@ -726,6 +726,10 @@ run_daemon(const char* cfgfile, int cmdline_verbose, int debug_mode, int need_pi
 		apply_settings(daemon, cfg, cmdline_verbose, debug_mode);
 		if(!done_setup)
 			config_lookup_uid(cfg);
+		else if(!connect_sslctx_update(daemon->connect_sslctx,
+			cfg->tls_cert_bundle, cfg->tls_win_cert)) {
+			log_err("could not update SSL_CTX");
+		}
 	
 		/* prepare */
 		if(!daemon_open_shared_ports(daemon))

--- a/util/net_help.c
+++ b/util/net_help.c
@@ -1435,6 +1435,42 @@ add_WIN_cacerts_to_openssl_store(SSL_CTX* tls_ctx)
 }
 #endif /* USE_WINSOCK */
 
+int connect_sslctx_update(void *sslctx, char* verifypem, int wincert)
+{
+#ifdef HAVE_SSL
+	if((verifypem && verifypem[0]) || wincert) {
+		SSL_CTX* ctx = (SSL_CTX *) sslctx;
+
+		if (!ctx)
+			return 0;
+		if(verifypem && verifypem[0]) {
+			if(!SSL_CTX_load_verify_locations(ctx, verifypem, NULL)) {
+				log_crypto_err("error in SSL_CTX verify");
+				return 0;
+			}
+		}
+		if(wincert) {
+#ifdef USE_WINSOCK
+			if(!add_WIN_cacerts_to_openssl_store(ctx)) {
+				log_crypto_err("error in add_WIN_cacerts_to_openssl_store");
+				return 0;
+			}
+#else
+			if(!SSL_CTX_set_default_verify_paths(ctx)) {
+				log_crypto_err("error in default_verify_paths");
+				return 0;
+			}
+#endif
+		}
+		SSL_CTX_set_verify(ctx, SSL_VERIFY_PEER, NULL);
+	}
+	return 1;
+#else
+	(void)verifypem; (void)wincert;
+	return 0;
+#endif
+}
+
 void* connect_sslctx_create(char* key, char* pem, char* verifypem, int wincert)
 {
 #ifdef HAVE_SSL
@@ -1497,32 +1533,9 @@ void* connect_sslctx_create(char* key, char* pem, char* verifypem, int wincert)
 			return NULL;
 		}
 	}
-	if((verifypem && verifypem[0]) || wincert) {
-		if(verifypem && verifypem[0]) {
-			if(!SSL_CTX_load_verify_locations(ctx, verifypem, NULL)) {
-				log_crypto_err("error in SSL_CTX verify");
-				SSL_CTX_free(ctx);
-				return NULL;
-			}
-		}
-#ifdef USE_WINSOCK
-		if(wincert) {
-			if(!add_WIN_cacerts_to_openssl_store(ctx)) {
-				log_crypto_err("error in add_WIN_cacerts_to_openssl_store");
-				SSL_CTX_free(ctx);
-				return NULL;
-			}
-		}
-#else
-		if(wincert) {
-			if(!SSL_CTX_set_default_verify_paths(ctx)) {
-				log_crypto_err("error in default_verify_paths");
-				SSL_CTX_free(ctx);
-				return NULL;
-			}
-		}
-#endif
-		SSL_CTX_set_verify(ctx, SSL_VERIFY_PEER, NULL);
+	if (!connect_sslctx_update(ctx, verifypem, wincert)) {
+		SSL_CTX_free(ctx);
+		return NULL;
 	}
 	return ctx;
 #else

--- a/util/net_help.h
+++ b/util/net_help.h
@@ -508,6 +508,16 @@ void* listen_sslctx_create(char* key, char* pem, char* verifypem);
  */
 void* connect_sslctx_create(char* key, char* pem, char* verifypem, int wincert);
 
+
+/**
+ * update SSL connect context certs
+ * @param verifypem: if nonNULL used for verifylocation file.
+ * @param wincert: add system certificate store to ctx (add to verifypem ca
+ * 	certs).
+ * @return 0 on failure (logged).
+ */
+int connect_sslctx_update(void *sslctx, char* verifypem, int wincert);
+
 /**
  * accept a new fd and wrap it in a BIO in SSL
  * @param sslctx: the SSL_CTX to use (from listen_sslctx_create()).


### PR DESCRIPTION
We need potentially higher privileges when reading key file, but not for reading cert bundle. Try to update also TLS cert path configured for remote TLS servers on reload command.