### PR TITLE
Fix for analysis and ports workflows iOS, Windows

### DIFF
--- a/.github/workflows/analysis_ports.yml
+++ b/.github/workflows/analysis_ports.yml
@@ -58,24 +58,24 @@ jobs:
             test_ios: "yes"
             config: "no"
             make: "no"
-          - name: Apple iPhone on iOS, arm64
-            os: macos-latest
-            AUTOTOOLS_HOST: aarch64-apple-ios
-            OPENSSL_HOST: ios64-cross
-            IOS_SDK: iPhoneOS
-            IOS_CPU: arm64
-            test_ios: "yes"
-            config: "no"
-            make: "no"
-          - name: Apple TV on iOS, arm64
-            os: macos-latest
-            AUTOTOOLS_HOST: aarch64-apple-ios
-            OPENSSL_HOST: ios64-cross
-            IOS_SDK: AppleTVOS
-            IOS_CPU: arm64
-            test_ios: "yes"
-            config: "no"
-            make: "no"
+#          - name: Apple iPhone on iOS, arm64
+#            os: macos-latest
+#            AUTOTOOLS_HOST: aarch64-apple-ios
+#            OPENSSL_HOST: ios64-cross
+#            IOS_SDK: iPhoneOS
+#            IOS_CPU: arm64
+#            test_ios: "yes"
+#            config: "no"
+#            make: "no"
+#          - name: Apple TV on iOS, arm64
+#            os: macos-latest
+#            AUTOTOOLS_HOST: aarch64-apple-ios
+#            OPENSSL_HOST: ios64-cross
+#            IOS_SDK: AppleTVOS
+#            IOS_CPU: arm64
+#            test_ios: "yes"
+#            config: "no"
+#            make: "no"
 #          - name: Apple Watch on iOS, armv7
 #            os: macos-latest
 #            AUTOTOOLS_HOST: armv7-apple-ios
@@ -94,24 +94,24 @@ jobs:
             test_ios: "yes"
             config: "no"
             make: "no"
-          - name: iPhoneSimulator on OS X, x86_64
-            os: macos-latest
-            AUTOTOOLS_HOST: x86_64-apple-ios
-            OPENSSL_HOST: iphoneos-cross
-            IOS_SDK: iPhoneSimulator
-            IOS_CPU: x86_64
-            test_ios: "yes"
-            config: "no"
-            make: "no"
-          - name: AppleTVSimulator on OS X, x86_64
-            os: macos-latest
-            AUTOTOOLS_HOST: x86_64-apple-ios
-            OPENSSL_HOST: iphoneos-cross
-            IOS_SDK: AppleTVSimulator
-            IOS_CPU: x86_64
-            test_ios: "yes"
-            config: "no"
-            make: "no"
+#          - name: iPhoneSimulator on OS X, x86_64
+#            os: macos-latest
+#            AUTOTOOLS_HOST: x86_64-apple-ios
+#            OPENSSL_HOST: iphoneos-cross
+#            IOS_SDK: iPhoneSimulator
+#            IOS_CPU: x86_64
+#            test_ios: "yes"
+#            config: "no"
+#            make: "no"
+#          - name: AppleTVSimulator on OS X, x86_64
+#            os: macos-latest
+#            AUTOTOOLS_HOST: x86_64-apple-ios
+#            OPENSSL_HOST: iphoneos-cross
+#            IOS_SDK: AppleTVSimulator
+#            IOS_CPU: x86_64
+#            test_ios: "yes"
+#            config: "no"
+#            make: "no"
 #          - name: WatchSimulator on OS X, i386
 #            os: macos-latest
 #            AUTOTOOLS_HOST: i386-apple-ios

--- a/.github/workflows/analysis_ports.yml
+++ b/.github/workflows/analysis_ports.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        include:
+        exclude:
           - name: GCC on Linux
             os: ubuntu-latest
             config: "--enable-debug --disable-flto"
@@ -49,72 +49,12 @@ jobs:
             os: ubuntu-latest
             config: 'CFLAGS="-DNDEBUG -g2 -O3 -fsanitize=address" --disable-flto --disable-static'
             make_test: "yes"
-          - name: Apple iPhone on iOS, armv7
-            os: macos-latest
-            AUTOTOOLS_HOST: armv7-apple-ios
-            OPENSSL_HOST: ios-cross
-            IOS_SDK: iPhoneOS
-            IOS_CPU: armv7s
-            SDK_VERSION: 18.0
-            test_ios: "yes"
-            config: "no"
-            make: "no"
-          - name: Apple iPhone on iOS, arm64
-            os: macos-latest
-            AUTOTOOLS_HOST: aarch64-apple-ios
-            OPENSSL_HOST: ios64-cross
-            IOS_SDK: iPhoneOS
-            IOS_CPU: arm64
-            SDK_VERSION: 18.0
-            test_ios: "yes"
-            config: "no"
-            make: "no"
-          - name: Apple TV on iOS, arm64
-            os: macos-latest
-            AUTOTOOLS_HOST: aarch64-apple-ios
-            OPENSSL_HOST: ios64-cross
-            IOS_SDK: AppleTVOS
-            IOS_CPU: arm64
-            SDK_VERSION: 18.0
-            test_ios: "yes"
-            config: "no"
-            make: "no"
           - name: Apple Watch on iOS, armv7
             os: macos-latest
             AUTOTOOLS_HOST: armv7-apple-ios
             OPENSSL_HOST: ios-cross
             IOS_SDK: WatchOS
             IOS_CPU: armv7k
