### PR TITLE
QNX Porting support for unbound branch-1.24.1

### DIFF
--- a/compat/arc4random.c
+++ b/compat/arc4random.c
@@ -38,6 +38,9 @@
 #ifndef UB_ON_WINDOWS
 #include <sys/mman.h>
 #endif
+#ifdef __QNX__
+#include "util/log.h"
+#endif /* __QNX__ */
 
 #define KEYSTREAM_ONLY
 #include "chacha_private.h"
@@ -187,7 +190,11 @@ _rs_stir(void)
 		if(errno != ENOSYS ||
 			fallback_getentropy_urandom(rnd, sizeof rnd) == -1) {
 #ifdef SIGKILL
+#ifndef __QNX__
 			raise(SIGKILL);
+#else /* !__QNX__ */
+			fatal_exit("failed to getentropy");
+#endif /* __QNX__ */
 #else
 			exit(9); /* windows */
 #endif

--- a/services/outside_network.h
+++ b/services/outside_network.h
@@ -48,6 +48,10 @@
 #include "util/regional.h"
 #include "util/netevent.h"
 #include "dnstap/dnstap_config.h"
+#ifdef __QNX__
+/* For struct timeval */
+#include <sys/time.h>
+#endif /* __QNX__ */
 struct pending;
 struct pending_timeout;
 struct ub_randstate;

--- a/testcode/replay.h
+++ b/testcode/replay.h
@@ -142,6 +142,10 @@
 #include "util/netevent.h"
 #include "testcode/testpkts.h"
 #include "util/rbtree.h"
+#ifdef __QNX__
+/* For struct timeval */
+#include <sys/time.h>
+#endif /* __QNX__ */
 struct replay_answer;
 struct replay_moment;
 struct replay_range;

--- a/testcode/unitldns.c
+++ b/testcode/unitldns.c
@@ -207,7 +207,11 @@ rr_test_file(const char* input, const char* check)
 #define xstr(s) str(s)
 #define str(s) #s
 
+#ifndef __QNX__
 #define SRCDIRSTR xstr(SRCDIR)
+#else /* !__QNX__ */
+#define SRCDIRSTR "."
+#endif /* __QNX__ */
 
 /** read rrs to and from string, to and from wireformat */
 static void

--- a/testcode/unitmsgparse.c
+++ b/testcode/unitmsgparse.c
@@ -498,7 +498,11 @@ testfromdrillfile(sldns_buffer* pkt, struct alloc_cache* alloc,
 #define xstr(s) str(s)
 #define str(s) #s
 
+#ifndef __QNX__
 #define SRCDIRSTR xstr(SRCDIR)
+#else /* !__QNX__ */
+#define SRCDIRSTR "."
+#endif /* __QNX__ */
 
 void msgparse_test(void)
 {

--- a/testcode/unitverify.c
+++ b/testcode/unitverify.c
@@ -513,8 +513,11 @@ nsec3_hash_test(const char* fname)
 #define xstr(s) str(s)
 #define str(s) #s
 
+#ifndef __QNX__
 #define SRCDIRSTR xstr(SRCDIR)
-
+#else /* !__QNX__ */
+#define SRCDIRSTR "."
+#endif /* __QNX__ */
 #if defined(HAVE_SSL) && defined(USE_SHA1)
 /* Detect if openssl is configured to disable RSASHA1 signatures,
  * with the rh-allow-sha1-signatures disabled. */

--- a/testcode/unitzonemd.c
+++ b/testcode/unitzonemd.c
@@ -50,7 +50,11 @@
 
 #define xstr(s) str(s)
 #define str(s) #s
+#ifndef __QNX__
 #define SRCDIRSTR xstr(SRCDIR)
+#else /* !__QNX__ */
+#define SRCDIRSTR "."
+#endif /* __QNX__ */
 
 /** Add zone from file for testing */
 struct auth_zone* authtest_addzone(struct auth_zones* az, const char* name,

--- a/util/data/msgreply.h
+++ b/util/data/msgreply.h
@@ -44,6 +44,10 @@
 #include "util/storage/lruhash.h"
 #include "util/data/packed_rrset.h"
 #include "sldns/rrdef.h"
+#ifdef __QNX__
+/* For struct timeval */
+#include <sys/time.h>
+#endif /* __QNX__ */
 struct sldns_buffer;
 struct comm_reply;
 struct alloc_cache;

--- a/util/timehist.h
+++ b/util/timehist.h
@@ -42,6 +42,10 @@
 #ifndef UTIL_TIMEHIST_H
 #define UTIL_TIMEHIST_H
 
+#ifdef __QNX__
+/* For struct timeval */
+#include <sys/time.h>
+#endif /* __QNX__ */
 /** Number of buckets in a histogram */
 #define NUM_BUCKETS_HIST 40
 


### PR DESCRIPTION
This PR adds support for building and running unbound on QNX.

The changes are focused on enabling successful compilation and execution on QNX
while preserving existing behavior on Linux and other supported platforms.

Key changes
Add QNX-specific handling in few places and updated relevant QNX headers, Defines, system_apis.
Add QNX-specific handling for validating paths to ".", since we test on target.
Update build system logic to recognize QNX correctly.

The build completed successfully, and AMQP-CPP examples executed correctly without runtime issues.
Testing was performed on a QNX image running on Raspberry Pi.

Build and test instructions for QNX: https://github.com/qnx-ports/build-files/tree/main/ports/unbound