### PR TITLE
Use $action instead of $function in python SWIG interface

### DIFF
--- a/libunbound/python/libunbound.i
+++ b/libunbound/python/libunbound.i
@@ -853,7 +853,7 @@ Result: ['74.125.43.147', '74.125.43.99', '74.125.43.103', '74.125.43.104']
 %{ 
   //printf("resolve_start(%lX)\n",(long unsigned int)arg1);
   Py_BEGIN_ALLOW_THREADS 
-  $function 
+  $action 
   Py_END_ALLOW_THREADS 
   //printf("resolve_stop()\n");
 %} 


### PR DESCRIPTION
$function is not supported since SWIG 4.4.0.

Fedora Bug: https://bugzilla.redhat.com/show_bug.cgi?id=2405293