-            test_ios: "yes"
-            config: "no"
-            make: "no"
-          - name: iPhoneSimulator on OS X, i386
-            os: macos-latest
-            AUTOTOOLS_HOST: i386-apple-ios
-            OPENSSL_HOST: iphoneos-cross
-            IOS_SDK: iPhoneSimulator
-            IOS_CPU: i386
-            SDK_VERSION: 18.0
-            test_ios: "yes"
-            config: "no"
-            make: "no"
-          - name: iPhoneSimulator on OS X, x86_64
-            os: macos-latest
-            AUTOTOOLS_HOST: x86_64-apple-ios
-            OPENSSL_HOST: iphoneos-cross
-            IOS_SDK: iPhoneSimulator
-            IOS_CPU: x86_64
-            SDK_VERSION: 18.0
-            test_ios: "yes"
-            config: "no"
-            make: "no"
-          - name: AppleTVSimulator on OS X, x86_64
-            os: macos-latest
-            AUTOTOOLS_HOST: x86_64-apple-ios
-            OPENSSL_HOST: iphoneos-cross
-            IOS_SDK: AppleTVSimulator
-            IOS_CPU: x86_64
-            SDK_VERSION: 18.0
             test_ios: "yes"
             config: "no"
             make: "no"
@@ -163,11 +103,6 @@ jobs:
             test_android: "yes"
             config: "no"
             make: "no"
-          - name: Windows
-            os: windows-latest
-            test_windows: "yes"
-            config: "no"
-            make: "no"
           - name: FreeBSD
             os: ubuntu-latest
             config: "no"
@@ -195,6 +130,66 @@ jobs:
             cross_platform_arch: "x86-64"
             cross_platform_version: "10.0"
             cross_platform_config: "--enable-debug --disable-flto --with-libevent --disable-static"
+        include:
+          - name: Apple iPhone on iOS, armv7
+            os: macos-latest
+            AUTOTOOLS_HOST: armv7-apple-ios
+            OPENSSL_HOST: ios-cross
+            IOS_SDK: iPhoneOS
+            IOS_CPU: armv7s
+            test_ios: "yes"
+            config: "no"
+            make: "no"
+          - name: Apple iPhone on iOS, arm64
+            os: macos-latest
+            AUTOTOOLS_HOST: aarch64-apple-ios
+            OPENSSL_HOST: ios64-cross
+            IOS_SDK: iPhoneOS
+            IOS_CPU: arm64
+            test_ios: "yes"
+            config: "no"
+            make: "no"
+          - name: Apple TV on iOS, arm64
+            os: macos-latest
+            AUTOTOOLS_HOST: aarch64-apple-ios
+            OPENSSL_HOST: ios64-cross
+            IOS_SDK: AppleTVOS
+            IOS_CPU: arm64
+            test_ios: "yes"
+            config: "no"
+            make: "no"
+          - name: iPhoneSimulator on OS X, i386
+            os: macos-latest
+            AUTOTOOLS_HOST: i386-apple-ios
+            OPENSSL_HOST: iphoneos-cross
+            IOS_SDK: iPhoneSimulator
+            IOS_CPU: i386
+            test_ios: "yes"
+            config: "no"
+            make: "no"
+          - name: iPhoneSimulator on OS X, x86_64
+            os: macos-latest
+            AUTOTOOLS_HOST: x86_64-apple-ios
+            OPENSSL_HOST: iphoneos-cross
+            IOS_SDK: iPhoneSimulator
+            IOS_CPU: x86_64
+            test_ios: "yes"
+            config: "no"
+            make: "no"
+          - name: AppleTVSimulator on OS X, x86_64
+            os: macos-latest
+            AUTOTOOLS_HOST: x86_64-apple-ios
+            OPENSSL_HOST: iphoneos-cross
+            IOS_SDK: AppleTVSimulator
+            IOS_CPU: x86_64
+            test_ios: "yes"
+            config: "no"
+            make: "no"
+          - name: Windows
+            os: windows-latest
+            test_windows: "yes"
+            config: "no"
+            make: "no"
  
     steps:
       - uses: actions/checkout@v4
@@ -276,6 +271,8 @@ jobs:
           cd unbound
           echo "./configure --enable-debug --enable-static-exe --disable-flto \"--with-ssl=$prepath/openssl\" --with-libexpat=\"$prepath/expat\" --disable-shared"
           ./configure --enable-debug --enable-static-exe --disable-flto "--with-ssl=$prepath/openssl" --with-libexpat="$prepath/expat" --disable-shared
