### PR TITLE
dot and forward-first: make sure the recursion fallback does not use TLS (issue #1247)

### DIFF
--- a/iterator/iterator.c
+++ b/iterator/iterator.c
@@ -2206,6 +2206,11 @@ processLastResort(struct module_qstate* qstate, struct iter_qstate* iq,
 		qstate->region, iq->dp, 0))
 		log_err("out of memory in cache_fill_missing");
 	if(iq->dp->usable_list) {
+		if (iq->dp->ssl_upstream) {
+			verbose(VERB_OPS, "tls forwarders failed and forward-first is set. "
+					"trying recursive query.");
+			iq->dp->ssl_upstream = 0;
+		}
 		verbose(VERB_ALGO, "try parent-side-name, w. glue from cache");
 		return next_state(iq, QUERYTARGETS_STATE);
 	}


### PR DESCRIPTION
this fixes the issue #1247 by hard resetting ssl in the fallback case, when a DoT Forwarder is used with _forward-first=yes_ set.

As this might impact security, I added a logging statement if this occurs