### PR TITLE
Replace deprecated $function by new $action

### DIFF
--- a/libunbound/python/libunbound.i
+++ b/libunbound/python/libunbound.i
@@ -853,7 +853,7 @@ Result: ['74.125.43.147', '74.125.43.99', '74.125.43.103', '74.125.43.104']
 %{ 
   //printf("resolve_start(%lX)\n",(long unsigned int)arg1);
   Py_BEGIN_ALLOW_THREADS 
-  $function 
+  $action
   Py_END_ALLOW_THREADS 
   //printf("resolve_stop()\n");
 %} 


### PR DESCRIPTION
The long-deprecated $function was removed from future SWIG 4.4.0. It can be safely replaced by $action.

More information about swig change could be found in the commit [Remove long-deprecated $function variable](https://github.com/swig/swig/commit/3be7697a33c98435865fc713f8ecf7cf10765f13)