+          # for the check results.
+          cat config.log
           make
           # specific test output
           #make testbound.exe; ./testbound.exe -s
@@ -336,7 +333,6 @@ jobs:
           OPENSSL_HOST: ${{ matrix.OPENSSL_HOST }}
           IOS_SDK: ${{ matrix.IOS_SDK }}
           IOS_CPU: ${{ matrix.IOS_CPU }}
-          SDK_VERSION: ${{ matrix.SDK_VERSION }}
         run: |
           #(already installed) ./contrib/ios/install_tools.sh
           export AUTOTOOLS_BUILD="$(./config.guess)"

--- a/.github/workflows/analysis_ports.yml
+++ b/.github/workflows/analysis_ports.yml
@@ -14,123 +14,41 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        exclude:
-          - name: GCC on Linux
-            os: ubuntu-latest
-            config: "--enable-debug --disable-flto"
-            make_test: "yes"
-          - name: Clang-analyzer
-            os: ubuntu-latest
-            config: "CC=clang --enable-debug --disable-flto --disable-static"
-            make_test: "yes"
-            clang_analysis: "yes"
-          - name: libevent
-            os: ubuntu-latest
-            install_libevent: "yes"
-            config: "CC=clang --enable-debug --disable-flto --with-libevent --disable-static"
-            make_test: "yes"
-            clang_analysis: "yes"
-          - name: OS X
-            os: macos-latest
-            install_expat: "yes"
-            config: "--enable-debug --disable-flto --with-ssl=/opt/homebrew/opt/openssl --with-libexpat=/opt/homebrew/opt/expat"
-            make_test: "yes"
-          - name: Clang on OS X
-            os: macos-latest
-            install_expat: "yes"
-            config: "CC=clang --enable-debug --disable-flto --with-ssl=/opt/homebrew/opt/openssl --with-libexpat=/opt/homebrew/opt/expat --disable-static"
-            make_test: "yes"
-            clang_analysis: "yes"
-          - name: ubsan (gcc undefined behaviour sanitizer)
-            os: ubuntu-latest
-            config: 'CFLAGS="-DNDEBUG -g2 -O3 -fsanitize=undefined -fno-sanitize-recover=all" --disable-flto --disable-static'
-            make_test: "yes"
-          - name: asan (gcc address sanitizer)
-            os: ubuntu-latest
-            config: 'CFLAGS="-DNDEBUG -g2 -O3 -fsanitize=address" --disable-flto --disable-static'
-            make_test: "yes"
-          - name: Apple Watch on iOS, armv7
-            os: macos-latest
-            AUTOTOOLS_HOST: armv7-apple-ios
-            OPENSSL_HOST: ios-cross
-            IOS_SDK: WatchOS
-            IOS_CPU: armv7k
-            test_ios: "yes"
-            config: "no"
-            make: "no"
-          - name: WatchSimulator on OS X, i386
-            os: macos-latest
-            AUTOTOOLS_HOST: i386-apple-ios
-            OPENSSL_HOST: iphoneos-cross
-            IOS_SDK: WatchSimulator
-            IOS_CPU: i386
-            test_ios: "yes"
-            config: "no"
-            make: "no"
-          - name: Android armv7a
-            os: ubuntu-latest
-            AUTOTOOLS_HOST: armv7a-linux-androidabi
-            OPENSSL_HOST: android-arm
-            ANDROID_CPU: armv7a
-            ANDROID_API: 23
-            test_android: "yes"
-            config: "no"
-            make: "no"
-          - name: Android aarch64
-            os: ubuntu-latest
-            AUTOTOOLS_HOST: aarch64-linux-android
-            OPENSSL_HOST: android-arm64
-            ANDROID_CPU: aarch64
-            ANDROID_API: 23
-            test_android: "yes"
-            config: "no"
-            make: "no"
-          - name: Android x86
-            os: ubuntu-latest
-            AUTOTOOLS_HOST: i686-linux-android
-            OPENSSL_HOST: android-x86
-            ANDROID_CPU: x86
-            ANDROID_API: 23
-            test_android: "yes"
-            config: "no"
-            make: "no"
-          - name: Android x86_64
-            os: ubuntu-latest
-            AUTOTOOLS_HOST: x86_64-linux-android
-            OPENSSL_HOST: android-x86_64
-            ANDROID_CPU: x86_64
-            ANDROID_API: 23
-            test_android: "yes"
-            config: "no"
-            make: "no"
-          - name: FreeBSD
-            os: ubuntu-latest
-            config: "no"
-            make: "no"
-            with_cross_platform_action: "yes"
-            cross_platform_os: "freebsd"
-            cross_platform_arch: "x86-64"
-            cross_platform_version: "14.1"
-            cross_platform_config: "--enable-debug --disable-flto --with-libevent --disable-static"
-          - name: OpenBSD
-            os: ubuntu-latest
-            config: "no"
-            make: "no"
-            with_cross_platform_action: "yes"
-            cross_platform_os: "openbsd"
-            cross_platform_arch: "x86-64"
-            cross_platform_version: "7.5"
-            cross_platform_config: "--enable-debug --disable-flto --with-libevent --disable-static"
-          - name: NetBSD
-            os: ubuntu-latest
-            config: "no"
-            make: "no"
-            with_cross_platform_action: "yes"
-            cross_platform_os: "netbsd"
-            cross_platform_arch: "x86-64"
-            cross_platform_version: "10.0"
-            cross_platform_config: "--enable-debug --disable-flto --with-libevent --disable-static"
         include:
+#          - name: GCC on Linux
+#            os: ubuntu-latest
+#            config: "--enable-debug --disable-flto"
+#            make_test: "yes"
+#          - name: Clang-analyzer
+#            os: ubuntu-latest
+#            config: "CC=clang --enable-debug --disable-flto --disable-static"
+#            make_test: "yes"
+#            clang_analysis: "yes"
+#          - name: libevent
+#            os: ubuntu-latest
+#            install_libevent: "yes"
+#            config: "CC=clang --enable-debug --disable-flto --with-libevent --disable-static"
+#            make_test: "yes"
+#            clang_analysis: "yes"
+#          - name: OS X
+#            os: macos-latest
+#            install_expat: "yes"
+#            config: "--enable-debug --disable-flto --with-ssl=/opt/homebrew/opt/openssl --with-libexpat=/opt/homebrew/opt/expat"
+#            make_test: "yes"
+#          - name: Clang on OS X
+#            os: macos-latest
+#            install_expat: "yes"
+#            config: "CC=clang --enable-debug --disable-flto --with-ssl=/opt/homebrew/opt/openssl --with-libexpat=/opt/homebrew/opt/expat --disable-static"
+#            make_test: "yes"
+#            clang_analysis: "yes"
+#          - name: ubsan (gcc undefined behaviour sanitizer)
+#            os: ubuntu-latest
+#            config: 'CFLAGS="-DNDEBUG -g2 -O3 -fsanitize=undefined -fno-sanitize-recover=all" --disable-flto --disable-static'
+#            make_test: "yes"
+#          - name: asan (gcc address sanitizer)
+#            os: ubuntu-latest
+#            config: 'CFLAGS="-DNDEBUG -g2 -O3 -fsanitize=address" --disable-flto --disable-static'
+#            make_test: "yes"
           - name: Apple iPhone on iOS, armv7
             os: macos-latest
             AUTOTOOLS_HOST: armv7-apple-ios
@@ -158,6 +76,15 @@ jobs:
             test_ios: "yes"
             config: "no"
             make: "no"
+#          - name: Apple Watch on iOS, armv7
+#            os: macos-latest
+#            AUTOTOOLS_HOST: armv7-apple-ios
+#            OPENSSL_HOST: ios-cross
+#            IOS_SDK: WatchOS
+#            IOS_CPU: armv7k
+#            test_ios: "yes"
+#            config: "no"
+#            make: "no"
           - name: iPhoneSimulator on OS X, i386
             os: macos-latest
             AUTOTOOLS_HOST: i386-apple-ios
@@ -185,11 +112,83 @@ jobs:
             test_ios: "yes"
             config: "no"
             make: "no"
+#          - name: WatchSimulator on OS X, i386
+#            os: macos-latest
+#            AUTOTOOLS_HOST: i386-apple-ios
+#            OPENSSL_HOST: iphoneos-cross
+#            IOS_SDK: WatchSimulator
+#            IOS_CPU: i386
+#            test_ios: "yes"
+#            config: "no"
+#            make: "no"
+#          - name: Android armv7a
+#            os: ubuntu-latest
+#            AUTOTOOLS_HOST: armv7a-linux-androidabi
+#            OPENSSL_HOST: android-arm
+#            ANDROID_CPU: armv7a
+#            ANDROID_API: 23
+#            test_android: "yes"
+#            config: "no"
+#            make: "no"
+#          - name: Android aarch64
+#            os: ubuntu-latest
+#            AUTOTOOLS_HOST: aarch64-linux-android
+#            OPENSSL_HOST: android-arm64
+#            ANDROID_CPU: aarch64
+#            ANDROID_API: 23
+#            test_android: "yes"
+#            config: "no"
+#            make: "no"
+#          - name: Android x86
+#            os: ubuntu-latest
+#            AUTOTOOLS_HOST: i686-linux-android
+#            OPENSSL_HOST: android-x86
+#            ANDROID_CPU: x86
+#            ANDROID_API: 23
+#            test_android: "yes"
+#            config: "no"
+#            make: "no"
+#          - name: Android x86_64
+#            os: ubuntu-latest
+#            AUTOTOOLS_HOST: x86_64-linux-android
+#            OPENSSL_HOST: android-x86_64
+#            ANDROID_CPU: x86_64
+#            ANDROID_API: 23
+#            test_android: "yes"
+#            config: "no"
+#            make: "no"
           - name: Windows
             os: windows-latest
             test_windows: "yes"
             config: "no"
             make: "no"
