### PR TITLE
pythonmod: fix HANDLE_LEAK on pythonmod_init

### DIFF
--- a/pythonmod/pythonmod.c
+++ b/pythonmod/pythonmod.c
@@ -454,6 +454,7 @@ int pythonmod_init(struct module_env* env, int id)
    if(PyDict_SetItemString(pe->data, "script", fname) < 0) {
 	log_err("pythonmod: could not add item to dictionary");
 	Py_XDECREF(fname);
+	fclose(script_py);
 	goto python_init_fail;
    }
    Py_XDECREF(fname);
@@ -462,6 +463,7 @@ int pythonmod_init(struct module_env* env, int id)
 	log_err("pythonmod: could not add mod_env object");
 	Py_XDECREF(pe->data);  /* 2 times, here and on python_init_fail; */
 	                       /* on failure the reference is not stolen */
+	fclose(script_py);
 	goto python_init_fail;
    }
 


### PR DESCRIPTION
Found by the static analyzer Svace (ISP RAS).

Handle 'script_py' is created at pythonmod.c:436
by calling function 'fopen' and lost at pythonmod.c:457,465.