### PR TITLE
Prefer SOURCE_DATE_EPOCH over actual time

### DIFF
--- a/ax_build_date_epoch.m4
+++ b/ax_build_date_epoch.m4
@@ -1,0 +1,70 @@
+# ===========================================================================
+#   https://www.gnu.org/software/autoconf-archive/ax_build_date_epoch.html
+# ===========================================================================
+#
+# SYNOPSIS
+#
+#   AX_BUILD_DATE_EPOCH(VARIABLE[, FORMAT[, ACTION-IF-FAIL]])
+#
+# DESCRIPTION
+#
+#   Sets VARIABLE to a string representing the current time.  It is
+#   formatted according to FORMAT if specified, otherwise it is formatted as
+#   the number of seconds (excluding leap seconds) since the UNIX epoch (01
+#   Jan 1970 00:00:00 UTC).
+#
+#   If the SOURCE_DATE_EPOCH environment variable is set, it uses the value
+#   of that variable instead of the current time.  See
+#   https://reproducible-builds.org/specs/source-date-epoch).  If
+#   SOURCE_DATE_EPOCH is set but cannot be properly interpreted as a UNIX
+#   timestamp, then execute ACTION-IF-FAIL if specified, otherwise error.
+#
+#   VARIABLE is AC_SUBST-ed.
+#
+# LICENSE
+#
+#   Copyright (c) 2016 Eric Bavier <bavier@member.fsf.org>
+#
+#   This program is free software: you can redistribute it and/or modify it
+#   under the terms of the GNU General Public License as published by the
+#   Free Software Foundation, either version 3 of the License, or (at your
+#   option) any later version.
+#
+#   This program is distributed in the hope that it will be useful, but
+#   WITHOUT ANY WARRANTY; without even the implied warranty of
+#   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General
+#   Public License for more details.
+#
+#   You should have received a copy of the GNU General Public License along
+#   with this program. If not, see <https://www.gnu.org/licenses/>.
+#
+#   As a special exception, the respective Autoconf Macro's copyright owner
+#   gives unlimited permission to copy, distribute and modify the configure
+#   scripts that are the output of Autoconf when processing the Macro. You
+#   need not follow the terms of the GNU General Public License when using
+#   or distributing such scripts, even though portions of the text of the
+#   Macro appear in them. The GNU General Public License (GPL) does govern
+#   all other use of the material that constitutes the Autoconf Macro.
+#
+#   This special exception to the GPL applies to versions of the Autoconf
+#   Macro released by the Autoconf Archive. When you make and distribute a
+#   modified version of the Autoconf Macro, you may extend this special
+#   exception to the GPL to apply to your modified version as well.
+
+#serial 2
+
+AC_DEFUN([AX_BUILD_DATE_EPOCH],
+[dnl
+AC_MSG_CHECKING([for build time])
+ax_date_fmt="m4_default($2,%s)"
+AS_IF([test x"$SOURCE_DATE_EPOCH" = x],
+ [$1=`date "+$ax_date_fmt"`],
+ [ax_build_date=`date -u -d "@$SOURCE_DATE_EPOCH" "+$ax_date_fmt" 2>/dev/null \
+                 || date -u -r "$SOURCE_DATE_EPOCH" "+$ax_date_fmt" 2>/dev/null`
+  AS_IF([test x"$ax_build_date" = x],
+   [m4_ifval([$3],
+      [$3],
+      [AC_MSG_ERROR([malformed SOURCE_DATE_EPOCH])])],
+   [$1=$ax_build_date])])
+AC_MSG_RESULT([$$1])
+])dnl AX_BUILD_DATE_EPOCH

--- a/configure
+++ b/configure
@@ -19894,7 +19894,25 @@ if test "`uname`" = "Linux"; then
 	GCC_DOCKER_LINTFLAGS='-syntax'
 
 fi
-CONFIG_DATE=`date +%Y%m%d`
+{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for build time" >&5
+printf %s "checking for build time... " >&6; }
+ax_date_fmt="%Y%m%d"
+if test x"$SOURCE_DATE_EPOCH" = x
+then :
+  CONFIG_DATE=`date "+$ax_date_fmt"`
+else $as_nop
+  ax_build_date=`date -u -d "@$SOURCE_DATE_EPOCH" "+$ax_date_fmt" 2>/dev/null \
+                 || date -u -r "$SOURCE_DATE_EPOCH" "+$ax_date_fmt" 2>/dev/null`
+  if test x"$ax_build_date" = x
+then :
+  as_fn_error $? "malformed SOURCE_DATE_EPOCH" "$LINENO" 5
+else $as_nop
+  CONFIG_DATE=$ax_build_date
+fi
+fi
+{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $CONFIG_DATE" >&5
+printf "%s\n" "$CONFIG_DATE" >&6; }
+
 
 
 # Checks for libraries.