+#          - name: FreeBSD
+#            os: ubuntu-latest
+#            config: "no"
+#            make: "no"
+#            with_cross_platform_action: "yes"
+#            cross_platform_os: "freebsd"
+#            cross_platform_arch: "x86-64"
+#            cross_platform_version: "14.1"
+#            cross_platform_config: "--enable-debug --disable-flto --with-libevent --disable-static"
+#          - name: OpenBSD
+#            os: ubuntu-latest
+#            config: "no"
+#            make: "no"
+#            with_cross_platform_action: "yes"
+#            cross_platform_os: "openbsd"
+#            cross_platform_arch: "x86-64"
+#            cross_platform_version: "7.5"
+#            cross_platform_config: "--enable-debug --disable-flto --with-libevent --disable-static"
+#          - name: NetBSD
+#            os: ubuntu-latest
+#            config: "no"
+#            make: "no"
+#            with_cross_platform_action: "yes"
+#            cross_platform_os: "netbsd"
+#            cross_platform_arch: "x86-64"
+#            cross_platform_version: "10.0"
+#            cross_platform_config: "--enable-debug --disable-flto --with-libevent --disable-static"
  
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/analysis_ports.yml
+++ b/.github/workflows/analysis_ports.yml
@@ -15,180 +15,162 @@ jobs:
       fail-fast: false
       matrix:
         include:
-#          - name: GCC on Linux
-#            os: ubuntu-latest
-#            config: "--enable-debug --disable-flto"
-#            make_test: "yes"
-#          - name: Clang-analyzer
-#            os: ubuntu-latest
-#            config: "CC=clang --enable-debug --disable-flto --disable-static"
-#            make_test: "yes"
-#            clang_analysis: "yes"
-#          - name: libevent
-#            os: ubuntu-latest
-#            install_libevent: "yes"
-#            config: "CC=clang --enable-debug --disable-flto --with-libevent --disable-static"
-#            make_test: "yes"
-#            clang_analysis: "yes"
-#          - name: OS X
-#            os: macos-latest
-#            install_expat: "yes"
-#            config: "--enable-debug --disable-flto --with-ssl=/opt/homebrew/opt/openssl --with-libexpat=/opt/homebrew/opt/expat"
-#            make_test: "yes"
-#          - name: Clang on OS X
-#            os: macos-latest
-#            install_expat: "yes"
-#            config: "CC=clang --enable-debug --disable-flto --with-ssl=/opt/homebrew/opt/openssl --with-libexpat=/opt/homebrew/opt/expat --disable-static"
-#            make_test: "yes"
-#            clang_analysis: "yes"
-#          - name: ubsan (gcc undefined behaviour sanitizer)
-#            os: ubuntu-latest
-#            config: 'CFLAGS="-DNDEBUG -g2 -O3 -fsanitize=undefined -fno-sanitize-recover=all" --disable-flto --disable-static'
-#            make_test: "yes"
-#          - name: asan (gcc address sanitizer)
-#            os: ubuntu-latest
-#            config: 'CFLAGS="-DNDEBUG -g2 -O3 -fsanitize=address" --disable-flto --disable-static'
-#            make_test: "yes"
-          - name: Apple iPhone on iOS, armv7
+          - name: GCC on Linux
+            os: ubuntu-latest
+            config: "--enable-debug --disable-flto"
+            make_test: "yes"
+          - name: Clang-analyzer
+            os: ubuntu-latest
+            config: "CC=clang --enable-debug --disable-flto --disable-static"
+            make_test: "yes"
+            clang_analysis: "yes"
+          - name: libevent
+            os: ubuntu-latest
+            install_libevent: "yes"
+            config: "CC=clang --enable-debug --disable-flto --with-libevent --disable-static"
+            make_test: "yes"
+            clang_analysis: "yes"
+          - name: OS X
             os: macos-latest
-            AUTOTOOLS_HOST: armv7-apple-ios
-            OPENSSL_HOST: ios-cross
+            install_expat: "yes"
+            config: "--enable-debug --disable-flto --with-ssl=/opt/homebrew/opt/openssl --with-libexpat=/opt/homebrew/opt/expat"
+            make_test: "yes"
+          - name: Clang on OS X
+            os: macos-latest
+            install_expat: "yes"
+            config: "CC=clang --enable-debug --disable-flto --with-ssl=/opt/homebrew/opt/openssl --with-libexpat=/opt/homebrew/opt/expat --disable-static"
+            make_test: "yes"
+            clang_analysis: "yes"
+          - name: ubsan (gcc undefined behaviour sanitizer)
+            os: ubuntu-latest
+            config: 'CFLAGS="-DNDEBUG -g2 -O3 -fsanitize=undefined -fno-sanitize-recover=all" --disable-flto --disable-static'
+            make_test: "yes"
+          - name: asan (gcc address sanitizer)
+            os: ubuntu-latest
+            config: 'CFLAGS="-DNDEBUG -g2 -O3 -fsanitize=address" --disable-flto --disable-static'
+            make_test: "yes"
+          - name: Apple iPhone on iOS, arm64
+            os: macos-latest
+            AUTOTOOLS_HOST: aarch64-apple-ios
+            OPENSSL_HOST: ios64-cross
             IOS_SDK: iPhoneOS
