### PR TITLE
[Feat] Unbound: Refresh local-zone ipset entry TTL on subsequent queries with matching IPs in RRSet

### DIFF
--- a/daemon/remote.c
+++ b/daemon/remote.c
@@ -5153,7 +5153,7 @@ getmem_config_view(struct config_view* p)
 			+ getmem_config_strlist(s->local_data)
 			+ getmem_config_strlist(s->local_zones_nodefault)
 #ifdef USE_IPSET
-			+ getmem_config_strlist(s->local_zones_ipset)
+			+ getmem_config_str2list(s->local_zones_ipset)
 #endif
 			+ getmem_config_str2list(s->respip_actions)
 			+ getmem_config_str2list(s->respip_data);
@@ -5217,7 +5217,7 @@ config_file_getmem(struct config_file* cfg)
 	m += getmem_config_str2list(cfg->local_zones);
 	m += getmem_config_strlist(cfg->local_zones_nodefault);
 #ifdef USE_IPSET
-	m += getmem_config_strlist(cfg->local_zones_ipset);
+	m += getmem_config_str2list(cfg->local_zones_ipset);
 #endif
 	m += getmem_config_strlist(cfg->local_data);
 	m += getmem_config_str3list(cfg->local_zone_overrides);

--- a/ipset/ipset.c
+++ b/ipset/ipset.c
@@ -156,7 +156,7 @@ static int add_to_ipset(filter_dev dev, const char *setname, const void *ipaddr,
 
 	nlh = mnl_nlmsg_put_header(buffer);
 	nlh->nlmsg_type = IPSET_CMD_ADD | (NFNL_SUBSYS_IPSET << 8);
-	nlh->nlmsg_flags = NLM_F_REQUEST|NLM_F_ACK|NLM_F_EXCL;
+	nlh->nlmsg_flags = NLM_F_REQUEST|NLM_F_ACK|NLM_F_REPLACE|NLM_F_CREATE;
 
 	nfg = mnl_nlmsg_put_extra_header(nlh, sizeof(struct nfgenmsg));
 	nfg->nfgen_family = af;

--- a/util/config_file.h
+++ b/util/config_file.h
@@ -466,7 +466,7 @@ struct config_file {
 	struct config_strlist* local_zones_nodefault;
 #ifdef USE_IPSET
 	/** local zones ipset list */
-	struct config_strlist* local_zones_ipset;
+	struct config_str2list* local_zones_ipset;
 #endif
 	/** do not add any default local zone */
 	int local_zones_disable_default;
@@ -893,7 +893,7 @@ struct config_view {
 	struct config_strlist* local_zones_nodefault;
 #ifdef USE_IPSET
 	/** local zones ipset list */
-	struct config_strlist* local_zones_ipset;
+	struct config_str2list* local_zones_ipset;
 #endif
 	/** Fallback to global local_zones when there is no match in the view
 	 * view specific tree. 1 for yes, 0 for no */

--- a/util/configlexer.lex
+++ b/util/configlexer.lex
@@ -440,7 +440,7 @@ log-tag-queryreply{COLON}	{ YDVAR(1, VAR_LOG_TAG_QUERYREPLY) }
 log-local-actions{COLON}       { YDVAR(1, VAR_LOG_LOCAL_ACTIONS) }
 log-servfail{COLON}		{ YDVAR(1, VAR_LOG_SERVFAIL) }
 log-destaddr{COLON}		{ YDVAR(1, VAR_LOG_DESTADDR) }
-local-zone{COLON}		{ YDVAR(2, VAR_LOCAL_ZONE) }
+local-zone{COLON}		{ YDVAR(3, VAR_LOCAL_ZONE) }
 local-data{COLON}		{ YDVAR(1, VAR_LOCAL_DATA) }
 local-data-ptr{COLON}		{ YDVAR(1, VAR_LOCAL_DATA_PTR) }
 unblock-lan-zones{COLON}	{ YDVAR(1, VAR_UNBLOCK_LAN_ZONES) }

--- a/util/configparser.y
+++ b/util/configparser.y
@@ -2388,20 +2388,28 @@ server_local_zone: VAR_LOCAL_ZONE STRING_ARG STRING_ARG
 			free($3);
 #ifdef USE_IPSET
 		} else if(strcmp($3, "ipset")==0) {
-			size_t len = strlen($2);
-			/* Make sure to add the trailing dot.
-			 * These are str compared to domain names. */
-			if($2[len-1] != '.') {
-				if(!($2 = realloc($2, len+2))) {
-					fatal_exit("out of memory adding local-zone");
-				}
-				$2[len] = '.';
-				$2[len+1] = 0;
-			}
-			if(!cfg_strlist_insert(&cfg_parser->cfg->
-				local_zones_ipset, $2))
-				fatal_exit("out of memory adding local-zone");
-			free($3);
+            if (strncmp($4, "refresh_ttl", 11) != 0
+                || strncmp($4, "no_refresh_ttl", 14)) {
+                yyerror("local-zone ipset TTL behaviour: expected "
+                    "refresh_ttl or no_refresh_ttl");
+                free($3);
+                free($4);
+            } else {
+                size_t len = strlen($2);
+                /* Make sure to add the trailing dot.
+                 * These are str compared to domain names. */
+                if($2[len-1] != '.') {
+                    if(!($2 = realloc($2, len+2))) {
+                        fatal_exit("out of memory adding local-zone");
+                    }
+                    $2[len] = '.';
+                    $2[len+1] = 0;
+                }
+                if(!cfg_str2list_insert(&cfg_parser->cfg->
+                    local_zones_ipset, $2, $4))
+                    fatal_exit("out of memory adding local-zone");
+                free($3);
+            }
 #endif
 		} else {
 			if(!cfg_str2list_insert(&cfg_parser->cfg->local_zones,


### PR DESCRIPTION
# Background

- DNS servers can reuse the IPs for domains, e.g., `1.2.3.4` => `4.3.2.1`, and then back to `1.2.3.4` after
- Unbound only creates a fresh ipset rule, it doesn't refresh existing entries' TTL
- We can have a case where ipset entry's TTL is about to expire, but then the DNS server switched to that IP again. We will have a period where we have an address missing from the ipset for that domain until the DNS entry expires

See this table for example 

timestamp | ipset entry   | DNS entry      |
----------|---------------|----------------|
0         | 1.2.3.4 TTL 3 | 1.2.3.4 TTL 60 |
3         | -             | 1.2.3.4 TTL 57 |

This means worst case scenario is `DNS TTL - ipset TTL` of no ipset entry presence. In the worst case scenario a 60 second RRSet entry (for example) could have an ipset entry present for only 1 second if the query finishes on the last second that the ipset contains the ip.

Note that bumping ipset TTL value itself might help reducing the occurrences, but not going to fully eliminate the problem

# Solution

To make non-overlapping DNS cycles more palatable, Unbound can refresh/reset the TTL of an ipset set instead of leaving it at the current value. This applies when a DNS query responds with an IP that matches an existing ipset entry that was stored as a result of a previous DNS query

# Notes

A follow up PR for a more comprehensive rework of ipset support has been raised here: <https://github.com/NLnetLabs/unbound/pull/1335>