### PR TITLE
Add unbound members group access to control key

### DIFF
--- a/smallapp/unbound-control-setup.sh.in
+++ b/smallapp/unbound-control-setup.sh.in
@@ -204,7 +204,8 @@ fi
 # remove unused permissions
 chmod o-rw \
       "$SVR_BASE.pem" \
-      "$SVR_BASE.key" \
+      "$SVR_BASE.key"
+chmod g+r,o-rw \
       "$CTL_BASE.pem" \
       "$CTL_BASE.key"
 


### PR DESCRIPTION
Recent openssl genrsa does not use umask for generated keys. There is no strong reason why every member of unbound group should be able read server key. But control key would be quite useful to be group readable and to allow control access to whole group. Allowing access to control by group membership, not via sudo.