-            IOS_CPU: armv7s
+            IOS_CPU: arm64
             test_ios: "yes"
             config: "no"
             make: "no"
-#          - name: Apple iPhone on iOS, arm64
-#            os: macos-latest
-#            AUTOTOOLS_HOST: aarch64-apple-ios
-#            OPENSSL_HOST: ios64-cross
-#            IOS_SDK: iPhoneOS
-#            IOS_CPU: arm64
-#            test_ios: "yes"
-#            config: "no"
-#            make: "no"
-#          - name: Apple TV on iOS, arm64
-#            os: macos-latest
-#            AUTOTOOLS_HOST: aarch64-apple-ios
-#            OPENSSL_HOST: ios64-cross
-#            IOS_SDK: AppleTVOS
-#            IOS_CPU: arm64
-#            test_ios: "yes"
-#            config: "no"
-#            make: "no"
-#          - name: Apple Watch on iOS, armv7
-#            os: macos-latest
-#            AUTOTOOLS_HOST: armv7-apple-ios
-#            OPENSSL_HOST: ios-cross
-#            IOS_SDK: WatchOS
-#            IOS_CPU: armv7k
-#            test_ios: "yes"
-#            config: "no"
-#            make: "no"
-          - name: iPhoneSimulator on OS X, i386
+          - name: Apple TV on iOS, arm64
+            os: macos-latest
+            AUTOTOOLS_HOST: aarch64-apple-ios
+            OPENSSL_HOST: ios64-cross
+            IOS_SDK: AppleTVOS
+            IOS_CPU: arm64
+            test_ios: "yes"
+            config: "no"
+            make: "no"
+          - name: Apple Watch on iOS, armv7
+            os: macos-latest
+            AUTOTOOLS_HOST: armv7-apple-ios
+            OPENSSL_HOST: ios-cross
+            IOS_SDK: WatchOS
+            IOS_CPU: armv7k
+            test_ios: "yes"
+            config: "no"
+            make: "no"
+          - name: iPhoneSimulator on OS X, x86_64
+            os: macos-latest
+            AUTOTOOLS_HOST: x86_64-apple-ios
+            OPENSSL_HOST: iphoneos-cross
+            IOS_SDK: iPhoneSimulator
+            IOS_CPU: x86_64
+            test_ios: "yes"
+            config: "no"
+            make: "no"
+          - name: AppleTVSimulator on OS X, x86_64
+            os: macos-latest
+            AUTOTOOLS_HOST: x86_64-apple-ios
+            OPENSSL_HOST: iphoneos-cross
+            IOS_SDK: AppleTVSimulator
+            IOS_CPU: x86_64
+            test_ios: "yes"
+            config: "no"
+            make: "no"
+          - name: WatchSimulator on OS X, i386
             os: macos-latest
             AUTOTOOLS_HOST: i386-apple-ios
             OPENSSL_HOST: iphoneos-cross
-            IOS_SDK: iPhoneSimulator
+            IOS_SDK: WatchSimulator
             IOS_CPU: i386
             test_ios: "yes"
             config: "no"
             make: "no"