@@ -25000,7 +25018,25 @@ printf "%s\n" "#define MAXSYSLOGMSGLEN 10240" >>confdefs.h
 
 version=1.22.1
 
-date=`date +'%b %e, %Y'`
+{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking for build time" >&5
+printf %s "checking for build time... " >&6; }
+ax_date_fmt="%b %e, %Y"
+if test x"$SOURCE_DATE_EPOCH" = x
+then :
+  date=`date "+$ax_date_fmt"`
+else $as_nop
+  ax_build_date=`date -u -d "@$SOURCE_DATE_EPOCH" "+$ax_date_fmt" 2>/dev/null \
+                 || date -u -r "$SOURCE_DATE_EPOCH" "+$ax_date_fmt" 2>/dev/null`
+  if test x"$ax_build_date" = x
+then :
+  as_fn_error $? "malformed SOURCE_DATE_EPOCH" "$LINENO" 5
+else $as_nop
+  date=$ax_build_date
+fi
+fi
+{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $date" >&5
+printf "%s\n" "$date" >&6; }
+
 
 
 ac_config_files="$ac_config_files Makefile doc/example.conf doc/libunbound.3 doc/unbound.8 doc/unbound-anchor.8 doc/unbound-checkconf.8 doc/unbound.conf.5 doc/unbound-control.8 doc/unbound-host.1 smallapp/unbound-control-setup.sh dnstap/dnstap_config.h dnscrypt/dnscrypt_config.h contrib/libunbound.pc contrib/unbound.socket contrib/unbound.service contrib/unbound_portable.service"

--- a/configure.ac
+++ b/configure.ac
@@ -909,7 +909,7 @@ if test "`uname`" = "Linux"; then
 	GCC_DOCKER_LINTFLAGS='-syntax'
 	AC_SUBST(GCC_DOCKER_LINTFLAGS)
 fi
-CONFIG_DATE=`date +%Y%m%d`
+AX_BUILD_DATE_EPOCH(CONFIG_DATE, [%Y%m%d])
 AC_SUBST(CONFIG_DATE)
 
 # Checks for libraries.
@@ -2436,7 +2436,8 @@ char *unbound_stat_strdup_log(const char *s, const char* file, int line,
 dnl if we build from source tree, the man pages need @date@ and @version@
 dnl if this is a distro tarball, that was already done by makedist.sh
 AC_SUBST(version, [VERSION_MAJOR.VERSION_MINOR.VERSION_MICRO])
-AC_SUBST(date, [`date +'%b %e, %Y'`])
+AX_BUILD_DATE_EPOCH(date, [[%b %e, %Y]])
+AC_SUBST(date)
 
 AC_CONFIG_FILES([Makefile doc/example.conf doc/libunbound.3 doc/unbound.8 doc/unbound-anchor.8 doc/unbound-checkconf.8 doc/unbound.conf.5 doc/unbound-control.8 doc/unbound-host.1 smallapp/unbound-control-setup.sh dnstap/dnstap_config.h dnscrypt/dnscrypt_config.h contrib/libunbound.pc contrib/unbound.socket contrib/unbound.service contrib/unbound_portable.service])
 AC_CONFIG_HEADERS([config.h])

--- a/configure.ac
+++ b/configure.ac
@@ -2,6 +2,7 @@
 # Process this file with autoconf to produce a configure script.
 AC_PREREQ([2.56])
 sinclude(acx_nlnetlabs.m4)
+sinclude(ax_build_date_epoch.m4)
 sinclude(ax_pthread.m4)
 sinclude(acx_python.m4)
 sinclude(ax_pkg_swig.m4)


### PR DESCRIPTION
I have noticed that unbound's man pages were not reproducible in NixOS. (See [Diffoscope output](https://web.archive.org/web/20250210112414/https://reproducible.nixos.org/nixos-iso-minimal-runtime/diff/35eb81a1e97f3414a27f18a2e849f2646bd68f4f9b490cbcacc9de0918df2d2a-f32ed734f47e3ab6ac2e680e99d01224ca239fede3f91c047e570f9e71b4324d.html))

Instead of using the current system time, this patch makes the configure script prefer [SOURCE_DATE_EPOCH](https://reproducible-builds.org/docs/source-date-epoch/) and otherwise fall back to system time.

ax_build_date_epoch: https://www.gnu.org/software/autoconf-archive/ax_build_date_epoch.html
