### PR TITLE
check before use daemon->shm_info

### DIFF
--- a/util/shm_side/shm_main.c
+++ b/util/shm_side/shm_main.c
@@ -195,7 +195,7 @@ void shm_main_shutdown(struct daemon* daemon)
 {
 #ifdef HAVE_SHMGET
 	/* web are OK, just disabled */
-	if(!daemon->cfg->shm_enable)
+	if(!daemon->cfg->shm_enable || !daemon->shm_info)
 		return;
 
 	verbose(VERB_DETAIL, "SHM shutdown - KEY [%d] - ID CTL [%d] ARR [%d] - PTR CTL [%p] ARR [%p]",


### PR DESCRIPTION
fix coredump after the command `unbound-control stop unbound`

fix: https://github.com/NLnetLabs/unbound/issues/1228