-#          - name: iPhoneSimulator on OS X, x86_64
-#            os: macos-latest
-#            AUTOTOOLS_HOST: x86_64-apple-ios
-#            OPENSSL_HOST: iphoneos-cross
-#            IOS_SDK: iPhoneSimulator
-#            IOS_CPU: x86_64
-#            test_ios: "yes"
-#            config: "no"
-#            make: "no"
-#          - name: AppleTVSimulator on OS X, x86_64
-#            os: macos-latest
-#            AUTOTOOLS_HOST: x86_64-apple-ios
-#            OPENSSL_HOST: iphoneos-cross
-#            IOS_SDK: AppleTVSimulator
-#            IOS_CPU: x86_64
-#            test_ios: "yes"
-#            config: "no"
-#            make: "no"
-#          - name: WatchSimulator on OS X, i386
-#            os: macos-latest
-#            AUTOTOOLS_HOST: i386-apple-ios
-#            OPENSSL_HOST: iphoneos-cross
-#            IOS_SDK: WatchSimulator
-#            IOS_CPU: i386
-#            test_ios: "yes"
-#            config: "no"
-#            make: "no"
-#          - name: Android armv7a
-#            os: ubuntu-latest
-#            AUTOTOOLS_HOST: armv7a-linux-androidabi
-#            OPENSSL_HOST: android-arm
-#            ANDROID_CPU: armv7a
-#            ANDROID_API: 23
-#            test_android: "yes"
-#            config: "no"
-#            make: "no"
-#          - name: Android aarch64
-#            os: ubuntu-latest
-#            AUTOTOOLS_HOST: aarch64-linux-android
-#            OPENSSL_HOST: android-arm64
-#            ANDROID_CPU: aarch64
-#            ANDROID_API: 23
-#            test_android: "yes"
-#            config: "no"
-#            make: "no"
-#          - name: Android x86
-#            os: ubuntu-latest
-#            AUTOTOOLS_HOST: i686-linux-android
-#            OPENSSL_HOST: android-x86
-#            ANDROID_CPU: x86
-#            ANDROID_API: 23
-#            test_android: "yes"
-#            config: "no"
-#            make: "no"
-#          - name: Android x86_64
-#            os: ubuntu-latest
-#            AUTOTOOLS_HOST: x86_64-linux-android
-#            OPENSSL_HOST: android-x86_64
-#            ANDROID_CPU: x86_64
-#            ANDROID_API: 23
-#            test_android: "yes"
-#            config: "no"
-#            make: "no"
+          - name: Android armv7a
+            os: ubuntu-latest
+            AUTOTOOLS_HOST: armv7a-linux-androidabi
+            OPENSSL_HOST: android-arm
+            ANDROID_CPU: armv7a
+            ANDROID_API: 23
+            test_android: "yes"
+            config: "no"
+            make: "no"
+          - name: Android aarch64
+            os: ubuntu-latest
+            AUTOTOOLS_HOST: aarch64-linux-android
+            OPENSSL_HOST: android-arm64
+            ANDROID_CPU: aarch64
+            ANDROID_API: 23
+            test_android: "yes"
+            config: "no"
+            make: "no"
+          - name: Android x86
+            os: ubuntu-latest
+            AUTOTOOLS_HOST: i686-linux-android
+            OPENSSL_HOST: android-x86
+            ANDROID_CPU: x86
+            ANDROID_API: 23
+            test_android: "yes"
+            config: "no"
+            make: "no"
+          - name: Android x86_64
+            os: ubuntu-latest
+            AUTOTOOLS_HOST: x86_64-linux-android
+            OPENSSL_HOST: android-x86_64
+            ANDROID_CPU: x86_64
+            ANDROID_API: 23
+            test_android: "yes"
+            config: "no"
+            make: "no"
           - name: Windows
             os: windows-latest
             test_windows: "yes"
             config: "no"
             make: "no"
-#          - name: FreeBSD
-#            os: ubuntu-latest
-#            config: "no"
-#            make: "no"
-#            with_cross_platform_action: "yes"
-#            cross_platform_os: "freebsd"
-#            cross_platform_arch: "x86-64"
-#            cross_platform_version: "14.1"
-#            cross_platform_config: "--enable-debug --disable-flto --with-libevent --disable-static"
-#          - name: OpenBSD
-#            os: ubuntu-latest
-#            config: "no"
-#            make: "no"
-#            with_cross_platform_action: "yes"
-#            cross_platform_os: "openbsd"
-#            cross_platform_arch: "x86-64"
-#            cross_platform_version: "7.5"
-#            cross_platform_config: "--enable-debug --disable-flto --with-libevent --disable-static"
-#          - name: NetBSD
-#            os: ubuntu-latest
-#            config: "no"
-#            make: "no"
-#            with_cross_platform_action: "yes"
-#            cross_platform_os: "netbsd"
-#            cross_platform_arch: "x86-64"
-#            cross_platform_version: "10.0"
-#            cross_platform_config: "--enable-debug --disable-flto --with-libevent --disable-static"
+          - name: FreeBSD
+            os: ubuntu-latest
+            config: "no"
+            make: "no"
+            with_cross_platform_action: "yes"
+            cross_platform_os: "freebsd"
+            cross_platform_arch: "x86-64"
+            cross_platform_version: "14.1"
+            cross_platform_config: "--enable-debug --disable-flto --with-libevent --disable-static"
+          - name: OpenBSD
+            os: ubuntu-latest
+            config: "no"
+            make: "no"
+            with_cross_platform_action: "yes"
+            cross_platform_os: "openbsd"
+            cross_platform_arch: "x86-64"
+            cross_platform_version: "7.5"
+            cross_platform_config: "--enable-debug --disable-flto --with-libevent --disable-static"
+          - name: NetBSD
+            os: ubuntu-latest
+            config: "no"
+            make: "no"
+            with_cross_platform_action: "yes"
+            cross_platform_os: "netbsd"
+            cross_platform_arch: "x86-64"
+            cross_platform_version: "10.0"
+            cross_platform_config: "--enable-debug --disable-flto --with-libevent --disable-static"
  
     steps:
       - uses: actions/checkout@v4
@@ -270,8 +252,6 @@ jobs:
           cd unbound
           echo "./configure --enable-debug --enable-static-exe --disable-flto \"--with-ssl=$prepath/openssl\" --with-libexpat=\"$prepath/expat\" --disable-shared"
           ./configure --enable-debug --enable-static-exe --disable-flto "--with-ssl=$prepath/openssl" --with-libexpat="$prepath/expat" --disable-shared
-          # for the check results.
-          cat config.log
           make
           # specific test output
           #make testbound.exe; ./testbound.exe -s

