### PR TITLE
Do not initialize quic_table unless it is enabled

### DIFF
--- a/daemon/daemon.c
+++ b/daemon/daemon.c
@@ -558,9 +558,11 @@ daemon_create_workers(struct daemon* daemon)
 	verbose(VERB_ALGO, "total of %d outgoing ports available", numport);
 
 #ifdef HAVE_NGTCP2
-	daemon->doq_table = doq_table_create(daemon->cfg, daemon->rand);
-	if(!daemon->doq_table)
-		fatal_exit("could not create doq_table: out of memory");
+	if (cfg_has_quic(daemon->cfg)) {
+		daemon->doq_table = doq_table_create(daemon->cfg, daemon->rand);
+		if(!daemon->doq_table)
+			fatal_exit("could not create doq_table: out of memory");
+	}
 #endif
 	
 	daemon->num = (daemon->cfg->num_threads?daemon->cfg->num_threads:1);
@@ -917,8 +919,10 @@ daemon_cleanup(struct daemon* daemon)
 	daemon->dnscenv = NULL;
 #endif
 #ifdef HAVE_NGTCP2
-	doq_table_delete(daemon->doq_table);
-	daemon->doq_table = NULL;
+	if (daemon->doq_table) {
+		doq_table_delete(daemon->doq_table);
+		daemon->doq_table = NULL;
+	}
 #endif
 	daemon->cfg = NULL;
 }

--- a/services/listen_dnsport.c
+++ b/services/listen_dnsport.c
@@ -3286,7 +3286,7 @@ doq_table_create(struct config_file* cfg, struct ub_randstate* rnd)
 	/* Initialize the ossl crypto, it is harmless to call twice,
 	 * and this is before use of doq connections. */
 	if(ngtcp2_crypto_ossl_init() != 0) {
-		log_err("ngtcp2_crypto_oss_init failed");
+		log_err("ngtcp2_crypto_ossl_init failed");
 		free(table);
 		return NULL;
 	}

