### PR TITLE
edns-subnet: fix NULL_AFTER_DEREF on subnetmod

### DIFF
--- a/edns-subnet/subnetmod.c
+++ b/edns-subnet/subnetmod.c
@@ -232,13 +232,13 @@ subnetmod_init(struct module_env *env, int id)
 		HASH_DEFAULT_STARTARRAY, env->cfg->msg_cache_size,
 		msg_cache_sizefunc, query_info_compare, query_entry_delete,
 		subnet_data_delete, NULL);
-	slabhash_setmarkdel(sn_env->subnet_msg_cache, &subnet_markdel);
 	if(!sn_env->subnet_msg_cache) {
 		log_err("subnetcache: could not create cache");
 		free(sn_env);
 		env->modinfo[id] = NULL;
 		return 0;
 	}
+	slabhash_setmarkdel(sn_env->subnet_msg_cache, &subnet_markdel);
 	/* whitelist for edns subnet capable servers */
 	sn_env->whitelist = ecs_whitelist_create();
 	if(!sn_env->whitelist ||


### PR DESCRIPTION
Found by static analyzer svace.
Static analyzer message: Redundant comparison with a NULL value at subnetmod.c:236 for pointer 'sn_env->subnet_msg_cache', which was dereferenced at slabhash.c:228 by passing as 1st parameter to function 'slabhash_setmarkdel' at subnetmod.c:235.

Moved usage of sn_env->subnet_msg_cache in slabhash_setmarkdel after checking.