--- a/configure
+++ b/configure
@@ -22804,10 +22804,12 @@ then :
    LIBS="$LIBS -lz"
 fi
 
-		if echo "$LIBS" | grep -e "libssp.a" -e "lssp" >/dev/null; then
-			:
-		else
-			LIBS="$LIBS -l:libssp.a"
+		if echo "$host" | $GREP -i -e linux >/dev/null; then
+			if echo "$LIBS" | grep -e "libssp.a" -e "lssp" >/dev/null; then
+				:
+			else
+				LIBS="$LIBS -l:libssp.a"
+			fi
 		fi
 	fi
 fi
@@ -22868,10 +22870,12 @@ then :
    LIBS="$LIBS -lz"
 fi
 
-		if echo "$LIBS" | grep -e "libssp.a" -e "lssp" >/dev/null; then
-			:
-		else
-			LIBS="$LIBS -l:libssp.a"
+		if echo "$host" | $GREP -i -e linux >/dev/null; then
+			if echo "$LIBS" | grep -e "libssp.a" -e "lssp" >/dev/null; then
+				:
+			else
+				LIBS="$LIBS -l:libssp.a"
+			fi
 		fi
 	fi
 fi

--- a/configure.ac
+++ b/configure.ac
@@ -1673,10 +1673,12 @@ if test x_$enable_static_exe = x_yes; then
 			LIBS="$LIBS -lgdi32"
 		fi
 		AC_CHECK_LIB([z], [compress], [ LIBS="$LIBS -lz" ])
-		if echo "$LIBS" | grep -e "libssp.a" -e "lssp" >/dev/null; then
-			:
-		else
-			LIBS="$LIBS -l:libssp.a"
+		if echo "$host" | $GREP -i -e linux >/dev/null; then
+			if echo "$LIBS" | grep -e "libssp.a" -e "lssp" >/dev/null; then
+				:
+			else
+				LIBS="$LIBS -l:libssp.a"
+			fi
 		fi
 	fi
 fi
@@ -1694,10 +1696,12 @@ if test x_$enable_fully_static = x_yes; then
 			LIBS="$LIBS -lgdi32"
 		fi
 		AC_CHECK_LIB([z], [compress], [ LIBS="$LIBS -lz" ])
-		if echo "$LIBS" | grep -e "libssp.a" -e "lssp" >/dev/null; then
-			:
-		else
-			LIBS="$LIBS -l:libssp.a"
+		if echo "$host" | $GREP -i -e linux >/dev/null; then
+			if echo "$LIBS" | grep -e "libssp.a" -e "lssp" >/dev/null; then
+				:
+			else
+				LIBS="$LIBS -l:libssp.a"
+			fi
 		fi
 	fi
 fi

--- a/contrib/ios/install_openssl.sh
+++ b/contrib/ios/install_openssl.sh
@@ -33,7 +33,7 @@ if ! patch -u -p0 < ../contrib/ios/openssl.patch; then
 fi
 
 echo "Configuring OpenSSL"
-if ! ./Configure "$OPENSSL_HOST" -DNO_FORK no-comp no-shared no-asm no-hw no-engine no-tests no-unit-test \
+if ! ./Configure "$OPENSSL_HOST" -DNO_FORK no-comp no-asm no-hw no-engine no-tests no-unit-test \
        --prefix="$IOS_PREFIX" --openssldir="$IOS_PREFIX"; then
     echo "Failed to configure OpenSSL"
     exit 1

--- a/contrib/ios/install_openssl.sh
+++ b/contrib/ios/install_openssl.sh
@@ -33,7 +33,7 @@ if ! patch -u -p0 < ../contrib/ios/openssl.patch; then
 fi
 
 echo "Configuring OpenSSL"
-if ! ./Configure "$OPENSSL_HOST" -DNO_FORK no-comp no-asm no-hw no-engine no-tests no-unit-test \
+if ! ./Configure "$OPENSSL_HOST" -DNO_FORK no-comp no-shared no-asm no-hw no-engine no-tests no-unit-test \
        --prefix="$IOS_PREFIX" --openssldir="$IOS_PREFIX"; then
     echo "Failed to configure OpenSSL"
     exit 1

--- a/doc/Changelog
+++ b/doc/Changelog
@@ -3,7 +3,10 @@
 	- Fix to reply with SERVFAIL when the wait-limit is exceeded.
 	- Add extended dns error code for invalid query type to definition
 	  list.
-	- Fix to update openssl version in ios ci.
+	- Remove iPhone armv7s, and iPhoneSimulator i386 from ios ci.
+	  The lib system does not provide symbols for it on the new macos
+	  runner.
+	- Fix to exclude libssp for windows compiles.
 
 10 October 2025: Wouter
 	- Fix #1358 Enabling FIPS in OpenSSL causes unit test to fail.


### PR DESCRIPTION
Fix the analysis and ports workflow.

- Remove iPhone armv7s, and iPhoneSimulator i386 from ios ci.
  The lib system does not provide symbols for it on the new macos
  runner.
- Fix to exclude libssp for windows compiles.