--- a/services/listen_dnsport.c
+++ b/services/listen_dnsport.c
@@ -1564,7 +1564,7 @@ listen_create(struct comm_base* base, struct listen_port* ports,
 			cp = comm_point_create_udp(base, ports->fd,
 				front->udp_buff, ports->pp2_enabled, cb,
 				cb_arg, ports->socket);
-		} else if(ports->ftype == listen_type_doq) {
+		} else if(ports->ftype == listen_type_doq && doq_table) {
 #ifndef HAVE_NGTCP2
 			log_warn("Unbound is not compiled with "
 				"ngtcp2. This is required to use DNS "
@@ -3275,7 +3275,11 @@ nghttp2_session_callbacks* http2_req_callbacks_create(void)
 struct doq_table*
 doq_table_create(struct config_file* cfg, struct ub_randstate* rnd)
 {
-	struct doq_table* table = calloc(1, sizeof(*table));
+	struct doq_table* table;
+
+	if (!cfg->quic_port)
+		return NULL;
+	table = calloc(1, sizeof(*table));
 	if(!table)
 		return NULL;
 #ifdef USE_NGTCP2_CRYPTO_OSSL
@@ -3354,7 +3358,7 @@ conn_tree_del(rbnode_type* node, void* arg)
 {
 	struct doq_table* table = (struct doq_table*)arg;
 	struct doq_conn* conn;
-	if(!node)
+	if(!node || !table)
 		return;
 	conn = (struct doq_conn*)node->key;
 	if(conn->timer.timer_in_list) {
@@ -3413,6 +3417,7 @@ doq_timer_find_time(struct doq_table* table, struct timeval* tv)
 {
 	struct doq_timer key;
 	struct rbnode_type* node;
+	log_assert(table != NULL);
 	memset(&key, 0, sizeof(key));
 	key.time.tv_sec = tv->tv_sec;
 	key.time.tv_usec = tv->tv_usec;
@@ -4922,6 +4927,7 @@ doq_conid_find(struct doq_table* table, const uint8_t* data, size_t datalen)
 	key.node.key = &key;
 	key.cid = (void*)data;
 	key.cidlen = datalen;
+	log_assert(table != NULL);
 	node = rbtree_search(table->conid_tree, &key);
 	if(node)
 		return (struct doq_conid*)node->key;
@@ -5662,6 +5668,8 @@ doq_table_quic_size_available(struct doq_table* table,
 	struct config_file* cfg, size_t mem)
 {
 	size_t cur;
+	if (!table)
+		return 0;
 	lock_basic_lock(&table->size_lock);
 	cur = table->current_size;
 	lock_basic_unlock(&table->size_lock);

--- a/testcode/doqclient.c
+++ b/testcode/doqclient.c
@@ -2255,7 +2255,7 @@ create_doq_client_data(const char* svr, int port, struct ub_event_base* base,
 	/* Initialize the ossl crypto, it is harmless to call twice,
 	 * and this is before use of doq connections. */
 	if(ngtcp2_crypto_ossl_init() != 0)
-		fatal_exit("ngtcp2_crypto_oss_init failed");
+		fatal_exit("ngtcp2_crypto_ossl_init failed");
 #elif defined(HAVE_NGTCP2_CRYPTO_QUICTLS_INIT)
 	if(ngtcp2_crypto_quictls_init() != 0)
 		fatal_exit("ngtcp2_crypto_quictls_init failed");

--- a/util/configparser.y
+++ b/util/configparser.y
@@ -1235,14 +1235,17 @@ server_http_notls_downstream: VAR_HTTP_NOTLS_DOWNSTREAM STRING_ARG
 server_quic_port: VAR_QUIC_PORT STRING_ARG
 	{
 		OUTYY(("P(server_quic_port:%s)\n", $2));
-#ifndef HAVE_NGTCP2
-		log_warn("%s:%d: Unbound is not compiled with "
-			"ngtcp2. This is required to use DNS "
-			"over QUIC.", cfg_parser->filename, cfg_parser->line);
-#endif
-		if(atoi($2) == 0)
+		if(atoi($2) == 0 && strcmp($2,"0")!=0)
 			yyerror("port number expected");
-		else cfg_parser->cfg->quic_port = atoi($2);
+		else {
+			cfg_parser->cfg->quic_port = atoi($2);
+#ifndef HAVE_NGTCP2
+			if (cfg_parser->cfg->quic_port != 0)
+				log_warn("%s:%d: Unbound is not compiled with "
+					"ngtcp2. This is required to use DNS "
+					"over QUIC.", cfg_parser->filename, cfg_parser->line);
+#endif
+		}
 		free($2);
 	};
 server_quic_size: VAR_QUIC_SIZE STRING_ARG

--- a/util/netevent.c
+++ b/util/netevent.c
@@ -2723,6 +2723,7 @@ doq_server_socket_create(struct doq_table* table, struct ub_randstate* rnd,
 {
 	size_t doq_buffer_size = 4096; /* bytes buffer size, for one packet. */
 	struct doq_server_socket* doq_socket;
+	log_assert(doq_table != NULL);
 	doq_socket = calloc(1, sizeof(*doq_socket));
 	if(!doq_socket) {
 		return NULL;
@@ -2804,6 +2805,7 @@ doq_lookup_repinfo(struct doq_table* table, struct comm_reply* repinfo)
 {
 	struct doq_conn* conn;
 	struct doq_conn_key key;
+	log_assert(table != NULL);
 	doq_conn_key_from_repinfo(&key, repinfo);
 	lock_rw_rdlock(&table->lock);
 	conn = doq_conn_find(table, &key.paddr.addr,
@@ -5880,6 +5882,7 @@ comm_point_create_doq(struct comm_base *base, int fd, sldns_buffer* buffer,
 	struct config_file* cfg)
 {
 #ifdef HAVE_NGTCP2
+	log_assert(table != NULL);
 	struct comm_point* c = (struct comm_point*)calloc(1,
 		sizeof(struct comm_point));
 	short evbits;


### PR DESCRIPTION
Fedora in FIPS mode might fail to initialize ngtcp2 library, because some ciphers desired are not available.

Make it possible to skip initialization by setting explicitly quic_port to 0. Unless we have some listeners for port 853 configured, skip its initialization as well.

Related: https://pagure.io/freeipa/issue/9877