### PR TITLE
fix build with gcc-15 -Wbuiltin-declaration-mismatch error

### DIFF
--- a/compat/malloc.c
+++ b/compat/malloc.c
@@ -6,7 +6,7 @@
 #include <sys/types.h>
 
 #ifndef USE_WINSOCK
-void *malloc ();
+void *malloc (size_t n);
 #else
 /* provide a prototype */
 void *malloc (size_t n);


### PR DESCRIPTION
See more details: http://errors.yoctoproject.org/Errors/Details/850313 ../git/compat/malloc.c:9:7: warning: conflicting types for built-in function 'malloc'; expected 'void *(long unsigned int)' [-Wbuiltin-declaration-mismatch]
    9 | void *malloc ();
      |       ^~~~~~
../git/compat/malloc.c:5:1: note: 'malloc' is declared in header '<stdlib.h>'
    4 | #include "config.h"
  +++ |+#include <stdlib.h>
    5 | #undef malloc
../git/compat/malloc.c: In function 'rpl_malloc_unbound':
../git/compat/malloc.c:23:10: error: too many arguments to function 'malloc'; expected 0, have 1
   23 |   return malloc (n);
      |          ^~~~~~  ~
../git/compat/malloc.c:9:7: note: declared here
    9 | void *malloc ();
      |       ^~~~~~

* Seeing that there is '#undef malloc', it appears they don't want to use the malloc from stdlib.h. Therefore, we need to correctly define the parameters for malloc.