### PR TITLE
fix: cross typos, see detail below

### DIFF
--- a/.codespellrc
+++ b/.codespellrc
@@ -1,0 +1,4 @@
+[codespell]
+skip = ./.git,./autom4te.cache,./node_modules,./po,./testdata,./dnscrypt/testdata,./pythonmod/examples/dict_data.txt,./configure,./config.guess,./config.sub,./ltmain.sh,./aclocal.m4,./contrib/fastrpz.patch
+ignore-words-list = GOST,gost,EDE,ede,aNULL,siz,servent,SectionIn,tolen,clen,ans,shs,nd,te,crypted,hel
+ignore-regex = .*(ratatui|Affinitized|affinitized|ede|fo|onl).*

--- a/Makefile.in
+++ b/Makefile.in
@@ -668,7 +668,7 @@ uninstall:	$(PYTHONMOD_UNINSTALL) $(PYUNBOUND_UNINSTALL) $(UNBOUND_EVENT_UNINSTA
 
 iana_update:
 	curl -o port-numbers.tmp https://www.iana.org/assignments/service-names-port-numbers/service-names-port-numbers.xml --compressed
-	if file port-numbers.tmp | grep 'gzip' >/dev/null; then zcat port-numbers.tmp; else cat port-numbers.tmp; fi | awk '/<record>/ {p=0;} /<protocol>udp/ {p=1;} /<protocol>[^u]/ {p=0;} /Decomissioned|Decommissioned|Removed|De-registered|unassigned|Unassigned|Reserved/ {u=1;} /<number>/ { if(u==1) {u=0;} else { if(p==1) { match($$0,/[0-9]+/); print substr($$0, RSTART, RLENGTH) ","}}}' | sort -nu > util/iana_ports.inc
+	if file port-numbers.tmp | grep 'gzip' >/dev/null; then zcat port-numbers.tmp; else cat port-numbers.tmp; fi | awk '/<record>/ {p=0;} /<protocol>udp/ {p=1;} /<protocol>[^u]/ {p=0;} /Decomm?issioned|Removed|De-registered|unassigned|Unassigned|Reserved/ {u=1;} /<number>/ { if(u==1) {u=0;} else { if(p==1) { match($$0,/[0-9]+/); print substr($$0, RSTART, RLENGTH) ","}}}' | sort -nu > util/iana_ports.inc
 	rm -f port-numbers.tmp
 
 # dependency generation
@@ -862,7 +862,7 @@ listen_dnsport.lo listen_dnsport.o: $(srcdir)/services/listen_dnsport.c config.h
  $(srcdir)/services/localzone.h $(srcdir)/services/authzone.h $(srcdir)/daemon/stats.h $(srcdir)/util/timehist.h \
  $(srcdir)/libunbound/unbound.h $(srcdir)/respip/respip.h $(srcdir)/util/fptr_wlist.h $(srcdir)/util/tube.h \
  $(srcdir)/util/timeval_func.h \
- 
+
 localzone.lo localzone.o: $(srcdir)/services/localzone.c config.h $(srcdir)/services/localzone.h \
  $(srcdir)/util/rbtree.h $(srcdir)/util/locks.h $(srcdir)/util/log.h $(srcdir)/util/storage/dnstree.h \
  $(srcdir)/util/module.h $(srcdir)/util/storage/lruhash.h $(srcdir)/util/data/msgreply.h \
@@ -920,13 +920,13 @@ rpz.lo rpz.o: $(srcdir)/services/rpz.c config.h $(srcdir)/services/rpz.h $(srcdi
  $(srcdir)/util/net_help.h $(srcdir)/util/random.h $(srcdir)/util/regional.h $(srcdir)/util/data/msgencode.h \
  $(srcdir)/services/cache/dns.h $(srcdir)/iterator/iterator.h $(srcdir)/services/outbound_list.h \
  $(srcdir)/iterator/iter_delegpt.h $(srcdir)/daemon/worker.h $(srcdir)/libunbound/worker.h $(srcdir)/util/alloc.h \
- $(srcdir)/dnstap/dnstap.h 
+ $(srcdir)/dnstap/dnstap.h
 rfc_1982.lo rfc_1982.o: $(srcdir)/util/rfc_1982.c config.h $(srcdir)/util/rfc_1982.h
 outbound_list.lo outbound_list.o: $(srcdir)/services/outbound_list.c config.h \
  $(srcdir)/services/outbound_list.h $(srcdir)/services/outside_network.h $(srcdir)/util/alloc.h \
  $(srcdir)/util/locks.h $(srcdir)/util/log.h $(srcdir)/util/rbtree.h $(srcdir)/util/regional.h $(srcdir)/util/netevent.h \
  $(srcdir)/dnscrypt/dnscrypt.h  $(srcdir)/dnscrypt/cert.h \
- 
+
 outside_network.lo outside_network.o: $(srcdir)/services/outside_network.c config.h \
  $(srcdir)/services/outside_network.h $(srcdir)/util/alloc.h $(srcdir)/util/locks.h $(srcdir)/util/log.h \
  $(srcdir)/util/rbtree.h $(srcdir)/util/regional.h $(srcdir)/util/netevent.h $(srcdir)/dnscrypt/dnscrypt.h \
@@ -942,7 +942,7 @@ outside_network.lo outside_network.o: $(srcdir)/services/outside_network.c confi
  $(srcdir)/services/localzone.h $(srcdir)/sldns/sbuffer.h $(srcdir)/util/config_file.h \
  $(srcdir)/services/authzone.h $(srcdir)/daemon/stats.h $(srcdir)/util/timehist.h $(srcdir)/libunbound/unbound.h \
  $(srcdir)/respip/respip.h $(srcdir)/util/edns.h $(srcdir)/dnstap/dnstap.h \
- 
+
 alloc.lo alloc.o: $(srcdir)/util/alloc.c config.h $(srcdir)/util/alloc.h $(srcdir)/util/locks.h $(srcdir)/util/log.h \
  $(srcdir)/util/regional.h $(srcdir)/util/data/packed_rrset.h $(srcdir)/util/storage/lruhash.h \
  $(srcdir)/util/fptr_wlist.h $(srcdir)/util/netevent.h $(srcdir)/dnscrypt/dnscrypt.h \
@@ -1044,13 +1044,13 @@ netevent.lo netevent.o: $(srcdir)/util/netevent.c config.h $(srcdir)/util/neteve
  $(srcdir)/libunbound/unbound.h $(srcdir)/respip/respip.h $(srcdir)/util/proxy_protocol.h \
  $(srcdir)/util/timeval_func.h $(srcdir)/sldns/str2wire.h $(srcdir)/dnstap/dnstap.h \
   $(srcdir)/services/listen_dnsport.h $(srcdir)/daemon/acl_list.h \
- 
+
 net_help.lo net_help.o: $(srcdir)/util/net_help.c config.h $(srcdir)/util/net_help.h $(srcdir)/util/log.h \
  $(srcdir)/util/random.h $(srcdir)/util/data/dname.h $(srcdir)/util/storage/lruhash.h $(srcdir)/util/locks.h \
  $(srcdir)/util/module.h $(srcdir)/util/data/msgreply.h $(srcdir)/util/data/packed_rrset.h \
  $(srcdir)/sldns/rrdef.h $(srcdir)/util/data/msgparse.h $(srcdir)/sldns/pkthdr.h $(srcdir)/util/regional.h \
  $(srcdir)/util/config_file.h $(srcdir)/sldns/parseutil.h $(srcdir)/sldns/wire2str.h $(srcdir)/sldns/str2wire.h \
- 
+
 random.lo random.o: $(srcdir)/util/random.c config.h $(srcdir)/util/random.h $(srcdir)/util/log.h
 rbtree.lo rbtree.o: $(srcdir)/util/rbtree.c config.h $(srcdir)/util/log.h $(srcdir)/util/fptr_wlist.h \
  $(srcdir)/util/netevent.h $(srcdir)/dnscrypt/dnscrypt.h  \
@@ -1140,7 +1140,7 @@ autotrust.lo autotrust.o: $(srcdir)/validator/autotrust.c config.h $(srcdir)/val
  $(srcdir)/services/authzone.h $(srcdir)/daemon/stats.h $(srcdir)/util/timehist.h $(srcdir)/libunbound/unbound.h \
  $(srcdir)/respip/respip.h $(srcdir)/services/cache/rrset.h $(srcdir)/util/storage/slabhash.h \
  $(srcdir)/validator/val_kcache.h $(srcdir)/sldns/wire2str.h $(srcdir)/sldns/str2wire.h $(srcdir)/sldns/keyraw.h \
- 
+
 val_anchor.lo val_anchor.o: $(srcdir)/validator/val_anchor.c config.h $(srcdir)/validator/val_anchor.h \
  $(srcdir)/util/rbtree.h $(srcdir)/util/locks.h $(srcdir)/util/log.h $(srcdir)/validator/val_sigcrypt.h \
  $(srcdir)/util/data/packed_rrset.h $(srcdir)/util/storage/lruhash.h $(srcdir)/sldns/pkthdr.h \
@@ -1171,7 +1171,7 @@ val_kentry.lo val_kentry.o: $(srcdir)/validator/val_kentry.c config.h $(srcdir)/
  $(srcdir)/util/storage/lruhash.h $(srcdir)/util/locks.h $(srcdir)/util/log.h $(srcdir)/sldns/rrdef.h \
  $(srcdir)/util/data/packed_rrset.h $(srcdir)/util/data/dname.h $(srcdir)/util/storage/lookup3.h \
  $(srcdir)/util/regional.h $(srcdir)/util/net_help.h $(srcdir)/util/random.h $(srcdir)/sldns/keyraw.h \
- 
+
 val_neg.lo val_neg.o: $(srcdir)/validator/val_neg.c config.h \
  $(srcdir)/validator/val_neg.h $(srcdir)/util/locks.h $(srcdir)/util/log.h $(srcdir)/util/rbtree.h \
  $(srcdir)/validator/val_nsec.h $(srcdir)/util/data/packed_rrset.h $(srcdir)/util/storage/lruhash.h \
@@ -1196,7 +1196,7 @@ val_secalgo.lo val_secalgo.o: $(srcdir)/validator/val_secalgo.c config.h $(srcdi
  $(srcdir)/util/storage/lruhash.h $(srcdir)/util/locks.h $(srcdir)/util/log.h $(srcdir)/validator/val_secalgo.h \
  $(srcdir)/validator/val_nsec3.h $(srcdir)/util/rbtree.h $(srcdir)/sldns/rrdef.h $(srcdir)/sldns/keyraw.h \
  $(srcdir)/sldns/sbuffer.h \
- 
+
 val_sigcrypt.lo val_sigcrypt.o: $(srcdir)/validator/val_sigcrypt.c config.h \
  $(srcdir)/validator/val_sigcrypt.h $(srcdir)/util/data/packed_rrset.h $(srcdir)/util/storage/lruhash.h \
  $(srcdir)/util/locks.h $(srcdir)/util/log.h $(srcdir)/sldns/pkthdr.h $(srcdir)/sldns/rrdef.h \
@@ -1211,7 +1211,7 @@ val_sigcrypt.lo val_sigcrypt.o: $(srcdir)/validator/val_sigcrypt.c config.h \
  $(srcdir)/services/modstack.h $(srcdir)/services/rpz.h $(srcdir)/services/localzone.h \
  $(srcdir)/util/storage/dnstree.h $(srcdir)/services/view.h $(srcdir)/services/authzone.h \
  $(srcdir)/daemon/stats.h $(srcdir)/util/timehist.h $(srcdir)/libunbound/unbound.h $(srcdir)/respip/respip.h \
- 
+
 val_utils.lo val_utils.o: $(srcdir)/validator/val_utils.c config.h $(srcdir)/validator/val_utils.h \
  $(srcdir)/util/data/packed_rrset.h $(srcdir)/util/storage/lruhash.h $(srcdir)/util/locks.h $(srcdir)/util/log.h \
  $(srcdir)/sldns/pkthdr.h $(srcdir)/sldns/rrdef.h $(srcdir)/validator/validator.h $(srcdir)/util/module.h \
@@ -1303,7 +1303,7 @@ dtstream.lo dtstream.o: $(srcdir)/dnstap/dtstream.c config.h $(srcdir)/dnstap/dt
  $(srcdir)/util/alloc.h $(srcdir)/util/rbtree.h $(srcdir)/util/regional.h $(srcdir)/util/netevent.h \
  $(srcdir)/dnscrypt/dnscrypt.h  $(srcdir)/dnscrypt/cert.h \
   $(srcdir)/sldns/sbuffer.h \
- 
+
 dnscrypt.lo dnscrypt.o: $(srcdir)/dnscrypt/dnscrypt.c config.h $(srcdir)/sldns/sbuffer.h \
  $(srcdir)/util/config_file.h $(srcdir)/sldns/rrdef.h $(srcdir)/util/net_help.h $(srcdir)/util/log.h \
  $(srcdir)/util/random.h $(srcdir)/util/netevent.h $(srcdir)/dnscrypt/dnscrypt.h \
@@ -1376,7 +1376,7 @@ unitverify.lo unitverify.o: $(srcdir)/testcode/unitverify.c config.h $(srcdir)/u
  $(srcdir)/util/data/dname.h $(srcdir)/util/regional.h $(srcdir)/util/alloc.h $(srcdir)/util/net_help.h \
  $(srcdir)/util/random.h $(srcdir)/util/config_file.h $(srcdir)/sldns/sbuffer.h $(srcdir)/sldns/keyraw.h \
  $(srcdir)/sldns/str2wire.h $(srcdir)/sldns/wire2str.h \
- 
+
 readhex.lo readhex.o: $(srcdir)/testcode/readhex.c config.h $(srcdir)/testcode/readhex.h $(srcdir)/util/log.h \
  $(srcdir)/sldns/sbuffer.h $(srcdir)/sldns/parseutil.h
 testpkts.lo testpkts.o: $(srcdir)/testcode/testpkts.c config.h $(srcdir)/testcode/testpkts.h \
@@ -1416,7 +1416,7 @@ unittcpreuse.lo unittcpreuse.o: $(srcdir)/testcode/unittcpreuse.c config.h $(src
  $(srcdir)/util/log.h $(srcdir)/util/random.h $(srcdir)/services/outside_network.h $(srcdir)/util/alloc.h \
  $(srcdir)/util/locks.h $(srcdir)/util/rbtree.h $(srcdir)/util/regional.h $(srcdir)/util/netevent.h \
  $(srcdir)/dnscrypt/dnscrypt.h  $(srcdir)/dnscrypt/cert.h \
- 
+
 unitdoq.lo unitdoq.o: $(srcdir)/testcode/unitdoq.c config.h $(srcdir)/util/netevent.h \
  $(srcdir)/dnscrypt/dnscrypt.h  $(srcdir)/dnscrypt/cert.h \
  $(srcdir)/util/locks.h $(srcdir)/util/log.h \
@@ -1514,7 +1514,7 @@ stats.lo stats.o: $(srcdir)/daemon/stats.c config.h $(srcdir)/daemon/stats.h $(s
  $(srcdir)/services/cache/infra.h $(srcdir)/util/rtt.h $(srcdir)/validator/val_kcache.h \
  $(srcdir)/validator/val_neg.h $(srcdir)/edns-subnet/subnetmod.h $(srcdir)/util/data/dname.h \
  $(srcdir)/edns-subnet/addrtree.h $(srcdir)/edns-subnet/edns-subnet.h \
- 
+
 unbound.lo unbound.o: $(srcdir)/daemon/unbound.c config.h $(srcdir)/util/log.h $(srcdir)/daemon/daemon.h \
  $(srcdir)/util/locks.h $(srcdir)/util/alloc.h $(srcdir)/services/modstack.h  \
   $(srcdir)/daemon/remote.h \
@@ -1635,7 +1635,7 @@ stats.lo stats.o: $(srcdir)/daemon/stats.c config.h $(srcdir)/daemon/stats.h $(s
  $(srcdir)/services/cache/infra.h $(srcdir)/util/rtt.h $(srcdir)/validator/val_kcache.h \
  $(srcdir)/validator/val_neg.h $(srcdir)/edns-subnet/subnetmod.h $(srcdir)/util/data/dname.h \
  $(srcdir)/edns-subnet/addrtree.h $(srcdir)/edns-subnet/edns-subnet.h \
- 
+
 replay.lo replay.o: $(srcdir)/testcode/replay.c config.h $(srcdir)/util/log.h $(srcdir)/util/net_help.h \
  $(srcdir)/util/random.h $(srcdir)/util/config_file.h $(srcdir)/sldns/rrdef.h $(srcdir)/testcode/replay.h \
  $(srcdir)/util/netevent.h $(srcdir)/dnscrypt/dnscrypt.h  \
@@ -1754,19 +1754,19 @@ libworker.lo libworker.o: $(srcdir)/libunbound/libworker.c config.h \
  $(srcdir)/dnstap/dtstream.h
 unbound-host.lo unbound-host.o: $(srcdir)/smallapp/unbound-host.c config.h $(srcdir)/libunbound/unbound.h \
  $(srcdir)/sldns/rrdef.h $(srcdir)/sldns/wire2str.h \
- 
+
 asynclook.lo asynclook.o: $(srcdir)/testcode/asynclook.c config.h $(srcdir)/libunbound/unbound.h \
  $(srcdir)/libunbound/context.h $(srcdir)/util/locks.h $(srcdir)/util/log.h $(srcdir)/util/alloc.h $(srcdir)/util/rbtree.h \
  $(srcdir)/services/modstack.h $(srcdir)/libunbound/unbound-event.h $(srcdir)/util/data/packed_rrset.h \
  $(srcdir)/util/storage/lruhash.h $(srcdir)/sldns/rrdef.h \
- 
+
 streamtcp.lo streamtcp.o: $(srcdir)/testcode/streamtcp.c config.h $(srcdir)/util/locks.h $(srcdir)/util/log.h \
  $(srcdir)/util/net_help.h $(srcdir)/util/random.h $(srcdir)/util/proxy_protocol.h \
  $(srcdir)/util/data/msgencode.h $(srcdir)/util/data/msgparse.h $(srcdir)/util/storage/lruhash.h \
  $(srcdir)/sldns/pkthdr.h $(srcdir)/sldns/rrdef.h $(srcdir)/util/data/msgreply.h \
  $(srcdir)/util/data/packed_rrset.h $(srcdir)/util/data/dname.h $(srcdir)/sldns/sbuffer.h \
  $(srcdir)/sldns/str2wire.h $(srcdir)/sldns/wire2str.h \
- 
+
 perf.lo perf.o: $(srcdir)/testcode/perf.c config.h $(srcdir)/util/log.h $(srcdir)/util/locks.h $(srcdir)/util/net_help.h \
  $(srcdir)/util/random.h $(srcdir)/util/data/msgencode.h $(srcdir)/util/data/msgreply.h \
  $(srcdir)/util/storage/lruhash.h $(srcdir)/util/data/packed_rrset.h $(srcdir)/sldns/rrdef.h \
@@ -1786,12 +1786,12 @@ unbound-control.lo unbound-control.o: $(srcdir)/smallapp/unbound-control.c confi
  $(srcdir)/dnscrypt/cert.h \
  $(srcdir)/services/modstack.h $(srcdir)/respip/respip.h $(srcdir)/services/listen_dnsport.h \
  $(srcdir)/daemon/acl_list.h \
- 
+
 unbound-anchor.lo unbound-anchor.o: $(srcdir)/smallapp/unbound-anchor.c config.h $(srcdir)/libunbound/unbound.h \
  $(srcdir)/sldns/rrdef.h $(srcdir)/sldns/parseutil.h \
- 
+
 petal.lo petal.o: $(srcdir)/testcode/petal.c config.h \
- 
+
 unbound-dnstap-socket.lo unbound-dnstap-socket.o: $(srcdir)/dnstap/unbound-dnstap-socket.c config.h \
  $(srcdir)/dnstap/dtstream.h $(srcdir)/util/locks.h $(srcdir)/util/log.h $(srcdir)/dnstap/dnstap_fstrm.h \
  $(srcdir)/util/ub_event.h $(srcdir)/util/net_help.h $(srcdir)/util/random.h $(srcdir)/services/listen_dnsport.h \
@@ -1815,7 +1815,7 @@ pythonmod_utils.lo pythonmod_utils.o: $(srcdir)/pythonmod/pythonmod_utils.c conf
  $(srcdir)/util/net_help.h $(srcdir)/util/random.h $(srcdir)/services/cache/dns.h \
  $(srcdir)/services/cache/rrset.h $(srcdir)/util/storage/slabhash.h $(srcdir)/util/regional.h \
  $(srcdir)/iterator/iter_delegpt.h $(srcdir)/sldns/sbuffer.h \
- 
+
 win_svc.lo win_svc.o: $(srcdir)/winrc/win_svc.c config.h $(srcdir)/winrc/win_svc.h $(srcdir)/winrc/w_inst.h \
  $(srcdir)/daemon/daemon.h $(srcdir)/util/locks.h $(srcdir)/util/log.h $(srcdir)/util/alloc.h $(srcdir)/services/modstack.h \
    $(srcdir)/daemon/worker.h \
@@ -1835,7 +1835,7 @@ anchor-update.lo anchor-update.o: $(srcdir)/winrc/anchor-update.c config.h $(src
  $(srcdir)/sldns/rrdef.h $(srcdir)/sldns/pkthdr.h $(srcdir)/sldns/wire2str.h
 keyraw.lo keyraw.o: $(srcdir)/sldns/keyraw.c config.h $(srcdir)/sldns/keyraw.h \
  $(srcdir)/sldns/rrdef.h \
- 
+
 sbuffer.lo sbuffer.o: $(srcdir)/sldns/sbuffer.c config.h $(srcdir)/sldns/sbuffer.h
 wire2str.lo wire2str.o: $(srcdir)/sldns/wire2str.c config.h $(srcdir)/sldns/wire2str.h $(srcdir)/sldns/str2wire.h \
  $(srcdir)/sldns/rrdef.h $(srcdir)/sldns/pkthdr.h $(srcdir)/sldns/parseutil.h $(srcdir)/sldns/sbuffer.h \
@@ -1852,7 +1852,7 @@ dohclient.lo dohclient.o: $(srcdir)/testcode/dohclient.c config.h $(srcdir)/sldn
  $(srcdir)/util/data/msgencode.h $(srcdir)/util/data/msgreply.h $(srcdir)/util/storage/lruhash.h \
  $(srcdir)/util/locks.h $(srcdir)/util/log.h $(srcdir)/util/data/packed_rrset.h $(srcdir)/util/data/msgparse.h \
  $(srcdir)/sldns/pkthdr.h $(srcdir)/util/net_help.h $(srcdir)/util/random.h \
- 
+
 doqclient.lo doqclient.o: $(srcdir)/testcode/doqclient.c config.h \
  $(srcdir)/util/locks.h $(srcdir)/util/log.h $(srcdir)/util/net_help.h $(srcdir)/util/random.h $(srcdir)/sldns/sbuffer.h \
  $(srcdir)/sldns/str2wire.h $(srcdir)/sldns/rrdef.h $(srcdir)/sldns/wire2str.h $(srcdir)/util/data/msgreply.h \
@@ -1883,10 +1883,10 @@ strlcpy.lo strlcpy.o: $(srcdir)/compat/strlcpy.c config.h
 strptime.lo strptime.o: $(srcdir)/compat/strptime.c config.h
 getentropy_freebsd.lo getentropy_freebsd.o: $(srcdir)/compat/getentropy_freebsd.c
 getentropy_linux.lo getentropy_linux.o: $(srcdir)/compat/getentropy_linux.c config.h \
- 
+
 getentropy_osx.lo getentropy_osx.o: $(srcdir)/compat/getentropy_osx.c
 getentropy_solaris.lo getentropy_solaris.o: $(srcdir)/compat/getentropy_solaris.c config.h \
- 
+
 getentropy_win.lo getentropy_win.o: $(srcdir)/compat/getentropy_win.c
 explicit_bzero.lo explicit_bzero.o: $(srcdir)/compat/explicit_bzero.c config.h
 arc4random.lo arc4random.o: $(srcdir)/compat/arc4random.c config.h $(srcdir)/compat/chacha_private.h

--- a/cachedb/redis.c
+++ b/cachedb/redis.c
@@ -4,22 +4,22 @@
  * Copyright (c) 2018, NLnet Labs. All rights reserved.
  *
  * This software is open source.
- * 
+ *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
  * are met:
- * 
+ *
  * Redistributions of source code must retain the above copyright notice,
  * this list of conditions and the following disclaimer.
- * 
+ *
  * Redistributions in binary form must reproduce the above copyright notice,
  * this list of conditions and the following disclaimer in the documentation
  * and/or other materials provided with the distribution.
- * 
+ *
  * Neither the name of the NLNET LABS nor the names of its contributors may
  * be used to endorse or promote products derived from this software without
  * specific prior written permission.
- * 
+ *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
  * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
  * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
@@ -192,7 +192,7 @@ redis_connect(const char* host, int port, const char* path,
 		redisReply* rep;
 		rep = redisCommand(ctx, "AUTH %s", password);
 		if(!rep || rep->type == REDIS_REPLY_ERROR) {
-			log_err("failed to authenticate %swith password", infostr);
+			log_err("failed to authenticate %s with password", infostr);
 			freeReplyObject(rep);
 			goto fail;
 		}

--- a/compat/inet_ntop.c
+++ b/compat/inet_ntop.c
@@ -34,7 +34,7 @@
 #include <stdio.h>
 
 #ifndef IN6ADDRSZ
-#define IN6ADDRSZ   16   /* IPv6 T_AAAA */                 
+#define IN6ADDRSZ   16   /* IPv6 T_AAAA */
 #endif
 
 #ifndef INT16SZ
@@ -82,7 +82,7 @@ inet_ntop(int af, const void *src, char *dst, size_t size)
  * return:
  *	`dst' (as a const)
  * notes:
- *	(1) uses no statics
+ *	(1) uses no static variables
  *	(2) takes a u_char* not an in_addr as input
  * author:
  *	Paul Vixie, 1996.

--- a/contrib/parseunbound.pl
+++ b/contrib/parseunbound.pl
@@ -50,7 +50,7 @@ my $offset = 0;
 my $inthread=0;
 my $inpid;
 
-# We should continue looping untill we meet these conditions:
+# We should continue looping until we meet these conditions:
 # a) more total queries than the previous run (which defaults to 0) AND
 # b) parsed all $numthreads threads in the log.
 my $numqueries = $previousresult ? $previousresult->[1] : 0;
@@ -66,7 +66,7 @@ while ( scalar keys %startstats < $numthreads || scalar keys %donestats < $numth
     for my $line ( <$in> ) {
         chomp($line);
 
-        #[1208777234] unbound[6705:0] 
+        #[1208777234] unbound[6705:0]
         if ($line =~ m/^\[\d+\] unbound\[\d+:(\d+)\]/) {
             $inthread = $1;
             if ($inthread + 1 > $numthreads) {
@@ -110,12 +110,12 @@ while ( scalar keys %startstats < $numthreads || scalar keys %donestats < $numth
             next;
         }
         elsif ( $line =~ m/info:\s+(\d+)\.(\d+)\s+(\d+)\.(\d+)\s+(\d+)/ ) {
-            my ($froms, $fromus, $toms, $tous, $counter) = ($1, $2, $3, $4, $5);
+            my ($from_s, $from_us, $to_s, $to_us, $counter) = ($1, $2, $3, $4, $5);
             my $prefix = '';
-            if ($froms > 0) {
-                $allstats{$inthread}->{'s_' . int($froms)} = $counter;
+            if ($from_s > 0) {
+                $allstats{$inthread}->{'s_' . int($from_s)} = $counter;
             } else {
-                $allstats{$inthread}->{'us_' . int($fromus)} = $counter;
+                $allstats{$inthread}->{'us_' . int($from_us)} = $counter;
             }
         }
     }

--- a/contrib/unbound.spec_fedora
+++ b/contrib/unbound.spec_fedora
@@ -22,7 +22,7 @@ Patch1: unbound-1.2-glob.patch
 
 Group: System Environment/Daemons
 BuildRoot: %{_tmppath}/%{name}-%{version}-%{release}-root-%(%{__id_u} -n)
-BuildRequires: flex, openssl-devel , ldns-devel >= 1.5.0, 
+BuildRequires: flex, openssl-devel , ldns-devel >= 1.5.0,
 BuildRequires: libevent-devel expat-devel
 %if %{with_python}
 BuildRequires:  python-devel swig
@@ -73,7 +73,7 @@ Summary: Libraries used by the unbound server and client applications
 Group: Applications/System
 Requires(post): /sbin/ldconfig
 Requires(postun): /sbin/ldconfig
-Requires: openssl 
+Requires: openssl
 
 %description libs
 Contains libraries used by the unbound server and client applications
@@ -89,7 +89,7 @@ Python modules and extensions for unbound
 %endif
 
 %prep
-%setup -q 
+%setup -q
 %patch1 -p1
 
 %build
@@ -116,7 +116,7 @@ install -d 0755 %{buildroot}%{_datadir}/munin/plugins/
 install -m 0755 %{SOURCE4} %{buildroot}%{_datadir}/munin/plugins/unbound
 for plugin in unbound_munin_hits unbound_munin_queue unbound_munin_memory unbound_munin_by_type unbound_munin_by_class unbound_munin_by_opcode unbound_munin_by_rcode unbound_munin_by_flags unbound_munin_histogram; do
     ln -s unbound %{buildroot}%{_datadir}/munin/plugins/$plugin
-done 
+done
 
 # install root and DLV key
 install -m 0644 %{SOURCE5} %{SOURCE6} %{buildroot}%{_sysconfdir}/unbound/
@@ -132,7 +132,7 @@ mkdir -p %{buildroot}%{_localstatedir}/run/unbound
 %clean
 rm -rf ${RPM_BUILD_ROOT}
 
-%files 
+%files
 %defattr(-,root,root,-)
 %doc doc/README doc/CREDITS doc/LICENSE doc/FEATURES
 %attr(0755,root,root) %{_initrddir}/%{name}
@@ -182,10 +182,10 @@ exit 0
 %preun
 if [ "$1" -eq 0 ]; then
         /sbin/service %{name} stop >/dev/null 2>&1
-        /sbin/chkconfig --del %{name} 
+        /sbin/chkconfig --del %{name}
 fi
 
-%postun 
+%postun
 if [ "$1" -ge "1" ]; then
   /sbin/service %{name} condrestart >/dev/null 2>&1 || :
 fi
@@ -198,7 +198,7 @@ fi
 - Fix install location of pythonmod from sitelib to sitearch
 - Removed patches merged in by upstream
 - Removed versioned openssl dep, it differs per branch
- 
+
 * Mon Aug 08 2011 Paul Wouters <paul@xelerance.com> - 1.4.12-3
 - Added pythonmod docs and examples
 - Fix for python module load in the server (Tom Hendrikx)
@@ -249,17 +249,17 @@ fi
 - Upgraded to 1.4.5
 
 * Mon May 31 2010 Paul Wouters <paul@xelerance.com> - 1.4.4-2
-- Added accidentally omitted svn patches to cvs 
+- Added accidentally omitted svn patches to cvs
 
 * Mon May 31 2010 Paul Wouters <paul@xelerance.com> - 1.4.4-1
 - Upgraded to 1.4.4 with svn patches
 - Obsolete dnssec-conf to ensure it is de-installed
 
-* Thu Mar 11 2010 Paul Wouters <paul@xelerance.com> - 1.4.3-1
-- Update to 1.4.3 that fixes 64bit crasher
+* Tue Mar 11 2010 Paul Wouters <paul@xelerance.com> - 1.4.3-1
+- Update to 1.4.3 that fixes 64bit crash
 
 * Tue Mar 09 2010 Paul Wouters <paul@xelerance.com> - 1.4.2-1
-- Updated to 1.4.2 
+- Updated to 1.4.2
 - Updated unbound.conf with new options
 - Enabled pre-fetching DNSKEY records (DNSSEC speedup)
 - Enabled re-fetching popular records before they expire
@@ -369,7 +369,7 @@ fi
 - label control certs after generation correctly
 
 * Thu Nov 20 2008 Paul Wouters <paul@xelerance.com> - 1.1.1-1
-- Updated to unbound 1.1.1 which fixes a crasher and
+- Updated to unbound 1.1.1 which fixes a crash and
   addresses nlnetlabs bug #219
 
 * Wed Nov 19 2008 Paul Wouters <paul@xelerance.com> - 1.1.0-3
@@ -408,7 +408,7 @@ fi
   causes unbound to listen on 0.0.0.0 instead of 127.0.0.1
 
 * Sun Oct 19 2008 Paul Wouters <paul@xelerance.com> - 1.0.2-3
-- Split off unbound-libs, make build verbose 
+- Split off unbound-libs, make build verbose
 
 * Thu Oct  9 2008 Paul Wouters <paul@xelerance.com> - 1.0.2-2
 - FSB compliance, chroot fixes, initscript fixes

--- a/daemon/acl_list.c
+++ b/daemon/acl_list.c
@@ -4,22 +4,22 @@
  * Copyright (c) 2007, NLnet Labs. All rights reserved.
  *
  * This software is open source.
- * 
+ *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
  * are met:
- * 
+ *
  * Redistributions of source code must retain the above copyright notice,
  * this list of conditions and the following disclaimer.
- * 
+ *
  * Redistributions in binary form must reproduce the above copyright notice,
  * this list of conditions and the following disclaimer in the documentation
  * and/or other materials provided with the distribution.
- * 
+ *
  * Neither the name of the NLNET LABS nor the names of its contributors may
  * be used to endorse or promote products derived from this software without
  * specific prior written permission.
- * 
+ *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
  * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
  * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
@@ -497,7 +497,7 @@ read_acl_tag_actions(struct acl_list* acl, struct config_file* cfg,
 	return 1;
 }
 
-/** read acl tag datas config */
+/** read acl tag data config */
 static int
 read_acl_tag_datas(struct acl_list* acl, struct config_file* cfg,
 	struct config_str3list** acl_tag_datas)
@@ -697,7 +697,7 @@ read_acl_interface_tag_actions(struct acl_list* acl_interface,
 	return 1;
 }
 
-/** read acl tag datas config for interface */
+/** read acl tag data config for interface */
 static int
 read_acl_interface_tag_datas(struct acl_list* acl_interface,
 	struct config_file* cfg,

--- a/daemon/remote.c
+++ b/daemon/remote.c
@@ -1510,7 +1510,7 @@ do_datas_add(struct daemon_remote* rc, RES* ssl, struct worker* worker)
 			buf+cmd_len, line))
 			num++;
 	}
-	(void)ssl_printf(ssl, "added %d datas\n", num);
+	(void)ssl_printf(ssl, "added %d data items\n", num);
 }
 
 /** Remove RR data */
@@ -1562,7 +1562,7 @@ do_datas_remove(struct daemon_remote* rc, RES* ssl, struct worker* worker)
 		}
 		else	num++;
 	}
-	(void)ssl_printf(ssl, "removed %d datas\n", num);
+	(void)ssl_printf(ssl, "removed %d data items\n", num);
 }
 
 /** Add a new zone to view */
@@ -1643,6 +1643,28 @@ do_view_data_add(RES* ssl, struct worker* worker, char* arg)
 	lock_rw_unlock(&v->lock);
 }
 
+/** Remove RR data from view */
+static void
+do_view_data_remove(RES* ssl, struct worker* worker, char* arg)
+{
+	char* arg2;
+	struct view* v;
+	if(!find_arg2(ssl, arg, &arg2))
+		return;
+	v = views_find_view(worker->env.views, arg, 1 /* get write lock*/);
+	if(!v) {
+		ssl_printf(ssl,"no view with name: %s\n", arg);
+		return;
+	}
+	if(!v->local_zones) {
+		lock_rw_unlock(&v->lock);
+		send_ok(ssl);
+		return;
+	}
+	do_data_remove(ssl, v->local_zones, arg2);
+	lock_rw_unlock(&v->lock);
+}
+
 /** Add new RR data from stdin to view */
 static void
 do_view_datas_add(struct daemon_remote* rc, RES* ssl, struct worker* worker,
@@ -1682,29 +1704,7 @@ do_view_datas_add(struct daemon_remote* rc, RES* ssl, struct worker* worker,
 			num++;
 	}
 	lock_rw_unlock(&v->lock);
-	(void)ssl_printf(ssl, "added %d datas\n", num);
-}
-
-/** Remove RR data from view */
-static void
-do_view_data_remove(RES* ssl, struct worker* worker, char* arg)
-{
-	char* arg2;
-	struct view* v;
-	if(!find_arg2(ssl, arg, &arg2))
-		return;
-	v = views_find_view(worker->env.views, arg, 1 /* get write lock*/);
-	if(!v) {
-		ssl_printf(ssl,"no view with name: %s\n", arg);
-		return;
-	}
-	if(!v->local_zones) {
-		lock_rw_unlock(&v->lock);
-		send_ok(ssl);
-		return;
-	}
-	do_data_remove(ssl, v->local_zones, arg2);
-	lock_rw_unlock(&v->lock);
+	(void)ssl_printf(ssl, "added %d data items\n", num);
 }
 
 /** Remove RR data from stdin from view */
@@ -1723,7 +1723,7 @@ do_view_datas_remove(struct daemon_remote* rc, RES* ssl, struct worker* worker,
 	}
 	if(!v->local_zones){
 		lock_rw_unlock(&v->lock);
-		ssl_printf(ssl, "removed 0 datas\n");
+		ssl_printf(ssl, "removed 0 data items\n");
 		return;
 	}
 	/* put the view name in the command buf */
@@ -1747,7 +1747,7 @@ do_view_datas_remove(struct daemon_remote* rc, RES* ssl, struct worker* worker,
 		else	num++;
 	}
 	lock_rw_unlock(&v->lock);
-	(void)ssl_printf(ssl, "removed %d datas\n", num);
+	(void)ssl_printf(ssl, "removed %d data items\n", num);
 }
 
 /** information for the domain search */

--- a/dnstap/unbound-dnstap-socket.c
+++ b/dnstap/unbound-dnstap-socket.c
@@ -4,22 +4,22 @@
  * Copyright (c) 2020, NLnet Labs. All rights reserved.
  *
  * This software is open source.
- * 
+ *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
  * are met:
- * 
+ *
  * Redistributions of source code must retain the above copyright notice,
  * this list of conditions and the following disclaimer.
- * 
+ *
  * Redistributions in binary form must reproduce the above copyright notice,
  * this list of conditions and the following disclaimer in the documentation
  * and/or other materials provided with the distribution.
- * 
+ *
  * Neither the name of the NLNET LABS nor the names of its contributors may
  * be used to endorse or promote products derived from this software without
  * specific prior written permission.
- * 
+ *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
  * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
  * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
@@ -644,7 +644,7 @@ static void log_data_frame(uint8_t* pkt, size_t len)
 	} else {
 		mtype = "nomessage";
 	}
-	
+
 	printf("%s%s%s%s%s\n", mtype, (maddr?" ":""), (maddr?maddr:""),
 		(qinf?" ":""), (qinf?qinf:""));
 	free(maddr);
@@ -1211,7 +1211,7 @@ void dtio_mainfdcallback(int fd, short ATTR_UNUSED(bits), void* arg)
 			log_info("accepted new dnstap client");
 		}
 	}
-	
+
 	data = calloc(1, sizeof(*data));
 	if(!data) fatal_exit("out of memory");
 	data->fd = s;
@@ -1344,22 +1344,22 @@ setup_and_run(struct config_strlist_head* local_list,
 static int internal_unittest()
 {
 	/* unit test tap_data_list_try_to_free_tail() */
-#define unit_tap_datas_max 5
-	struct tap_data* datas[unit_tap_datas_max];
+#define unit_tap_data_max 5
+	struct tap_data* data_items[unit_tap_data_max];
 	struct tap_data_list* list;
 	struct tap_socket* socket = calloc(1, sizeof(*socket));
 	size_t i = 0;
 	log_assert(socket);
-	log_assert(unit_tap_datas_max>2); /* needed for the test */
-	for(i=0; i<unit_tap_datas_max; i++) {
-		datas[i] = calloc(1, sizeof(struct tap_data));
-		log_assert(datas[i]);
-		log_assert(tap_data_list_insert(&socket->data_list, datas[i]));
+	log_assert(unit_tap_data_max>2); /* needed for the test */
+	for(i=0; i<unit_tap_data_max; i++) {
+		data_items[i] = calloc(1, sizeof(struct tap_data));
+		log_assert(data_items[i]);
+		log_assert(tap_data_list_insert(&socket->data_list, data_items[i]));
 	}
 	/* sanity base check */
 	list = socket->data_list;
 	for(i=0; list; i++) list = list->next;
-	log_assert(i==unit_tap_datas_max);
+	log_assert(i==unit_tap_data_max);
 
 	/* Free the last data, tail cannot be erased */
 	list = socket->data_list;
@@ -1369,22 +1369,22 @@ static int internal_unittest()
 	tap_data_list_try_to_free_tail(list);
 	list = socket->data_list;
 	for(i=0; list; i++) list = list->next;
-	log_assert(i==unit_tap_datas_max);
+	log_assert(i==unit_tap_data_max);
 
 	/* Free the third to last data, tail cannot be erased */
 	list = socket->data_list;
-	for(i=0; i<unit_tap_datas_max-3; i++) list = list->next;
+	for(i=0; i<unit_tap_data_max-3; i++) list = list->next;
 	free(list->d);
 	list->d = NULL;
 	tap_data_list_try_to_free_tail(list);
 	list = socket->data_list;
 	for(i=0; list; i++) list = list->next;
-	log_assert(i==unit_tap_datas_max);
+	log_assert(i==unit_tap_data_max);
 
 	/* Free the second to last data, try to remove tail from the third
 	 * again, tail (last 2) should be removed */
 	list = socket->data_list;
-	for(i=0; i<unit_tap_datas_max-2; i++) list = list->next;
+	for(i=0; i<unit_tap_data_max-2; i++) list = list->next;
 	free(list->d);
 	list->d = NULL;
 	list = socket->data_list;
@@ -1392,7 +1392,7 @@ static int internal_unittest()
 	tap_data_list_try_to_free_tail(list);
 	list = socket->data_list;
 	for(i=0; list; i++) list = list->next;
-	log_assert(i==unit_tap_datas_max-2);
+	log_assert(i==unit_tap_data_max-2);
 
 	/* Free all the remaining data, try to remove tail from the start,
 	 * only the start should remain */
@@ -1415,9 +1415,9 @@ static int internal_unittest()
 	socket = calloc(1, sizeof(*socket));
 	log_assert(socket);
 	for(i=0; i<2; i++) {
-		datas[i] = calloc(1, sizeof(struct tap_data));
-		log_assert(datas[i]);
-		log_assert(tap_data_list_insert(&socket->data_list, datas[i]));
+		data_items[i] = calloc(1, sizeof(struct tap_data));
+		log_assert(data_items[i]);
+		log_assert(tap_data_list_insert(&socket->data_list, data_items[i]));
 	}
 	/* sanity base check */
 	list = socket->data_list;
@@ -1454,7 +1454,7 @@ extern int optind;
 extern char* optarg;
 
 /** main program for streamtcp */
-int main(int argc, char** argv) 
+int main(int argc, char** argv)
 {
 	int c;
 	int usessl = 0;
@@ -1604,7 +1604,7 @@ void worker_handle_control_cmd(struct tube* ATTR_UNUSED(tube),
 	log_assert(0);
 }
 
-int worker_handle_request(struct comm_point* ATTR_UNUSED(c), 
+int worker_handle_request(struct comm_point* ATTR_UNUSED(c),
 	void* ATTR_UNUSED(arg), int ATTR_UNUSED(error),
         struct comm_reply* ATTR_UNUSED(repinfo))
 {
@@ -1612,7 +1612,7 @@ int worker_handle_request(struct comm_point* ATTR_UNUSED(c),
 	return 0;
 }
 
-int worker_handle_service_reply(struct comm_point* ATTR_UNUSED(c), 
+int worker_handle_service_reply(struct comm_point* ATTR_UNUSED(c),
 	void* ATTR_UNUSED(arg), int ATTR_UNUSED(error),
         struct comm_reply* ATTR_UNUSED(reply_info))
 {
@@ -1620,7 +1620,7 @@ int worker_handle_service_reply(struct comm_point* ATTR_UNUSED(c),
 	return 0;
 }
 
-int remote_accept_callback(struct comm_point* ATTR_UNUSED(c), 
+int remote_accept_callback(struct comm_point* ATTR_UNUSED(c),
 	void* ATTR_UNUSED(arg), int ATTR_UNUSED(error),
         struct comm_reply* ATTR_UNUSED(repinfo))
 {
@@ -1628,7 +1628,7 @@ int remote_accept_callback(struct comm_point* ATTR_UNUSED(c),
 	return 0;
 }
 
-int remote_control_callback(struct comm_point* ATTR_UNUSED(c), 
+int remote_control_callback(struct comm_point* ATTR_UNUSED(c),
 	void* ATTR_UNUSED(arg), int ATTR_UNUSED(error),
         struct comm_reply* ATTR_UNUSED(repinfo))
 {
@@ -1657,7 +1657,7 @@ struct outbound_entry* worker_send_query(
 
 #ifdef UB_ON_WINDOWS
 void
-worker_win_stop_cb(int ATTR_UNUSED(fd), short ATTR_UNUSED(ev), void* 
+worker_win_stop_cb(int ATTR_UNUSED(fd), short ATTR_UNUSED(ev), void*
 	ATTR_UNUSED(arg)) {
 	log_assert(0);
 }
@@ -1669,7 +1669,7 @@ wsvc_cron_cb(void* ATTR_UNUSED(arg))
 }
 #endif /* UB_ON_WINDOWS */
 
-void 
+void
 worker_alloc_cleanup(void* ATTR_UNUSED(arg))
 {
 	log_assert(0);
@@ -1689,7 +1689,7 @@ struct outbound_entry* libworker_send_query(
 	return 0;
 }
 
-int libworker_handle_service_reply(struct comm_point* ATTR_UNUSED(c), 
+int libworker_handle_service_reply(struct comm_point* ATTR_UNUSED(c),
 	void* ATTR_UNUSED(arg), int ATTR_UNUSED(error),
         struct comm_reply* ATTR_UNUSED(reply_info))
 {
@@ -1704,21 +1704,21 @@ void libworker_handle_control_cmd(struct tube* ATTR_UNUSED(tube),
         log_assert(0);
 }
 
-void libworker_fg_done_cb(void* ATTR_UNUSED(arg), int ATTR_UNUSED(rcode), 
+void libworker_fg_done_cb(void* ATTR_UNUSED(arg), int ATTR_UNUSED(rcode),
 	struct sldns_buffer* ATTR_UNUSED(buf), enum sec_status ATTR_UNUSED(s),
 	char* ATTR_UNUSED(why_bogus), int ATTR_UNUSED(was_ratelimited))
 {
 	log_assert(0);
 }
 
-void libworker_bg_done_cb(void* ATTR_UNUSED(arg), int ATTR_UNUSED(rcode), 
+void libworker_bg_done_cb(void* ATTR_UNUSED(arg), int ATTR_UNUSED(rcode),
 	struct sldns_buffer* ATTR_UNUSED(buf), enum sec_status ATTR_UNUSED(s),
 	char* ATTR_UNUSED(why_bogus), int ATTR_UNUSED(was_ratelimited))
 {
 	log_assert(0);
 }
 
-void libworker_event_done_cb(void* ATTR_UNUSED(arg), int ATTR_UNUSED(rcode), 
+void libworker_event_done_cb(void* ATTR_UNUSED(arg), int ATTR_UNUSED(rcode),
 	struct sldns_buffer* ATTR_UNUSED(buf), enum sec_status ATTR_UNUSED(s),
 	char* ATTR_UNUSED(why_bogus), int ATTR_UNUSED(was_ratelimited))
 {

--- a/doc/Changelog
+++ b/doc/Changelog
@@ -334,7 +334,7 @@
 
 11 July 2025: Wouter
 	- Fix detection of SSL_CTX_set_tmp_ecdh function.
-	- For #1301: configure cant find SSL_is_quic in OpenSSL 3.5.1.
+	- For #1301: configure can't find SSL_is_quic in OpenSSL 3.5.1.
 
 8 July 2025: Wouter
 	- Fix to improve dnstap discovery on Fedora.
@@ -1836,7 +1836,7 @@
 	  either we set up a TLS connection or we return an error.
 
 21 March 2023: Philip
-	- Fix issue #851: reserved identifier violation 
+	- Fix issue #851: reserved identifier violation
 
 20 March 2023: Wouter
 	- iana portlist update.
@@ -2235,7 +2235,7 @@
 	- makedist.sh picks up 32bit libssp-0.dll when 32bit compile.
 
 27 May 2022: Wouter
-	- Fix #684: [FTBS] configure script error with libmnl on openSUSE 15.3 (and possibly other distributions)
+	- Fix #684: [FTBFS] configure script error with libmnl on openSUSE 15.3 (and possibly other distributions)
 	- Version is set to 1.16.0 for release. Release tag 1.16.0rc1. This
 	  became release 1.16.0 on 2 June 2022. The source code branch
 	  continues with version 1.16.1 under development.
@@ -3430,7 +3430,7 @@
 	  by Vítězslav Čížek.
 
 10 August 2020: Wouter
-	- Fix #287: doc typo: "Additionaly".
+	- Fix #287: doc typo: "Additionally".
 	- Rerun autoconf
 
 6 August 2020: Wouter
@@ -3518,7 +3518,7 @@
 29 June 2020: Wouter
 	- Move reply list clean for serve expired mesh callback to after
 	  the reply is sent, so that script callbacks have reply_info.
-	- Also move reply list clean for mesh callbacks to the scrip callback
+	- Also move reply list clean for mesh callbacks to the script callback
 	  can see the reply_info.
 	- Fix for mesh accounting if the reply list already empty to begin
 	  with.
@@ -4416,7 +4416,7 @@
 	  SOA serial probes.  This fixes that probes fail because earlier
 	  probe addresses are unreachable.
 	- Fix that auth zone fails over to next master for timeout in tcp.
-	- Squelch SSL read and write connection reset by peer and broken pipe 
+	- Squelch SSL read and write connection reset by peer and broken pipe
 	  messages.  Verbosity 2 and higher enables them.
 
 8 April 2019: Wouter
@@ -4818,7 +4818,7 @@
 	  this omits 'can't assign requested address' errors unless
 	  verbosity is set to a high value.
 	- Set default for so-reuseport to no for FreeBSD.  It is enabled
-	  by default for Linux and DragonFlyBSD.  The setting can 
+	  by default for Linux and DragonFlyBSD.  The setting can
 	  be configured in unbound.conf to override the default.
 	- iana port update.
 
@@ -4851,7 +4851,7 @@
 	  does not have it.
 	- Fix unbound for openssl in FIPS mode, it uses the digests with
 	  the EVP call contexts.
-	- Fix that with harden-below-nxdomain and qname minisation enabled
+	- Fix that with harden-below-nxdomain and qname minimisation enabled
 	  some iterator states for nonresponsive domains can get into a
 	  state where they waited for an empty list.
 	- Stop UDP to TCP failover after timeouts that causes the ping count
@@ -5418,7 +5418,7 @@
 	- Fixed contrib/fastrpz.patch, even though this already applied
 	  cleanly for me, now also for others.
 	- patch to log creates keytag queries, from A. Schulze.
-	- patch suggested by Debian lintian: allow to -> allow one to, from 
+	- patch suggested by Debian lintian: allow to -> allow one to, from
 	  A. Schulze.
 	- Attempt to remove warning about trailing whitespace.
 
@@ -5569,39 +5569,39 @@
 	- Check whether --with-libunbound-only is set when using --with-nettle
 	  or --with-nss.
 
-4 December 2017: Wouter 
+4 December 2017: Wouter
 	- Fix link failure on OmniOS.
 
-1 December 2017: Wouter 
+1 December 2017: Wouter
 	- auth zone work.
 
-30 November 2017: Wouter 
+30 November 2017: Wouter
 	- Fix #3299 - forward CNAME daisy chain is not working
 
-14 November 2017: Wouter 
+14 November 2017: Wouter
 	- Fix #2882: Unbound behaviour changes (wrong) when domain-insecure is
 	  set for stub zone.  It no longer searches for DNSSEC information.
 	- auth xfer work on probe timer and lookup.
 
-13 November 2017: Wouter 
+13 November 2017: Wouter
 	- Fix #2801: Install libunbound.pc.
 	- Fix qname minimisation to send AAAA queries at zonecut like type A.
 	- reverted AAAA change.
 
-7 November 2017: Wouter 
+7 November 2017: Wouter
 	- Fix #2492: Documentation libunbound.
 
-3 November 2017: Wouter 
+3 November 2017: Wouter
 	- Fix #2362: TLS1.3/openssl-1.1.1 not working.
 	- Fix #2034 - Autoconf and -flto.
 	- Fix #2141 - for libsodium detect lack of entropy in chroot, print
 	  a message and exit.
 
-2 November 2017: Wouter 
+2 November 2017: Wouter
 	- Fix #1913: ub_ctx_config is under circumstances thread-safe.
 	- make ip-transparent option work on OpenBSD.
 
-31 October 2017: Wouter 
+31 October 2017: Wouter
 	- Document that errno is left informative on libunbound config read
 	  fail.
 	- lexer output.
@@ -5615,13 +5615,13 @@
 24 October 2017: Ralph
 	- Update B root ipv4 address.
 
-19 October 2017: Wouter 
+19 October 2017: Wouter
 	- authzone work, probe timer setup.
 
-18 October 2017: Wouter 
+18 October 2017: Wouter
 	- lint for recent authzone commit.
 
-17 October 2017: Wouter 
+17 October 2017: Wouter
 	- Fix #1749: With harden-referral-path: performance drops, due to
 	  circular dependency in NS and DS lookups.
 	- [dnscrypt] prevent dnscrypt-secret-key, dnscrypt-provider-cert
@@ -5641,19 +5641,19 @@
 	- Better documentation for cache-max-negative-ttl.
 	- Work on local root zone code.
 
-10 October 2017: Wouter 
+10 October 2017: Wouter
 	- tag 1.6.7
 	- trunk has version 1.6.8.
 
-6 October 2017: Wouter 
+6 October 2017: Wouter
 	- Fix spelling in unbound-control man page.
 
-5 October 2017: Wouter 
+5 October 2017: Wouter
 	- Fix trust-anchor-signaling works in libunbound.
 	- Fix some more crpls in testdata for different signaling default.
 	- tag 1.6.7rc1
 
-5 October 2017: Ralph 
+5 October 2017: Ralph
 	- Set trust-anchor-signaling default to yes
 	- Use RCODE from A query on DNS64 synthesized answer.
 
@@ -5999,7 +5999,7 @@
 	- sldns SMIMEA and AVC definitions, same as getdns definitions.
 
 1 May 2017: Wouter
-	- Fix #1259: "--disable-ecdsa" argument overwritten 
+	- Fix #1259: "--disable-ecdsa" argument overwritten
 	  by "#ifdef SHA256_DIGEST_LENGTH@daemon/remote.c".
 	- iana portlist update
 	- Fix #1258: Windows 10 X64 unbound 1.6.2 service will not start.
@@ -6021,7 +6021,7 @@
 21 April 2017: Ralph
 	- Fix #1254: clarify ratelimit-{for,below}-domain (from Manu Bretelle).
 	- iana portlist update
-	
+
 18 April 2017: Ralph
 	- Fix #1252: more indentation inconsistencies.
 	- Fix #1253: unused variable in edns-subnet/addrtree.c:getbit().
@@ -6084,7 +6084,7 @@
 6 April 2017: Wouter
 	- Small fixup for documentation.
 	- iana portlist update
-	- Fix respip for braces when locks arent used.
+	- Fix respip for braces when locks aren't used.
 	- Fix pythonmod for cb changes.
 
 4 April 2017: Wouter
@@ -6122,7 +6122,7 @@
 
 21 March 2017: Ralph
 	- Merge EDNS Client subnet implementation from feature branch into main
-	  branch, using new EDNS processing framework. 
+	  branch, using new EDNS processing framework.
 
 21 March 2017: Wouter
 	- Fix doxygen for dnscrypt files.
@@ -6255,7 +6255,7 @@
 	- iana portlist update
 
 12 January 2017: Wouter
-	- Fix to also block meta types 128 through to 248 with formerr. 
+	- Fix to also block meta types 128 through to 248 with formerr.
 	- Fix #1206: Some view-related commands are missing from 'unbound-control -h'
 
 9 January 2017: Wouter
@@ -6534,8 +6534,8 @@
 	- Add default root hints for IPv6 E.ROOT-SERVERS.NET, 2001:500:a8::e.
 
 25 August 2016: Ralph
-	- Clarify local-zone-override entry in unbound.conf.5 
-	
+	- Clarify local-zone-override entry in unbound.conf.5
+
 25 August 2016: Wouter
 	- 64bit build option for makedist windows compile, -w64.
 
@@ -6545,7 +6545,7 @@
 	- unbound.conf.5 entries for define-tag, access-control-tag,
 	  access-control-tag-action, access-control-tag-data, local-zone-tag,
 	  and local-zone-override.
-	  
+
 23 August 2016: Wouter
 	- Fix #804: unbound stops responding after outage.  Fixes queries
 	  that attempt to wait for an empty list of subqueries.
@@ -6737,7 +6737,7 @@
 	  harden-below-nxdomain documentation.
 
 20 May 2016: Ralph
-	- No QNAME minimisation fall-back for NXDOMAIN answers from DNSSEC 
+	- No QNAME minimisation fall-back for NXDOMAIN answers from DNSSEC
 	  signed zones.
 	- iana portlist update.
 
@@ -6934,7 +6934,7 @@
 	  warnings.
 
 15 December 2015: Ralph
-	- Fix #729: omit use of escape sequences in echo since they are not 
+	- Fix #729: omit use of escape sequences in echo since they are not
 	  portable (unbound-control-setup).
 
 11 December 2015: Wouter
@@ -6961,7 +6961,7 @@
 3 December 2015: Ralph
 	- (after rc1 tag)
 	- Committed fix to qname minimisation and unit test case for it.
-	
+
 3 December 2015: Wouter
 	- iana portlist update.
 	- 1.5.7rc1 prerelease tag.
@@ -7475,7 +7475,7 @@
 	- Patch from Robert Edmonds fixes hyphens in unbound-anchor man page.
 	- Removed 'increased limit open files' log message that is written
 	  to console.  It is only written on verbosity 4 and higher.
-	  This keeps system bootup console cleaner.
+	  This keeps system boot-up console cleaner.
 	- Patch from James Raftery, always print stats for rcodes 0..5.
 
 11 November 2014: Wouter
@@ -7910,7 +7910,7 @@
 	- if configured --with-libunbound-only fix make install.
 
 31 Oct 2013: Wouter
-	- Fix #531: Set SO_REUSEADDR so that the wildcard interface and a 
+	- Fix #531: Set SO_REUSEADDR so that the wildcard interface and a
 	  more specific interface port 53 can be used at the same time, and
 	  one of the daemons is unbound.
 	- iana portlist update.
@@ -7975,7 +7975,7 @@
 
 29 Jun 2013: Wouter
 	- Fix#512 memleak in testcode for testbound (if it fails).
-	- Fix#512 NSS returned arrays out of setup function to be statics.
+	- Fix#512 NSS returned arrays out of setup function to be static.
 
 26 Jun 2013: Wouter
 	- max include of 100.000 files (depth and globbed at one time).
@@ -8463,7 +8463,7 @@
 	- iter forwards uses malloc inside for more dynamicity.
 
 13 February 2012: Wouter
-	- RT#2955. Fix for cygwin compilation. 
+	- RT#2955. Fix for cygwin compilation.
 	- iana portlist updated.
 
 10 February 2012: Wouter
@@ -8636,7 +8636,7 @@
 	  Matthew Lee).
 
 21 October 2011: Wouter
-	- fix --enable-allsymbols, fptr wlist is disabled on windows with this 
+	- fix --enable-allsymbols, fptr wlist is disabled on windows with this
 	  option enabled because of memory layout exe vs dll.
 
 19 October 2011: Wouter
@@ -9130,7 +9130,7 @@
 16 August 2010: Wouter
 	- Fix acx_nlnetlabs.m4 configure output for autoconf-2.66 AS_TR_CPP
 	  changes, uses m4_bpatsubst now.
-	- make test (or make check) should be more portable and run the unit 
+	- make test (or make check) should be more portable and run the unit
 	  test and testbound scripts. (make longtest has special requirements).
 
 13 August 2010: Wouter
@@ -9223,7 +9223,7 @@
 
 23 June 2010: Wouter
 	- iana portlist updated.
-	- makedist upgraded cross compile openssl option, like this: 
+	- makedist upgraded cross compile openssl option, like this:
 	  ./makedist.sh -s -wssl openssl-1.0.0a.tar.gz -w --enable-gost
 
 22 June 2010: Wouter
@@ -9252,7 +9252,7 @@
 	- added documentation for the histogram printout to syslog.
 
 11 June 2010: Wouter
-	- When retry to parent the retrycount is not wiped, so failed 
+	- When retry to parent the retrycount is not wiped, so failed
 	  nameservers are not tried again.
 	- iana portlist updated.
 
@@ -9282,7 +9282,7 @@
 	- new splint flags for newer splint install.
 
 31 May 2010: Wouter
-	- Fix AD flag handling, it could in some cases mistakenly copy the AD 
+	- Fix AD flag handling, it could in some cases mistakenly copy the AD
 	  flag from upstream servers.
 	- alloc_special_obtain out of memory is not a fatal error any more,
 	  enabling unbound to continue longer in out of memory conditions.
@@ -9342,7 +9342,7 @@
 	  it was possible to not expire host data (if accessed often).
 
 28 April 2010: Wouter
-	- ldns tarball updated and GOST support is detected and then enabled. 
+	- ldns tarball updated and GOST support is detected and then enabled.
 	- iana portlist updated.
 	- Fix detection of gost support in ldns (reported by Chris Smith).
 
@@ -9363,7 +9363,7 @@
 	  no more double include.
 	- More strict scrubber (Thanks to George Barwood for the idea):
 	  NS set must be pertinent to the query (qname subdomain nsname).
-	- Fix bug#307: In 0x20 backoff fix fallback so the number of 
+	- Fix bug#307: In 0x20 backoff fix fallback so the number of
 	  outstanding queries does not become -1 and block the request.
 	  Fixed handling of recursion-lame in combination with 0x20 fallback.
 	  Fix so RRsets are compared canonicalized and sorted if the immediate
@@ -9407,8 +9407,8 @@
 
 6 April 2010: Wouter
 	- Fix EDNS probe for .de DNSSEC testbed failure, where the infra
-	  cache timeout coincided with a server update, the current EDNS 
-	  backoff is less sensitive, and does not cache the backoff unless 
+	  cache timeout coincided with a server update, the current EDNS
+	  backoff is less sensitive, and does not cache the backoff unless
 	  the backoff actually works and the domain is not expecting DNSSEC.
 	- GOST support with correct algorithm numbers.
 
@@ -9526,7 +9526,7 @@
 	- iana portlist updated.
 
 16 February 2010: Wouter
-	- Check for 'no space left on device' (or other errors) when 
+	- Check for 'no space left on device' (or other errors) when
 	  writing updated autotrust anchors and print errno to log.
 
 15 February 2010: Wouter
@@ -9615,7 +9615,7 @@
 	- review comments.
 	- tag 1.4.1.
 	- trunk to version 1.4.2.
-	
+
 15 December 2009: Wouter
 	- Answer to qclass=ANY queries, with class IN contents.
 	  Test that validation also works.
@@ -9697,14 +9697,14 @@
 	- fix manpage errors reported by debian lintian.
 	- review comments.
 	- fixup very long vallog2 level error strings.
-	
+
 11 November 2009: Wouter
 	- ldns tarball updated (to 1.6.2).
 	- review comments.
 
 10 November 2009: Wouter
 	- Thanks to Surfnet found bug in new dnssec-retry code that failed
-	  to combine well when combined with DLV and a particular failure. 
+	  to combine well when combined with DLV and a particular failure.
 	- Fixed unbound-control -h output about argument optionality.
 	- review comments.
 
@@ -9735,7 +9735,7 @@
 	- please doxygen
 	- add val-log-level print to corner case (nameserver.epost.bg).
 	- more detail to errors from insecure delegation checks.
-	- Fix double time subtraction in negative cache reported by 
+	- Fix double time subtraction in negative cache reported by
 	  Amanda Constant and Hugh Mahon.
 	- Made new validator error string available from libunbound for
 	  applications.  It is in result->why_bogus, a zero-terminated string.
@@ -9914,7 +9914,7 @@
 	- autotrust: process events.
 
 17 August 2009: Wouter
-	- Fix so that servers are only blacklisted if they fail to reply 
+	- Fix so that servers are only blacklisted if they fail to reply
 	  to 16 queries in a row and the timeout gets above 2 minutes.
 	- autotrust work, split up DS verification of DNSKEYs.
 
@@ -10037,7 +10037,7 @@
 	- iana portlist updated.  (one less port allocated, one more fraction
 	  of a bit for security!)
 	- updated fedora specfile in contrib from Paul Wouters.
-	
+
 19 June 2009: Wouter
 	- Fixup strict aliasing warning in iter priv code.
 	  and config_file code.
@@ -10097,7 +10097,7 @@
 
 9 June 2009: Wouter
 	- openssl key files are opened apache-style, when user is root and
-	  before chrooting.  This makes permissions on remote-control key 
+	  before chrooting.  This makes permissions on remote-control key
 	  files easier to set up.  Fixes bug #251.
 	- flush_type and flush_name remove msg cache entries.
 	- codereview - dp copy bogus setting fix.
@@ -10135,7 +10135,7 @@
 27 May 2009: Wouter
 	- detect lack of IPv6 support on XP (with a different error code).
 	- Fixup a crash-on-exit which was triggered by a very long queue.
-	  Unbound would try to re-use ports that came free, but this is
+	  Unbound would try to reuse ports that came free, but this is
 	  of course not really possible because everything is deleted.
 	  Most easily triggered on XP (not Vista), maybe because of the
 	  network stack encouraging large messages backlogs.
@@ -10148,7 +10148,7 @@
 	  Assertion checked if recursion parent query still existed.
 
 29 April 2009: Wouter
-	- Thanks to Brett Carr, caught windows resource leak, use 
+	- Thanks to Brett Carr, caught windows resource leak, use
 	  closesocket() and not close() on sockets or else the network stack
 	  starts to leak handles.
 	- Removed usage of windows Mutex because windows cannot handle enough
@@ -10219,9 +10219,9 @@
 	- nxdomain ttl considerations in requirements.txt
 
 3 April 2009: Wouter
-	- Fixed a bug that caused messages to be stored in the cache too 
+	- Fixed a bug that caused messages to be stored in the cache too
 	  long.  Hard to trigger, but NXDOMAINs for nameservers or CNAME
-	  targets have been more vulnerable to the TTL miscalculation bug. 
+	  targets have been more vulnerable to the TTL miscalculation bug.
 	- documentation test fixed for python addition.
 
 2 April 2009: Wouter
@@ -10229,7 +10229,7 @@
 	- documentation for pythonmod and pyunbound is generated in doc/html.
 	- iana portlist updated.
 	- fixed bug in unbound-control flush_zone where it would not flush
-	  every message in the target domain.  This especially impacted 
+	  every message in the target domain.  This especially impacted
 	  NXDOMAIN messages which could remain in the cache regardless.
 	- python module test package.
 
@@ -10327,7 +10327,7 @@
 11 March 2009: Wouter
 	- winsock event handler resets WSAevents after signalled.
 	- winsock event handler tests if signals are really signalled.
-	- install and service with log to file works on XP and Vista on 
+	- install and service with log to file works on XP and Vista on
 	  default install location.
 	- on windows logging to the Application logbook works (as a service).
 	- fix RUN_DIR on windows compile setting in makedist.
@@ -10359,7 +10359,7 @@
 	- document FAQ entry on stub/forward zones and default blocking.
 	- fix asynclook test app for libunbound not exporting symbols.
 	- service install and remove utils that work with vista UAC.
-		
+
 27 February 2009: Wouter
 	- Fixup lexer, to not give warnings about fwrite. Appeared in
 	  new lexer features.
@@ -10388,13 +10388,13 @@
 	  builtin.  The program uses wget and gpg to work.
 	- iana portlist updated.
 	- update-itar.sh: using ftp:// urls because https godaddy certificate
-	  is not available everywhere and then gives fatal errors.  The 
+	  is not available everywhere and then gives fatal errors.  The
 	  security is provided by pgp signature.
 
 18 February 2009: Wouter
 	- more cycle detection. Also for target queries.
 	- fixup bug where during deletion of the mesh queries the callbacks
-	  that were reentrant caused assertion failures. Keep the mesh in 
+	  that were reentrant caused assertion failures. Keep the mesh in
 	  a reentrant safe state.  Affects libunbound, reload of server,
 	  on quit and flush_requestlist.
 	- iana portlist updated.
@@ -10428,7 +10428,7 @@
 	- iana portlist updated.
 	- fixup EOL in include directive (reported by Paul Wouters).
 	  You can no longer specify newlines in the names of included files.
-	- config parser changed. Gives some syntax errors closer to where they 
+	- config parser changed. Gives some syntax errors closer to where they
 	  occurred. Does not enforce a space after keyword anymore.
 	  Does not allow literal newlines inside quoted strings anymore.
 	- verbosity level 5 logs customer IP for new requestlist entries.
@@ -10444,15 +10444,15 @@
 	- 1.3.0 development continues:
 	  change in libunbound API: ub_cancel can return an error, that
 	  the async_id did not exist, or that it was already delivered.
-	  The result could have been delivered just before the cancel 
+	  The result could have been delivered just before the cancel
 	  routine managed to acquire the lock, so a caller may get the
-	  result at the same time they call cancel.  For this case, 
+	  result at the same time they call cancel.  For this case,
 	  ub_cancel tries to return an error code.
 	  Fixes race condition in ub_cancel() libunbound function.
 	- MacOSX Leopard cleaner text output from configure.
 	- initgroups(3) is called to drop secondary group permissions, if
 	  applicable.
-	- configure option --with-ldns-builtin forces the use of the 
+	- configure option --with-ldns-builtin forces the use of the
 	  included ldns package with the unbound source.  The -I include
 	  is put before the others, so it avoids bad include files from
 	  an older ldns install.
@@ -10473,13 +10473,13 @@
 	  available (network unreachable). Debug still printed on high
 	  verbosity.
 	- unbound-host -4 and -6 options. Stops annoying ipv6 errors when
-	  debugging with unbound-host -4 -d ... 
+	  debugging with unbound-host -4 -d ...
 	- more cycle detection for NS-check, addr-check, root-prime and
 	  stub-prime queries in the iterator.  Avoids possible deadlock
 	  when priming fails.
 
 15 January 2009: Wouter
-	- bug #229: fixup configure checks for compilation with Solaris 
+	- bug #229: fixup configure checks for compilation with Solaris
 	  Sun cc compiler, ./configure CC=/opt/SUNWspro/bin/cc
 	- fixup suncc warnings.
 	- fix bug where unbound could crash using libevent 1.3 and older.
@@ -10517,7 +10517,7 @@
 	- removed debug print.
 
 8 January 2009: Wouter
-	- new version of ldns-trunk (today) included as tarball, fixed 
+	- new version of ldns-trunk (today) included as tarball, fixed
 	  bug #224, building with -j race condition.
 	- remove possible race condition in the test for race conditions.
 
@@ -10665,7 +10665,7 @@
 11 November 2008: Wouter
 	- unit test for negative cache, stress tests the refcounting.
 	- fix for refcounting error that could cause fptr_wlist fatal exit
-	  in the negative cache rbtree (upcoming 1.1 feature). (Thanks to 
+	  in the negative cache rbtree (upcoming 1.1 feature). (Thanks to
 	  Attila Nagy for testing).
 	- nicer comments in cachedump about failed RR to string conversion.
 	- fix 32bit wrap around when printing large (4G and more) mem usage
@@ -10723,7 +10723,7 @@
 	- updated ldns to use 1.4.0-pre20081022 so it picks up CFLAGS too.
 	- new stub-prime: yesno option. Default is off, so it does not prime.
 	  can be turned on to get same behaviour as previous unbound release.
-	- made automated test that checks if builtin root hints are uptodate.
+	- made automated test that checks if builtin root hints are up-to-date.
 	- finished draft-wijngaards-dnsext-resolver-side-mitigation
 	  implementation. The unwanted-reply-threshold can be set.
 	- fixup so fptr_whitelist test in alloc.c works.
@@ -10738,7 +10738,7 @@
 20 October 2008: Wouter
 	- quench a log message that is debug only.
 	- iana portlist updated.
-	- do not query bogus nameservers.  It is like nameservers that have 
+	- do not query bogus nameservers.  It is like nameservers that have
 	  the NS or A or AAAA record bogus are listed as donotquery.
 	- if server selection is faced with only bad choices, it will
 	  attempt to get more options to be fetched.
@@ -10748,7 +10748,7 @@
 	  the operators get the problem fixed sooner.  It makes validation
 	  failures go away sooner (60 seconds after the zone is fixed).
 	  Also it is likely to try different nameserver targets every minute,
-	  so that if a zone is bad on one server but not another, it is 
+	  so that if a zone is bad on one server but not another, it is
 	  likely to pick up the 'correct' one after a couple minutes,
 	  and if the TTL is big enough that solves validation for the zone.
 	- fixup unbound-control compilation on windows.
@@ -10783,7 +10783,7 @@
 
 13 October 2008: Wouter
 	- fixed recursion servers deployed as authoritative detection, so
-	  that as a last resort, a +RD query is sent there to get the 
+	  that as a last resort, a +RD query is sent there to get the
 	  correct answer.
 	- iana port list update.
 	- ldns tarball is snapshot of ldns r2759 (1.4.0-pre-20081013).
@@ -10905,7 +10905,7 @@
 2 September 2008: Wouter
 	- DoS protection features. Queries are jostled out to make room.
 	- testbound can pass time, increasing the internal timer.
-	- do not mark unsigned additionals bogus, leave unchecked, which
+	- do not mark unsigned additional records bogus, leave unchecked, which
 	  is removed too.
 
 1 September 2008: Wouter
@@ -10962,13 +10962,13 @@
 	- negative cache code, reviewed.
 
 18 August 2008: Wouter
-	- changes info: in logfile to notice: info: or debug: depending on 
+	- changes info: in logfile to notice: info: or debug: depending on
 	  the verbosity of the statements.  Better logfile message
 	  classification.
 	- bug #208: extra rc.d unbound flexibility for freebsd/nanobsd.
 
 15 August 2008: Wouter
-	- DLV nsec code fixed for better detection of closest existing 
+	- DLV nsec code fixed for better detection of closest existing
 	  enclosers from NSEC responses.
 	- DLV works, straight to the dlv repository, so not for production.
 	- Iana port update.
@@ -11001,7 +11001,7 @@
 	  validator is used on those NS records (if anchors enabled).
 
 7 August 2008: Wouter
-	- Scrubber more strict. CNAME chains, DNAMEs from cache, other 
+	- Scrubber more strict. CNAME chains, DNAMEs from cache, other
 	  irrelevant rrsets removed.
 	- 1.0.2 released from 1.0 support branch.
 	- fixup update-anchor.sh to work both in BSD shell and bash.
@@ -11010,7 +11010,7 @@
 	- fixup DS test so apex nodata works again.
 
 4 August 2008: Wouter
-	- iana port update. 
+	- iana port update.
 	- TODO update.
 	- fix bug 201: null ptr deref on cleanup while udp pkts wait for port.
 	- added explanatory text for outgoing-port-permit in manpage.
@@ -11116,7 +11116,7 @@
 	- WSA Startup and Cleanup called in unbound.exe.
 
 13 June 2008: Wouter
-	- port mingw32, more signal ifdefs, detect sleep, usleep, 
+	- port mingw32, more signal ifdefs, detect sleep, usleep,
 	  random, srandom (used inside the tests).
 	- signed or unsigned FD_SET is cast.
 
@@ -11153,24 +11153,24 @@
 
 2 June 2008: Wouter
 	- Jelte fixed bugs in my absence
-	  - bug 178: fixed unportable shell usage in configure (relied on 
+	  - bug 178: fixed unportable shell usage in configure (relied on
 	    bash shell).
 	  - bug 180: fixed buffer overflow in unbound-checkconf use of strncat.
 	  - bug 181: fixed buffer overflow in ldns (called by unbound to parse
 	    config file parts).
 	- fixes by Wouter
-	  - bug 177: fixed compilation failure on opensuse, the 
-	    --disable-static configure flag caused problems.  (Patch from 
+	  - bug 177: fixed compilation failure on opensuse, the
+	    --disable-static configure flag caused problems.  (Patch from
 	    Klaus Singvogel)
 	  - bug 179: same fix as 177.
-	  - bug 185: --disable-shared not passed along to ldns included with 
+	  - bug 185: --disable-shared not passed along to ldns included with
 	    unbound. Fixed so that configure parameters are passed to the
 	    subdir configure script.
 	    fixed that ./libtool is used always, you can still override
 	    manually with ./configure libtool=mylibtool or set $libtool in
 	    the environment.
 	- update of the ldns tarball to current ldns svn version (fix 181).
-	- bug 184: -r option for unbound-host, read resolv.conf for 
+	- bug 184: -r option for unbound-host, read resolv.conf for
 	  forwarder. (Note that forwarder must support DNSSEC for validation
 	  to succeed).
 
@@ -11311,7 +11311,7 @@
 	  section must be present in the reply (by the scrubber). And it must
 	  be equal to the question sent, at least lowercase folded.
 	  Previously this feature happened because the cache code refused
-	  to store such messages. However blocking by the scrubber makes 
+	  to store such messages. However blocking by the scrubber makes
 	  sure nothing gets into the RRset cache. Also, this looks like a
 	  timeout (instead of an allocation failure) and this retries are
 	  done (which is useful in a spoofing situation).
@@ -11319,7 +11319,7 @@
 	  include unknown servers. This makes unbound explore unknown servers.
 
 7 March 2008: Wouter
-	- -C config feature for harvest program. 
+	- -C config feature for harvest program.
 	- harvest handles CNAMEs too.
 
 5 March 2008: Wouter
@@ -11327,7 +11327,7 @@
 
 4 March 2008: Wouter
 	- From report by Jinmei Tatuya, rfc2181 trust value for remainder
-	  of a cname trust chain is lower; not full answer_AA. 
+	  of a cname trust chain is lower; not full answer_AA.
 	- test for this fix.
 	- default config file location is /usr/local/etc/unbound.
 	  Thus prefix is used to determine the location. This is also the
@@ -11358,13 +11358,13 @@
 	- harvest debug tool
 
 26 February 2008: Wouter
-	- delay utility delays TCP as well. If the server that is forwarded 
+	- delay utility delays TCP as well. If the server that is forwarded
 	  to has a TCP error, the delay utility closes the connection.
 	- delay does REUSE_ADDR, and can handle a server that closes its end.
 	- answers use casing from query.
 
 25 February 2008: Wouter
-	- delay utility works. Gets decent thoughput too (>20000).
+	- delay utility works. Gets decent throughput too (>20000).
 
 22 February 2008: Wouter
 	- +2% for recursions, if identical queries (except for destination
@@ -11390,7 +11390,7 @@
 21 February 2008: Wouter
 	- speedup of root-delegation message encoding by 15%.
 	- minor speedup of compress tree_lookup, maybe 1%.
-	- speedup of dname_lab_cmp and memlowercmp - the top functions in 
+	- speedup of dname_lab_cmp and memlowercmp - the top functions in
 	  profiler output, maybe a couple percent when it matters.
 
 20 February 2008: Wouter
@@ -11409,7 +11409,7 @@
 	  to default 'no').
 	- time is only gotten once and the value is shared across unbound.
 	- unittest cleans up crypto, so that it has no memory leaks.
-	- mini_event shares the time value with unbound this results in 
+	- mini_event shares the time value with unbound this results in
 	  +3% speed for cache responses and +9% for recursions.
 	- ldns tarball update with new NSEC3 sign code numbers.
 	- perform several reads per UDP operation. This improves performance
@@ -11417,11 +11417,11 @@
 	  improves cache response +50%, and recursions +10%.
 	- modified asynclook test. because the callback from async is not
 	  in any sort of lock (and thus can use all library functions freely),
-	  this causes a tiny race condition window when the last lock is 
+	  this causes a tiny race condition window when the last lock is
 	  released for a callback and a new cancel() for that callback.
-	  The only way to remove this is by putting callbacks into some 
+	  The only way to remove this is by putting callbacks into some
 	  lock window. I'd rather have the small possibility of a callback
-	  for a cancelled function then no use of library functions in 
+	  for a cancelled function then no use of library functions in
 	  callbacks. Could be possible to only outlaw process(), wait(),
 	  cancel() from callbacks, by adding another lock, but I'd rather not.
 
@@ -11430,12 +11430,12 @@
 	- unbound host prints errors if fails to configure context.
 	- fixup perf to resend faster, so that long waiting requests do
 	  not hold up the queue, they become lost packets or SERVFAILs,
-	  or can be sent a little while later (i.e. processing time may 
+	  or can be sent a little while later (i.e. processing time may
 	  take long, but throughput has to be high).
 	- fixup iterator operating in no cache conditions (RD flag unset
 	  after a CNAME).
 	- streamlined code for RD flag setting.
-	- profiled code and changed dname compares to be faster. 
+	- profiled code and changed dname compares to be faster.
 	  The speedup is about +3% to +8% (depending on the test).
 	- minievent tests for eintr and eagain.
 
@@ -11480,7 +11480,7 @@
 
 7 February 2008: Wouter
 	- moved up all current level 2 to be level 3. And 3 to 4.
-	  to make room for new debug level 2 for detailed information 
+	  to make room for new debug level 2 for detailed information
 	  for operators.
 	- verbosity level 2. Describes recursion and validation.
 	- cleaner configure script and fixes for libevent solaris.
@@ -11509,7 +11509,7 @@
 30 January 2008: Wouter
 	- check trailing / on chrootdir in checkconf.
 	- check if root hints and anchor files are in chrootdir.
-	- no route to host tcp error is verbosity level 2. 
+	- no route to host tcp error is verbosity level 2.
 	- removed unused send_reply_iov. and its configure check.
 	- added prints of 'remote address is 1.2.3.4 port 53' to errors
 	  from netevent; the basic socket errors.
@@ -11530,10 +11530,10 @@
 	- close fds after removing commpoints only (for epoll, kqueue).
 
 25 January 2008: Wouter
-	- added tpkg for asynclook and library use. 
+	- added tpkg for asynclook and library use.
 	- allows localhost to be queried when as a library.
 	- fixup race condition between cancel and answer (in case of
-	  really fast answers that beat the cancel).
+	  really fast answers that beat the cancellation).
 	- please doxygen, put doxygen comment in one place.
 	- asynclook -b blocking mode and test.
 	- refactor asynclook, nicer code.
@@ -11541,7 +11541,7 @@
 	  a mutex around the rand init.
 	- fix pass async_id=NULL to _async resolve().
 	- rewrote _wait() routine, so that it is threadsafe.
-	- cancelation is threadsafe.
+	- cancellation is threadsafe.
 	- asynclook extended test in tpkg.
 	- fixed two races where forked bg process waits for (somehow shared?)
 	  locks, so does not service the query pipe on the bg side.
@@ -11615,7 +11615,7 @@
 	- ldns.tgz updated with ldns-trunk (where buffer.h is updated).
 	- fix lint, unit test in optimize mode.
 	- default access control allows ::ffff:127.0.0.1 v6mapped localhost.
-	
+
 11 January 2008: Wouter
 	- man page, warning removed.
 	- added text describing the use of stub zones for private zones.
@@ -11643,7 +11643,7 @@
 
 2 January 2008: Wouter
 	- fixup typo in requirements.
-	- document that 'refused' is a better choice than 'drop' for 
+	- document that 'refused' is a better choice than 'drop' for
 	  the access control list, as refused will stop retries.
 
 7 December 2007: Wouter
@@ -11699,7 +11699,7 @@
 	- library extensive featurelist added to TODO.
 	- please doxygen, lint.
 	- library test application, with basic functionality.
-	- fix for building in a subdirectory. 
+	- fix for building in a subdirectory.
 	- link lib fix for Leopard.
 
 30 November 2007: Wouter
@@ -11753,7 +11753,7 @@
 		* But not: wildcard, nsec, referral, rrsig, cname/dname,
 			or additional section processing, NS put in auth.
 	- test for correct working of static and transparent and couple
-	  of important defaults (localhost, as112, reverses). 
+	  of important defaults (localhost, as112, reverses).
 	  Also checks deny and refuse settings.
 	- fixup implicit zone generation and AA bit for NXDOMAIN on localdata.
 
@@ -11765,7 +11765,7 @@
 	- local-zone and local-data options, config storage and documentation.
 
 19 November 2007: Wouter
-	- do not downcase NSEC and RRSIG for verification. Follows 
+	- do not downcase NSEC and RRSIG for verification. Follows
 	  draft-ietf-dnsext-dnssec-bis-updates-06.txt.
 	- fixup leaking unbound daemons at end of tests.
 	- README file updated.
@@ -11790,7 +11790,7 @@
 
 14 November 2007: Wouter
 	- testbed script does not recreate configure, since its in svn now.
-	- fixup checkconf test so that it does not test 
+	- fixup checkconf test so that it does not test
 	  /etc/unbound/unbound.conf.
 	- tag 0.6.
 
@@ -11811,7 +11811,7 @@
 	  If it doesn't exist, it is installed with the doc/example.conf file.
 	  The file is not deleted on uninstall.
 	- default listening is not all, but localhost interfaces.
-	
+
 8 November 2007: Wouter
 	- Fixup chroot and drop user privileges.
 	- new L root ip address in default hints.
@@ -11875,10 +11875,10 @@
 	- added configure (and its files) to svn, so that the trunk is easier
 	  to use. ./configure, config.guess, config.sub, ltmain.sh,
 	  and config.h.in.
-	- added yacc/lex generated files, util/configlexer.c, 
-	  util/configparser.c util/configparser.h, to svn. 
+	- added yacc/lex generated files, util/configlexer.c,
+	  util/configparser.c util/configparser.h, to svn.
 	- without lex no attempt to use it.
-	- unsecure response validation collated into one block.
+	- insecure response validation collated into one block.
 	- remove warning about const cast of cfgfile name.
 	- outgoing-interfaces can be different from service interfaces.
 	- ldns-src configure is done during unbound configure and
@@ -11886,7 +11886,7 @@
 	  make arguments from the unbound make invocation.
 	- nicer error when libevent problem causes instant exit on signal.
 	- read root hints from a root hint file (like BIND does).
-	  
+
 18 October 2007: Wouter
 	- addresses are logged with errors.
 	- fixup testcode fake event to remove pending before callback
@@ -11919,7 +11919,7 @@
 	- fix crash where failure to prime DNSKEY tried to print null pointer
 	  in the log message.
 	- removed some debug prints, only verb_algo (4) enables them.
-	- fixup test; new random generator took new paths; such as one 
+	- fixup test; new random generator took new paths; such as one
 	  where no scripted answer was available.
 	- mark insecure RRs as insecure.
 	- fixup removal of nonsecure items from the additional.
@@ -12032,7 +12032,7 @@
 	  proof is possible - the signature has been stripped off.
 
 20 September 2007: Wouter
-	- fixup and test for NSEC wildcard with empty nonterminals. 
+	- fixup and test for NSEC wildcard with empty nonterminals.
 	- makedist.sh fixup for svn info.
 	- acl features request in plan.
 	- improved DS empty nonterminal handling.
@@ -12071,7 +12071,7 @@
 
 12 September 2007: Wouter
 	- fixup of manual page warnings, like for NSD bugreport.
-	- nsec3 work, config, max iterations, filter, and hash cache. 
+	- nsec3 work, config, max iterations, filter, and hash cache.
 
 6 September 2007: Wouter
 	- fixup to find libevent on mac port install.
@@ -12114,7 +12114,7 @@
 	  CNAME'd messages.
 
 3 September 2007: Wouter
-	- Fixed error in iterator that would cause assertion failure in 
+	- Fixed error in iterator that would cause assertion failure in
 	  validator. CNAME to a NXDOMAIN response was collated into a response
 	  with both a CNAME and the NXDOMAIN rcode. Added a test that the
 	  rcode is changed to NOERROR (because of the CNAME).
@@ -12126,7 +12126,7 @@
 	- tool too summarize allocations per code line.
 
 31 August 2007: Wouter
-	- can read bind trusted-keys { ... }; files, in a compatibility mode. 
+	- can read bind trusted-keys { ... }; files, in a compatibility mode.
 	- iterator should not detach target queries that it still could need.
 	  the protection against multiple outstanding queries is moved to a
 	  current_query num check.
@@ -12142,7 +12142,7 @@
 	- memory accounting fixup for outside network tcp callbacks.
 	- memory accounting for iterator fixed storage.
 	- key cache size and slabs config options.
-	- lib crypto cleanups at exit. 
+	- lib crypto cleanups at exit.
 
 29 August 2007: Wouter
 	- test tool to sign rrsets for testing validator with.
@@ -12171,7 +12171,7 @@
 	  canonicalization routine will fail if it does not fit in buffer.
 	- faster verification for large sigsets.
 	- verb_detail mode reports validation failures, but not the entire
-	  algorithm for validation. Key prime failures are reported as 
+	  algorithm for validation. Key prime failures are reported as
 	  verb_ops level.
 
 27 August 2007: Wouter
@@ -12186,7 +12186,7 @@
 	  and store this in the cache.
 
 24 August 2007: Wouter
-	- message is bogus if unsecure authority rrsets are present.
+	- message is bogus if insecure authority rrsets are present.
 	- val-clean-additional option, so you can turn it off.
 	- move rrset verification out of the specific proof types into one
 	  routine. This makes the proof routines prettier.
@@ -12203,7 +12203,7 @@
 23 August 2007: Wouter
 	- CNAME handling - move needs_validation to before val_new().
 	  val_new() setups the chase-reply to be an edited copy of the msg.
-	  new classification, and find signer can find for it. 
+	  new classification, and find signer can find for it.
 	  removal of unsigned crap from additional, and query restart for
 	  cname.
 	- refuse to follow wildcarded DNAMEs when validating.
@@ -12339,7 +12339,7 @@
 30 July 2007: Wouter
 	- changed random state init, so that sequential process IDs are not
 	  cancelled out by sequential thread-ids in the random number seed.
-	- the fwd_three test, which sends three queries to unbound, and 
+	- the fwd_three test, which sends three queries to unbound, and
 	  unbound is kept waiting by ldns-testns for 3 seconds, failed
 	  because the retry timeout for default by unbound is 3 seconds too,
 	  it would hit that timeout and fail the test. Changed so that unbound
@@ -12520,7 +12520,7 @@
 7 June 2007: Wouter
 	- fixup error in double linked list insertion for subqueries and
 	  for outbound list of serviced queries for iterator module.
-	- nicer printout of outgoing port selection. 
+	- nicer printout of outgoing port selection.
 	- fixup cname target readout.
 	- nicer debug output.
 	- fixup rrset counts when prepending CNAMEs to the answer.
@@ -12566,7 +12566,7 @@
 	- sanitize incoming messages.
 	- split msgreply encode functions into own file msgencode.c.
 	- msg_parse to queryinfo/replyinfo conversion more versatile.
-	- process_response, classify response, delegpt_from_message. 
+	- process_response, classify response, delegpt_from_message.
 
 31 May 2007: Wouter
 	- querytargets state.
@@ -12635,7 +12635,7 @@
 	  and udp retries and rtt timing.
 
 16 May 2007: Wouter
-	- lruhash_touch() would cause locking order problems. Fixup in 
+	- lruhash_touch() would cause locking order problems. Fixup in
 	  lock-verify in case locking cycle is found.
 	- services/cache/rrset.c for rrset cache code.
 	- special rrset_cache LRU updating function that uses the rrset id.
@@ -12673,7 +12673,7 @@
 	  locks are disabled.
 
 8 May 2007: Wouter
-	- outgoing network keeps list of available tcp buffers for outgoing 
+	- outgoing network keeps list of available tcp buffers for outgoing
 	  tcp queries.
 	- outgoing-num-tcp config option.
 	- outgoing network keeps waiting list of queries waiting for buffer.
@@ -12709,7 +12709,7 @@
 2 May 2007: Wouter
 	- dname unit tests in own file and spread out neatly in functions.
 	- more dname unit tests.
-	- message encoding creates truncated TC flagged messages if they do 
+	- message encoding creates truncated TC flagged messages if they do
 	  not fit, and will leave out (whole)rrsets from additional if needed.
 
 1 May 2007: Wouter
@@ -12789,7 +12789,7 @@
 
 12 April 2007: Wouter
 	- dname compare routine that preserves case, with unit tests.
-	
+
 11 April 2007: Wouter
 	- parse work - dname packet parse, msgparse, querysection parse,
 	  start of sectionparse.
@@ -12817,7 +12817,7 @@
 	  in netevent (which is there to please lint) can be correct.
 	  The type on several OSes ranges from int, int32, uint32, size_t.
 	  Detects unsigned or signed using math trick.
-	- constants for DNS flags. 
+	- constants for DNS flags.
 	- compilation without locks fixup.
 	- removed include of unportable header from lookup3.c.
 	- more portable use of struct msghdr.
@@ -12828,7 +12828,7 @@
 2 April 2007: Wouter
 	- check sizes of udp received messages, not too short.
 	- review changes. Some memmoves can be memcpys: 4byte aligned.
-	  set id correctly on cached answers. 
+	  set id correctly on cached answers.
 	- review changes msgreply.c, memleak on error condition. AA flag
 	  clear on cached reply. Lowercase queries on hashing.
 	  unit test on lowercasing. Test AA bit not set on cached reply.
@@ -12872,7 +12872,7 @@
 	- AIX configure check.
 	- lock-verify can handle references to locks that are created
 	  in files it has not yet read in.
-	- threaded hash table test. 
+	- threaded hash table test.
 	- unit test runs lock-verify afterwards and checks result.
 	- need writelock to update data on hash_insert.
 	- message cache code, msgreply code.
@@ -12914,7 +12914,7 @@
 
 7 March 2007: Wouter
 	- created a wrapper around thread calls that performs some basic
-	  checking for data race and deadlock, and basic performance 
+	  checking for data race and deadlock, and basic performance
 	  contention measurement.
 
 6 March 2007: Wouter
@@ -12939,7 +12939,7 @@
 	- ub_thread_join portable definition.
 	- forking is used if no threading is available.
 	  Tested, it works, since pipes work across processes as well.
-	  Thread_join is replaced with waitpid. 
+	  Thread_join is replaced with waitpid.
 	- During reloads the daemon will temporarily handle signals,
 	  so that they do not result in problems.
 	- Also randomize the outgoing port range for tests.
@@ -12985,7 +12985,7 @@
 
 19 February 2007: Wouter
 	- Created 0.0 svn tag.
-	- added acx_pthread.m4 autoconf check for pthreads from 
+	- added acx_pthread.m4 autoconf check for pthreads from
 	  the autoconf archive. It is GPL-with-autoconf-exception Licensed.
 	  You can specify --with-pthreads, or --without-pthreads to configure.
 

--- a/doc/example.conf.in
+++ b/doc/example.conf.in
@@ -658,7 +658,7 @@ server:
 	# or, just before the iterator).
 	# module-config: "validator iterator"
 
-	# File with trusted keys, kept uptodate using RFC5011 probes,
+	# File with trusted keys, kept up-to-date using RFC5011 probes,
 	# initial file like trust-anchor-file, then it stores metadata.
 	# Use several entries, one per domain name, to track multiple zones.
 	#
@@ -718,7 +718,7 @@ server:
 	# val-max-restart: 5
 
 	# Should additional section of secure message also be kept clean of
-	# unsecure data. Useful to shield the users of this validator from
+	# insecure data. Useful to shield the users of this validator from
 	# potential bogus data in the additional section. All unsigned data
 	# in the additional section is removed from secure messages.
 	# val-clean-additional: yes

--- a/iterator/iter_hints.c
+++ b/iterator/iter_hints.c
@@ -4,22 +4,22 @@
  * Copyright (c) 2007, NLnet Labs. All rights reserved.
  *
  * This software is open source.
- * 
+ *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
  * are met:
- * 
+ *
  * Redistributions of source code must retain the above copyright notice,
  * this list of conditions and the following disclaimer.
- * 
+ *
  * Redistributions in binary form must reproduce the above copyright notice,
  * this list of conditions and the following disclaimer in the documentation
  * and/or other materials provided with the distribution.
- * 
+ *
  * Neither the name of the NLNET LABS nor the names of its contributors may
  * be used to endorse or promote products derived from this software without
  * specific prior written permission.
- * 
+ *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
  * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
  * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
@@ -50,7 +50,7 @@
 #include "sldns/str2wire.h"
 #include "sldns/wire2str.h"
 
-struct iter_hints* 
+struct iter_hints*
 hints_create(void)
 {
 	struct iter_hints* hints = (struct iter_hints*)calloc(1,
@@ -80,10 +80,10 @@ static void hints_del_tree(struct iter_hints* hints)
 	traverse_postorder(&hints->tree, &delhintnode, NULL);
 }
 
-void 
+void
 hints_delete(struct iter_hints* hints)
 {
-	if(!hints) 
+	if(!hints)
 		return;
 	lock_rw_destroy(&hints->lock);
 	hints_del_tree(hints);
@@ -113,8 +113,8 @@ ah(struct delegpt* dp, const char* sv, const char* ip)
 	return 1;
 }
 
-/** obtain compiletime provided root hints */
-static struct delegpt* 
+/** obtain compile time provided root hints */
+static struct delegpt*
 compile_time_root_prime(int do_ip4, int do_ip6)
 {
 	/* from:
@@ -191,7 +191,7 @@ hints_insert(struct iter_hints* hints, uint16_t c, struct delegpt* dp,
 }
 
 /** set stub name */
-static struct delegpt* 
+static struct delegpt*
 read_stubs_name(struct config_stub* s)
 {
 	struct delegpt* dp;
@@ -227,7 +227,7 @@ read_stubs_host(struct config_stub* s, struct delegpt* dp)
 		log_assert(p->str);
 		dname = authextstrtodname(p->str, &port, &tls_auth_name);
 		if(!dname) {
-			log_err("cannot parse stub %s nameserver name: '%s'", 
+			log_err("cannot parse stub %s nameserver name: '%s'",
 				s->name, p->str);
 			return 0;
 		}
@@ -252,7 +252,7 @@ read_stubs_host(struct config_stub* s, struct delegpt* dp)
 }
 
 /** set stub server addresses */
-static int 
+static int
 read_stubs_addr(struct config_stub* s, struct delegpt* dp)
 {
 	struct config_strlist* p;
@@ -262,7 +262,7 @@ read_stubs_addr(struct config_stub* s, struct delegpt* dp)
 	for(p = s->addrs; p; p = p->next) {
 		log_assert(p->str);
 		if(!authextstrtoaddr(p->str, &addr, &addrlen, &auth_name)) {
-			log_err("cannot parse stub %s ip address: '%s'", 
+			log_err("cannot parse stub %s ip address: '%s'",
 				s->name, p->str);
 			return 0;
 		}
@@ -281,7 +281,7 @@ read_stubs_addr(struct config_stub* s, struct delegpt* dp)
 }
 
 /** read stubs config */
-static int 
+static int
 read_stubs(struct iter_hints* hints, struct config_file* cfg)
 {
 	struct config_stub* s;
@@ -311,7 +311,7 @@ read_stubs(struct iter_hints* hints, struct config_file* cfg)
 }
 
 /** read root hints from file */
-static int 
+static int
 read_root_hints(struct iter_hints* hints, char* fname)
 {
 	struct sldns_file_parse_state pstate;
@@ -371,11 +371,11 @@ read_root_hints(struct iter_hints* hints, char* fname)
 			memset(&sa, 0, len);
 			sa.sin_family = AF_INET;
 			sa.sin_port = (in_port_t)htons(UNBOUND_DNS_PORT);
-			memmove(&sa.sin_addr, 
+			memmove(&sa.sin_addr,
 				sldns_wirerr_get_rdata(rr, rr_len, dname_len),
 				INET_SIZE);
 			if(!delegpt_add_target_mlc(dp, rr, dname_len,
-					(struct sockaddr_storage*)&sa, len, 
+					(struct sockaddr_storage*)&sa, len,
 					0, 0)) {
 				log_err("out of memory reading root hints");
 				goto stop_read;
@@ -388,7 +388,7 @@ read_root_hints(struct iter_hints* hints, char* fname)
 			memset(&sa, 0, len);
 			sa.sin6_family = AF_INET6;
 			sa.sin6_port = (in_port_t)htons(UNBOUND_DNS_PORT);
-			memmove(&sa.sin6_addr, 
+			memmove(&sa.sin6_addr,
 				sldns_wirerr_get_rdata(rr, rr_len, dname_len),
 				INET6_SIZE);
 			if(!delegpt_add_target_mlc(dp, rr, dname_len,
@@ -424,7 +424,7 @@ stop_read:
 }
 
 /** read root hints list */
-static int 
+static int
 read_root_hints_list(struct iter_hints* hints, struct config_file* cfg)
 {
 	struct config_strlist* p;
@@ -433,7 +433,7 @@ read_root_hints_list(struct iter_hints* hints, struct config_file* cfg)
 		if(p->str && p->str[0]) {
 			char* f = p->str;
 			if(cfg->chrootdir && cfg->chrootdir[0] &&
-				strncmp(p->str, cfg->chrootdir, 
+				strncmp(p->str, cfg->chrootdir,
 				strlen(cfg->chrootdir)) == 0)
 				f += strlen(cfg->chrootdir);
 			if(!read_root_hints(hints, f))
@@ -443,7 +443,7 @@ read_root_hints_list(struct iter_hints* hints, struct config_file* cfg)
 	return 1;
 }
 
-int 
+int
 hints_apply_cfg(struct iter_hints* hints, struct config_file* cfg)
 {
 	int nolock = 1;
@@ -463,7 +463,7 @@ hints_apply_cfg(struct iter_hints* hints, struct config_file* cfg)
 		return 0;
 	}
 
-	/* use fallback compiletime root hints */
+	/* use fallback compile time root hints */
 	if(!hints_find_root(hints, LDNS_RR_CLASS_IN, nolock)) {
 		struct delegpt* dp = compile_time_root_prime(cfg->do_ip4,
 			cfg->do_ip6);
@@ -507,7 +507,7 @@ hints_find_root(struct iter_hints* hints, uint16_t qclass, int nolock)
 	return hints_find(hints, &rootlab, qclass, nolock);
 }
 
-struct iter_hints_stub* 
+struct iter_hints_stub*
 hints_lookup_stub(struct iter_hints* hints, uint8_t* qname,
 	uint16_t qclass, struct delegpt* cache_dp, int nolock)
 {
@@ -540,8 +540,8 @@ hints_lookup_stub(struct iter_hints* hints, uint8_t* qname,
 	 */
 	if(r->noprime && query_dname_compare(cache_dp->name, r->dp->name)==0)
 		return r; /* use this stub instead of cached dp */
-	
-	/* 
+
+	/*
 	 * If our cached delegation point is above the hint, we need to prime.
 	 */
 	if(dname_strict_subdomain(r->dp->name, r->dp->namelabs,
@@ -561,7 +561,7 @@ int hints_next_root(struct iter_hints* hints, uint16_t* qclass, int nolock)
 	return ret;
 }
 
-size_t 
+size_t
 hints_get_mem(struct iter_hints* hints)
 {
 	size_t s;
@@ -576,7 +576,7 @@ hints_get_mem(struct iter_hints* hints)
 	return s;
 }
 
-int 
+int
 hints_add_stub(struct iter_hints* hints, uint16_t c, struct delegpt* dp,
 	int noprime, int nolock)
 {
@@ -597,7 +597,7 @@ hints_add_stub(struct iter_hints* hints, uint16_t c, struct delegpt* dp,
 	return 1;
 }
 
-void 
+void
 hints_delete_stub(struct iter_hints* hints, uint16_t c, uint8_t* nm,
 	int nolock)
 {

--- a/iterator/iterator.c
+++ b/iterator/iterator.c
@@ -4,22 +4,22 @@
  * Copyright (c) 2007, NLnet Labs. All rights reserved.
  *
  * This software is open source.
- * 
+ *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
  * are met:
- * 
+ *
  * Redistributions of source code must retain the above copyright notice,
  * this list of conditions and the following disclaimer.
- * 
+ *
  * Redistributions in binary form must reproduce the above copyright notice,
  * this list of conditions and the following disclaimer in the documentation
  * and/or other materials provided with the distribution.
- * 
+ *
  * Neither the name of the NLNET LABS nor the names of its contributors may
  * be used to endorse or promote products derived from this software without
  * specific prior written permission.
- * 
+ *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
  * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
  * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
@@ -83,7 +83,7 @@ int PROBE_MAXRTO = PROBE_MAXRTO_DEFAULT; /* in msec */
 
 static void target_count_increase_nx(struct iter_qstate* iq, int num);
 
-int 
+int
 iter_init(struct module_env* env, int id)
 {
 	struct iter_env* iter_env = (struct iter_env*)calloc(1,
@@ -107,7 +107,7 @@ iter_init(struct module_env* env, int id)
 	return 1;
 }
 
-void 
+void
 iter_deinit(struct module_env* env, int id)
 {
 	struct iter_env* iter_env;
@@ -130,7 +130,7 @@ iter_new(struct module_qstate* qstate, int id)
 	struct iter_qstate* iq = (struct iter_qstate*)regional_alloc(
 		qstate->region, sizeof(struct iter_qstate));
 	qstate->minfo[id] = iq;
-	if(!iq) 
+	if(!iq)
 		return 0;
 	memset(iq, 0, sizeof(*iq));
 	iq->state = INIT_REQUEST_STATE;
@@ -163,7 +163,7 @@ iter_new(struct module_qstate* qstate, int id)
 		iq->minimisation_state = INIT_MINIMISE_STATE;
 	else
 		iq->minimisation_state = DONOT_MINIMISE_STATE;
-	
+
 	memset(&iq->qinfo_out, 0, sizeof(struct query_info));
 	return 1;
 }
@@ -227,9 +227,9 @@ error_supers(struct module_qstate* qstate, int id, struct module_qstate* super)
 		qstate->qinfo.qtype == LDNS_RR_TYPE_AAAA) {
 		/* mark address as failed. */
 		struct delegpt_ns* dpns = NULL;
-		super_iq->num_target_queries--; 
+		super_iq->num_target_queries--;
 		if(super_iq->dp)
-			dpns = delegpt_find_ns(super_iq->dp, 
+			dpns = delegpt_find_ns(super_iq->dp,
 				qstate->qinfo.qname, qstate->qinfo.qname_len);
 		if(!dpns) {
 			/* not interested */
@@ -258,7 +258,7 @@ error_supers(struct module_qstate* qstate, int id, struct module_qstate* super)
 		super_iq->dp = NULL;
 	}
 	/* evaluate targets again */
-	super_iq->state = QUERYTARGETS_STATE; 
+	super_iq->state = QUERYTARGETS_STATE;
 	/* super becomes runnable, and will process this change */
 }
 
@@ -268,12 +268,12 @@ error_supers(struct module_qstate* qstate, int id, struct module_qstate* super)
  * @param id: module id
  * @param rcode: error code (DNS errcode).
  * @return: 0 for use by caller, to make notation easy, like:
- * 	return error_response(..). 
+ * 	return error_response(..).
  */
 static int
 error_response(struct module_qstate* qstate, int id, int rcode)
 {
-	verbose(VERB_QUERY, "return error response %s", 
+	verbose(VERB_QUERY, "return error response %s",
 		sldns_lookup_by_id(sldns_rcodes, rcode)?
 		sldns_lookup_by_id(sldns_rcodes, rcode)->name:"??");
 	qstate->return_rcode = rcode;
@@ -289,7 +289,7 @@ error_response(struct module_qstate* qstate, int id, int rcode)
  * @param id: module id
  * @param rcode: error code (DNS errcode).
  * @return: 0 for use by caller, to make notation easy, like:
- * 	return error_response(..). 
+ * 	return error_response(..).
  */
 static int
 error_response_cache(struct module_qstate* qstate, int id, int rcode)
@@ -380,7 +380,7 @@ prepend_is_duplicate(struct ub_packed_rrset_key** sets, size_t to,
 
 /** prepend the prepend list in the answer and authority section of dns_msg */
 static int
-iter_prepend(struct iter_qstate* iq, struct dns_msg* msg, 
+iter_prepend(struct iter_qstate* iq, struct dns_msg* msg,
 	struct regional* region)
 {
 	struct iter_prep_list* p;
@@ -397,7 +397,7 @@ iter_prepend(struct iter_qstate* iq, struct dns_msg* msg,
 		msg->rep->rrset_count > RR_COUNT_MAX) return 0; /* overflow */
 	sets = regional_alloc(region, (num_an+num_ns+msg->rep->rrset_count) *
 		sizeof(struct ub_packed_rrset_key*));
-	if(!sets) 
+	if(!sets)
 		return 0;
 	/* ANSWER section */
 	num_an = 0;
@@ -416,7 +416,7 @@ iter_prepend(struct iter_qstate* iq, struct dns_msg* msg,
 	for(p = iq->ns_prepend_list; p; p = p->next) {
 		if(prepend_is_duplicate(sets+msg->rep->an_numrrsets+num_an,
 			num_ns, p->rrset) || prepend_is_duplicate(
-			msg->rep->rrsets+msg->rep->an_numrrsets, 
+			msg->rep->rrsets+msg->rep->an_numrrsets,
 			msg->rep->ns_numrrsets, p->rrset))
 			continue;
 		sets[msg->rep->an_numrrsets + num_an + num_ns++] = p->rrset;
@@ -426,8 +426,8 @@ iter_prepend(struct iter_qstate* iq, struct dns_msg* msg,
 			msg->rep->serve_expired_ttl = msg->rep->ttl + SERVE_EXPIRED_TTL;
 		}
 	}
-	memcpy(sets + num_an + msg->rep->an_numrrsets + num_ns, 
-		msg->rep->rrsets + msg->rep->an_numrrsets, 
+	memcpy(sets + num_an + msg->rep->an_numrrsets + num_ns,
+		msg->rep->rrsets + msg->rep->an_numrrsets,
 		(msg->rep->ns_numrrsets + msg->rep->ar_numrrsets) *
 		sizeof(struct ub_packed_rrset_key*));
 
@@ -536,13 +536,13 @@ handle_cname_response(struct module_qstate* qstate, struct iter_qstate* iq,
 	*mname = iq->qchase.qname;
 	*mname_len = iq->qchase.qname_len;
 
-	/* Iterate over the ANSWER rrsets in order, looking for CNAMEs and 
+	/* Iterate over the ANSWER rrsets in order, looking for CNAMEs and
 	 * DNAMES. */
 	for(i=0; i<msg->rep->an_numrrsets; i++) {
 		struct ub_packed_rrset_key* r = msg->rep->rrsets[i];
 		/* If there is a (relevant) DNAME, add it to the list.
-		 * We always expect there to be CNAME that was generated 
-		 * by this DNAME following, so we don't process the DNAME 
+		 * We always expect there to be CNAME that was generated
+		 * by this DNAME following, so we don't process the DNAME
 		 * directly.  */
 		if(ntohs(r->rk.type) == LDNS_RR_TYPE_DNAME &&
 			dname_strict_subdomain_c(*mname, r->rk.dname) &&
@@ -794,9 +794,9 @@ target_count_increase_global_quota(struct iter_qstate* iq, int num)
  * @return false on error (malloc).
  */
 static int
-generate_sub_request(uint8_t* qname, size_t qnamelen, uint16_t qtype, 
+generate_sub_request(uint8_t* qname, size_t qnamelen, uint16_t qtype,
 	uint16_t qclass, struct module_qstate* qstate, int id,
-	struct iter_qstate* iq, enum iter_state initial_state, 
+	struct iter_qstate* iq, enum iter_state initial_state,
 	enum iter_state finalstate, struct module_qstate** subq_ret, int v,
 	int detached)
 {
@@ -816,15 +816,15 @@ generate_sub_request(uint8_t* qname, size_t qnamelen, uint16_t qtype,
 	 * state. */
 	if(initial_state == INIT_REQUEST_STATE)
 		qflags |= BIT_RD;
-	/* We set the CD flag so we can send this through the "head" of 
-	 * the resolution chain, which might have a validator. We are 
-	 * uninterested in validating things not on the direct resolution 
+	/* We set the CD flag so we can send this through the "head" of
+	 * the resolution chain, which might have a validator. We are
+	 * uninterested in validating things not on the direct resolution
 	 * path.  */
 	if(!v) {
 		qflags |= BIT_CD;
 		valrec = 1;
 	}
-	
+
 	if(detached) {
 		struct mesh_state* sub = NULL;
 		fptr_ok(fptr_whitelist_modenv_add_sub(
@@ -848,7 +848,7 @@ generate_sub_request(uint8_t* qname, size_t qnamelen, uint16_t qtype,
 		/* initialise the new subquery */
 		subq->curmod = id;
 		subq->ext_state[id] = module_state_initial;
-		subq->minfo[id] = regional_alloc(subq->region, 
+		subq->minfo[id] = regional_alloc(subq->region,
 			sizeof(struct iter_qstate));
 		if(!subq->minfo[id]) {
 			log_err("init subq: out of memory");
@@ -899,7 +899,7 @@ prime_root(struct module_qstate* qstate, struct iter_qstate* iq, int id,
 	struct delegpt* dp;
 	struct module_qstate* subq;
 	int nolock = 0;
-	verbose(VERB_DETAIL, "priming . %s NS", 
+	verbose(VERB_DETAIL, "priming . %s NS",
 		sldns_lookup_by_id(sldns_rr_classes, (int)qclass)?
 		sldns_lookup_by_id(sldns_rr_classes, (int)qclass)->name:"??");
 	dp = hints_find_root(qstate->env->hints, qclass, nolock);
@@ -907,9 +907,9 @@ prime_root(struct module_qstate* qstate, struct iter_qstate* iq, int id,
 		verbose(VERB_ALGO, "Cannot prime due to lack of hints");
 		return 0;
 	}
-	/* Priming requests start at the QUERYTARGETS state, skipping 
+	/* Priming requests start at the QUERYTARGETS state, skipping
 	 * the normal INIT state logic (which would cause an infloop). */
-	if(!generate_sub_request((uint8_t*)"\000", 1, LDNS_RR_TYPE_NS, 
+	if(!generate_sub_request((uint8_t*)"\000", 1, LDNS_RR_TYPE_NS,
 		qclass, qstate, id, iq, QUERYTARGETS_STATE, PRIME_RESP_STATE,
 		&subq, 0, 0)) {
 		lock_rw_unlock(&qstate->env->hints->lock);
@@ -917,10 +917,10 @@ prime_root(struct module_qstate* qstate, struct iter_qstate* iq, int id,
 		return 0;
 	}
 	if(subq) {
-		struct iter_qstate* subiq = 
+		struct iter_qstate* subiq =
 			(struct iter_qstate*)subq->minfo[id];
 		/* Set the initial delegation point to the hint.
-		 * copy dp, it is now part of the root prime query. 
+		 * copy dp, it is now part of the root prime query.
 		 * dp was part of in the fixed hints structure. */
 		subiq->dp = delegpt_copy(dp, subq->region);
 		lock_rw_unlock(&qstate->env->hints->lock);
@@ -932,13 +932,13 @@ prime_root(struct module_qstate* qstate, struct iter_qstate* iq, int id,
 			return 0;
 		}
 		/* there should not be any target queries. */
-		subiq->num_target_queries = 0; 
+		subiq->num_target_queries = 0;
 		subiq->dnssec_expected = iter_indicates_dnssec(
 			qstate->env, subiq->dp, NULL, subq->qinfo.qclass);
 	} else {
 		lock_rw_unlock(&qstate->env->hints->lock);
 	}
-	
+
 	/* this module stops, our submodule starts, and does the query. */
 	qstate->ext_state[id] = module_wait_subquery;
 	return 1;
@@ -962,7 +962,7 @@ static int
 prime_stub(struct module_qstate* qstate, struct iter_qstate* iq, int id,
 	uint8_t* qname, uint16_t qclass)
 {
-	/* Lookup the stub hint. This will return null if the stub doesn't 
+	/* Lookup the stub hint. This will return null if the stub doesn't
 	 * need to be re-primed. */
 	struct iter_hints_stub* stub;
 	struct delegpt* stub_dp;
@@ -977,7 +977,7 @@ prime_stub(struct module_qstate* qstate, struct iter_qstate* iq, int id,
 	stub_dp = stub->dp;
 	/* if we have an auth_zone dp, and stub is equal, don't prime stub
 	 * yet, unless we want to fallback and avoid the auth_zone */
-	if(!iq->auth_zone_avoid && iq->dp && iq->dp->auth_dp && 
+	if(!iq->auth_zone_avoid && iq->dp && iq->dp->auth_dp &&
 		query_dname_compare(iq->dp->name, stub_dp->name) == 0) {
 		lock_rw_unlock(&qstate->env->hints->lock);
 		return 0;
@@ -1003,12 +1003,12 @@ prime_stub(struct module_qstate* qstate, struct iter_qstate* iq, int id,
 	}
 
 	/* Otherwise, we need to (re)prime the stub. */
-	log_nametypeclass(VERB_DETAIL, "priming stub", stub_dp->name, 
+	log_nametypeclass(VERB_DETAIL, "priming stub", stub_dp->name,
 		LDNS_RR_TYPE_NS, qclass);
 
 	/* Stub priming events start at the QUERYTARGETS state to avoid the
 	 * redundant INIT state processing. */
-	if(!generate_sub_request(stub_dp->name, stub_dp->namelen, 
+	if(!generate_sub_request(stub_dp->name, stub_dp->namelen,
 		LDNS_RR_TYPE_NS, qclass, qstate, id, iq,
 		QUERYTARGETS_STATE, PRIME_RESP_STATE, &subq, 0, 0)) {
 		lock_rw_unlock(&qstate->env->hints->lock);
@@ -1018,7 +1018,7 @@ prime_stub(struct module_qstate* qstate, struct iter_qstate* iq, int id,
 		return 1; /* return 1 to make module stop, with error */
 	}
 	if(subq) {
-		struct iter_qstate* subiq = 
+		struct iter_qstate* subiq =
 			(struct iter_qstate*)subq->minfo[id];
 
 		/* Set the initial delegation point to the hint. */
@@ -1034,17 +1034,17 @@ prime_stub(struct module_qstate* qstate, struct iter_qstate* iq, int id,
 			(void)error_response(qstate, id, LDNS_RCODE_SERVFAIL);
 			return 1; /* return 1 to make module stop, with error */
 		}
-		/* there should not be any target queries -- although there 
-		 * wouldn't be anyway, since stub hints never have 
+		/* there should not be any target queries -- although there
+		 * wouldn't be anyway, since stub hints never have
 		 * missing targets. */
-		subiq->num_target_queries = 0; 
+		subiq->num_target_queries = 0;
 		subiq->wait_priming_stub = 1;
 		subiq->dnssec_expected = iter_indicates_dnssec(
 			qstate->env, subiq->dp, NULL, subq->qinfo.qclass);
 	} else {
 		lock_rw_unlock(&qstate->env->hints->lock);
 	}
-	
+
 	/* this module stops, our submodule starts, and does the query. */
 	qstate->ext_state[id] = module_wait_subquery;
 	return 1;
@@ -1151,7 +1151,7 @@ auth_zone_delegpt(struct module_qstate* qstate, struct iter_qstate* iq,
  * @param id: module id.
  */
 static void
-generate_a_aaaa_check(struct module_qstate* qstate, struct iter_qstate* iq, 
+generate_a_aaaa_check(struct module_qstate* qstate, struct iter_qstate* iq,
 	int id)
 {
 	struct iter_env* ie = (struct iter_env*)qstate->env->modinfo[id];
@@ -1176,17 +1176,17 @@ generate_a_aaaa_check(struct module_qstate* qstate, struct iter_qstate* iq,
 		/* is this query the same as the A/AAAA check for it */
 		if(qstate->qinfo.qtype == ntohs(s->rk.type) &&
 			qstate->qinfo.qclass == ntohs(s->rk.rrset_class) &&
-			query_dname_compare(qstate->qinfo.qname, 
+			query_dname_compare(qstate->qinfo.qname,
 				s->rk.dname)==0 &&
-			(qstate->query_flags&BIT_RD) && 
+			(qstate->query_flags&BIT_RD) &&
 			!(qstate->query_flags&BIT_CD))
 			continue;
 
 		/* generate subrequest for it */
-		log_nametypeclass(VERB_ALGO, "schedule addr fetch", 
-			s->rk.dname, ntohs(s->rk.type), 
+		log_nametypeclass(VERB_ALGO, "schedule addr fetch",
+			s->rk.dname, ntohs(s->rk.type),
 			ntohs(s->rk.rrset_class));
-		if(!generate_sub_request(s->rk.dname, s->rk.dname_len, 
+		if(!generate_sub_request(s->rk.dname, s->rk.dname_len,
 			ntohs(s->rk.type), ntohs(s->rk.rrset_class),
 			qstate, id, iq,
 			INIT_REQUEST_STATE, FINISHED_STATE, &subq, 1, 0)) {
@@ -1229,16 +1229,16 @@ generate_ns_check(struct module_qstate* qstate, struct iter_qstate* iq, int id)
 	if(qstate->qinfo.qtype == LDNS_RR_TYPE_DS)
 		return;
 
-	log_nametypeclass(VERB_ALGO, "schedule ns fetch", 
+	log_nametypeclass(VERB_ALGO, "schedule ns fetch",
 		iq->dp->name, LDNS_RR_TYPE_NS, iq->qchase.qclass);
-	if(!generate_sub_request(iq->dp->name, iq->dp->namelen, 
+	if(!generate_sub_request(iq->dp->name, iq->dp->namelen,
 		LDNS_RR_TYPE_NS, iq->qchase.qclass, qstate, id, iq,
 		INIT_REQUEST_STATE, FINISHED_STATE, &subq, 1, 0)) {
 		verbose(VERB_ALGO, "could not generate ns check");
 		return;
 	}
 	if(subq) {
-		struct iter_qstate* subiq = 
+		struct iter_qstate* subiq =
 			(struct iter_qstate*)subq->minfo[id];
 
 		/* make copy to avoid use of stub dp by different qs/threads */
@@ -1272,7 +1272,7 @@ generate_ns_check(struct module_qstate* qstate, struct iter_qstate* iq, int id)
  * @param id: module id.
  */
 static void
-generate_dnskey_prefetch(struct module_qstate* qstate, 
+generate_dnskey_prefetch(struct module_qstate* qstate,
 	struct iter_qstate* iq, int id)
 {
 	struct module_qstate* subq;
@@ -1295,9 +1295,9 @@ generate_dnskey_prefetch(struct module_qstate* qstate,
 		return;
 
 	/* if the DNSKEY is in the cache this lookup will stop quickly */
-	log_nametypeclass(VERB_ALGO, "schedule dnskey prefetch", 
+	log_nametypeclass(VERB_ALGO, "schedule dnskey prefetch",
 		iq->dp->name, LDNS_RR_TYPE_DNSKEY, iq->qchase.qclass);
-	if(!generate_sub_request(iq->dp->name, iq->dp->namelen, 
+	if(!generate_sub_request(iq->dp->name, iq->dp->namelen,
 		LDNS_RR_TYPE_DNSKEY, iq->qchase.qclass, qstate, id, iq,
 		INIT_REQUEST_STATE, FINISHED_STATE, &subq, 0, 0)) {
 		/* we'll be slower, but it'll work */
@@ -1305,7 +1305,7 @@ generate_dnskey_prefetch(struct module_qstate* qstate,
 		return;
 	}
 	if(subq) {
-		struct iter_qstate* subiq = 
+		struct iter_qstate* subiq =
 			(struct iter_qstate*)subq->minfo[id];
 		/* this qstate has the right delegation for the dnskey lookup*/
 		/* make copy to avoid use of stub dp by different qs/threads */
@@ -1316,7 +1316,7 @@ generate_dnskey_prefetch(struct module_qstate* qstate,
 
 /**
  * See if the query needs forwarding.
- * 
+ *
  * @param qstate: query state.
  * @param iq: iterator query state.
  * @return true if the request is forwarded, false if not.
@@ -1341,7 +1341,7 @@ forward_request(struct module_qstate* qstate, struct iter_qstate* iq)
 		nolock);
 	if(!dp) return 0;
 	/* send recursion desired to forward addr */
-	iq->chase_flags |= BIT_RD; 
+	iq->chase_flags |= BIT_RD;
 	iq->dp = delegpt_copy(dp, qstate->region);
 	lock_rw_unlock(&qstate->env->fwds->lock);
 	/* iq->dp checked by caller */
@@ -1349,7 +1349,7 @@ forward_request(struct module_qstate* qstate, struct iter_qstate* iq)
 	return 1;
 }
 
-/** 
+/**
  * Process the initial part of the request handling. This state roughly
  * corresponds to resolver algorithms steps 1 (find answer in cache) and 2
  * (find the best servers to ask).
@@ -1391,9 +1391,9 @@ processInitRequest(struct module_qstate* qstate, struct iter_qstate* iq,
 		return error_response_cache(qstate, id, LDNS_RCODE_SERVFAIL);
 	}
 
-	/* We enforce a maximum recursion/dependency depth -- in general, 
-	 * this is unnecessary for dependency loops (although it will 
-	 * catch those), but it provides a sensible limit to the amount 
+	/* We enforce a maximum recursion/dependency depth -- in general,
+	 * this is unnecessary for dependency loops (although it will
+	 * catch those), but it provides a sensible limit to the amount
 	 * of work required to answer a given query. */
 	verbose(VERB_ALGO, "request has dependency depth of %d", iq->depth);
 	if(iq->depth > ie->max_dependency_depth) {
@@ -1492,8 +1492,8 @@ processInitRequest(struct module_qstate* qstate, struct iter_qstate* iq,
 		verbose(VERB_ALGO, "cache blacklisted, going to the network");
 		msg = NULL;
 	} else if(!qstate->no_cache_lookup) {
-		msg = dns_cache_lookup(qstate->env, iq->qchase.qname, 
-			iq->qchase.qname_len, iq->qchase.qtype, 
+		msg = dns_cache_lookup(qstate->env, iq->qchase.qname,
+			iq->qchase.qname_len, iq->qchase.qtype,
 			iq->qchase.qclass, qstate->query_flags,
 			qstate->region, qstate->env->scratch, 0, dpname,
 			dpnamelen);
@@ -1503,8 +1503,8 @@ processInitRequest(struct module_qstate* qstate, struct iter_qstate* iq,
 			 * NOERROR/NODATA or NXDOMAIN answers that need validation */
 			msg = val_neg_getmsg(qstate->env->neg_cache, &iq->qchase,
 				qstate->region, qstate->env->rrset_cache,
-				qstate->env->scratch_buffer, 
-				*qstate->env->now, 1/*add SOA*/, NULL, 
+				qstate->env->scratch_buffer,
+				*qstate->env->now, 1/*add SOA*/, NULL,
 				qstate->env->cfg);
 		}
 		/* item taken from cache does not match our query name, thus
@@ -1515,13 +1515,13 @@ processInitRequest(struct module_qstate* qstate, struct iter_qstate* iq,
 	}
 	if(msg) {
 		/* handle positive cache response */
-		enum response_type type = response_type_from_cache(msg, 
+		enum response_type type = response_type_from_cache(msg,
 			&iq->qchase);
 		if(verbosity >= VERB_ALGO) {
-			log_dns_msg("msg from cache lookup", &msg->qinfo, 
+			log_dns_msg("msg from cache lookup", &msg->qinfo,
 				msg->rep);
-			verbose(VERB_ALGO, "msg ttl is %d, prefetch ttl %d", 
-				(int)msg->rep->ttl, 
+			verbose(VERB_ALGO, "msg ttl is %d, prefetch ttl %d",
+				(int)msg->rep->ttl,
 				(int)msg->rep->prefetch_ttl);
 		}
 
@@ -1530,16 +1530,16 @@ processInitRequest(struct module_qstate* qstate, struct iter_qstate* iq,
 			size_t slen = 0;
 			verbose(VERB_ALGO, "returning CNAME response from "
 				"cache");
-			if(!handle_cname_response(qstate, iq, msg, 
+			if(!handle_cname_response(qstate, iq, msg,
 				&sname, &slen)) {
 				errinf(qstate, "failed to prepend CNAME "
 					"components, malloc failure");
-				return error_response(qstate, id, 
+				return error_response(qstate, id,
 					LDNS_RCODE_SERVFAIL);
 			}
 			iq->qchase.qname = sname;
 			iq->qchase.qname_len = slen;
-			/* This *is* a query restart, even if it is a cheap 
+			/* This *is* a query restart, even if it is a cheap
 			 * one. */
 			iq->dp = NULL;
 			iq->refetch_glue = 0;
@@ -1591,14 +1591,14 @@ processInitRequest(struct module_qstate* qstate, struct iter_qstate* iq,
 		iq->refetch_glue = 0;
 		iq->minimisation_state = DONOT_MINIMISE_STATE;
 		/* the request has been forwarded.
-		 * forwarded requests need to be immediately sent to the 
+		 * forwarded requests need to be immediately sent to the
 		 * next state, QUERYTARGETS. */
 		return next_state(iq, QUERYTARGETS_STATE);
 	}
 
 	/* Resolver Algorithm Step 2 -- find the "best" servers. */
 
-	/* first, adjust for DS queries. To avoid the grandparent problem, 
+	/* first, adjust for DS queries. To avoid the grandparent problem,
 	 * we just look for the closest set of server to the parent of qname.
 	 * When re-fetching glue we also need to ask the parent.
 	 */
@@ -1630,25 +1630,25 @@ processInitRequest(struct module_qstate* qstate, struct iter_qstate* iq,
 	}
 	/* delname is the name to lookup a delegation for. If NULL rootprime */
 	while(1) {
-		
-		/* Lookup the delegation in the cache. If null, then the 
+
+		/* Lookup the delegation in the cache. If null, then the
 		 * cache needs to be primed for the qclass. */
 		if(delname)
-		     iq->dp = dns_cache_find_delegation(qstate->env, delname, 
-			delnamelen, iq->qchase.qtype, iq->qchase.qclass, 
+		     iq->dp = dns_cache_find_delegation(qstate->env, delname,
+			delnamelen, iq->qchase.qtype, iq->qchase.qclass,
 			qstate->region, &iq->deleg_msg,
 			*qstate->env->now+qstate->prefetch_leeway, 1,
 			dpname, dpnamelen);
 		else iq->dp = NULL;
 
-		/* If the cache has returned nothing, then we have a 
+		/* If the cache has returned nothing, then we have a
 		 * root priming situation. */
 		if(iq->dp == NULL) {
 			int r;
 			int nolock = 0;
 			/* if under auth zone, no prime needed */
 			if(!auth_zone_delegpt(qstate, iq, delname, delnamelen))
-				return error_response(qstate, id, 
+				return error_response(qstate, id,
 					LDNS_RCODE_SERVFAIL);
 			if(iq->dp) /* use auth zone dp */
 				return next_state(iq, INIT_REQUEST_2_STATE);
@@ -1677,7 +1677,7 @@ processInitRequest(struct module_qstate* qstate, struct iter_qstate* iq,
 				if(!iq->dp) {
 					log_err("out of memory in safety belt");
 					errinf(qstate, "malloc failure, in safety belt");
-					return error_response(qstate, id, 
+					return error_response(qstate, id,
 						LDNS_RCODE_SERVFAIL);
 				}
 				return next_state(iq, INIT_REQUEST_2_STATE);
@@ -1685,12 +1685,12 @@ processInitRequest(struct module_qstate* qstate, struct iter_qstate* iq,
 			/* Note that the result of this will set a new
 			 * DelegationPoint based on the result of priming. */
 			if(!prime_root(qstate, iq, id, iq->qchase.qclass))
-				return error_response(qstate, id, 
+				return error_response(qstate, id,
 					LDNS_RCODE_REFUSED);
 
-			/* priming creates and sends a subordinate query, with 
-			 * this query as the parent. So further processing for 
-			 * this event will stop until reactivated by the 
+			/* priming creates and sends a subordinate query, with
+			 * this query as the parent. So further processing for
+			 * this event will stop until reactivated by the
 			 * results of priming. */
 			return 0;
 		}
@@ -1734,7 +1734,7 @@ processInitRequest(struct module_qstate* qstate, struct iter_qstate* iq,
 				errinf(qstate, "no useful nameservers, "
 					"and cannot go up");
 				errinf_dname(qstate, "for zone", iq->dp->name);
-				return error_response(qstate, id, 
+				return error_response(qstate, id,
 					LDNS_RCODE_SERVFAIL);
 			}
 			if(dname_is_root(iq->dp->name)) {
@@ -1748,7 +1748,7 @@ processInitRequest(struct module_qstate* qstate, struct iter_qstate* iq,
 				 * but RD is on, so it is not used */
 				if(!iq->dp) {
 					log_err("internal error: no hints dp");
-					return error_response(qstate, id, 
+					return error_response(qstate, id,
 						LDNS_RCODE_REFUSED);
 				}
 				iq->dp = delegpt_copy(iq->dp, qstate->region);
@@ -1756,12 +1756,12 @@ processInitRequest(struct module_qstate* qstate, struct iter_qstate* iq,
 				if(!iq->dp) {
 					log_err("out of memory in safety belt");
 					errinf(qstate, "malloc failure, in safety belt, for root");
-					return error_response(qstate, id, 
+					return error_response(qstate, id,
 						LDNS_RCODE_SERVFAIL);
 				}
 				break;
 			} else {
-				verbose(VERB_ALGO, 
+				verbose(VERB_ALGO,
 					"cache delegation was useless:");
 				delegpt_log(VERB_ALGO, iq->dp);
 				/* go up */
@@ -1775,12 +1775,12 @@ processInitRequest(struct module_qstate* qstate, struct iter_qstate* iq,
 	verbose(VERB_ALGO, "cache delegation returns delegpt");
 	delegpt_log(VERB_ALGO, iq->dp);
 
-	/* Otherwise, set the current delegation point and move on to the 
+	/* Otherwise, set the current delegation point and move on to the
 	 * next state. */
 	return next_state(iq, INIT_REQUEST_2_STATE);
 }
 
-/** 
+/**
  * Process the second part of the initial request handling. This state
  * basically exists so that queries that generate root priming events have
  * the same init processing as ones that do not. Request events that reach
@@ -1801,7 +1801,7 @@ processInitRequest2(struct module_qstate* qstate, struct iter_qstate* iq,
 {
 	uint8_t* delname;
 	size_t delnamelen;
-	log_query_info(VERB_QUERY, "resolving (init part 2): ", 
+	log_query_info(VERB_QUERY, "resolving (init part 2): ",
 		&qstate->qinfo);
 
 	delname = iq->qchase.qname;
@@ -1819,7 +1819,7 @@ processInitRequest2(struct module_qstate* qstate, struct iter_qstate* iq,
 		stub = hints_lookup_stub(
 			qstate->env->hints, iq->qchase.qname, iq->qchase.qclass,
 			iq->dp, nolock);
-		if(!stub || !stub->dp->has_parent_side_NS || 
+		if(!stub || !stub->dp->has_parent_side_NS ||
 			dname_subdomain_c(iq->dp->name, stub->dp->name)) {
 			delname = iq->dp->name;
 			delnamelen = iq->dp->namelen;
@@ -1848,7 +1848,7 @@ processInitRequest2(struct module_qstate* qstate, struct iter_qstate* iq,
 	return next_state(iq, INIT_REQUEST_3_STATE);
 }
 
-/** 
+/**
  * Process the third part of the initial request handling. This state exists
  * as a separate state so that queries that generate stub priming events
  * will get the tail end of the init process but not repeat the stub priming
@@ -1860,28 +1860,28 @@ processInitRequest2(struct module_qstate* qstate, struct iter_qstate* iq,
  * @return true, advancing the event to the QUERYTARGETS_STATE.
  */
 static int
-processInitRequest3(struct module_qstate* qstate, struct iter_qstate* iq, 
+processInitRequest3(struct module_qstate* qstate, struct iter_qstate* iq,
 	int id)
 {
-	log_query_info(VERB_QUERY, "resolving (init part 3): ", 
+	log_query_info(VERB_QUERY, "resolving (init part 3): ",
 		&qstate->qinfo);
 	/* if the cache reply dp equals a validation anchor or msg has DS,
 	 * then DNSSEC RRSIGs are expected in the reply */
-	iq->dnssec_expected = iter_indicates_dnssec(qstate->env, iq->dp, 
+	iq->dnssec_expected = iter_indicates_dnssec(qstate->env, iq->dp,
 		iq->deleg_msg, iq->qchase.qclass);
 
-	/* If the RD flag wasn't set, then we just finish with the 
+	/* If the RD flag wasn't set, then we just finish with the
 	 * cached referral as the response. */
 	if(!(qstate->query_flags & BIT_RD) && iq->deleg_msg) {
 		iq->response = iq->deleg_msg;
 		if(verbosity >= VERB_ALGO && iq->response)
-			log_dns_msg("no RD requested, using delegation msg", 
+			log_dns_msg("no RD requested, using delegation msg",
 				&iq->response->qinfo, iq->response->rep);
 		if(qstate->reply_origin)
 			sock_list_insert(&qstate->reply_origin, NULL, 0, qstate->region);
 		return final_state(iq);
 	}
-	/* After this point, unset the RD flag -- this query is going to 
+	/* After this point, unset the RD flag -- this query is going to
 	 * be sent to an auth. server. */
 	iq->chase_flags &= ~BIT_RD;
 
@@ -1899,7 +1899,7 @@ processInitRequest3(struct module_qstate* qstate, struct iter_qstate* iq,
 }
 
 /**
- * Given a basic query, generate a parent-side "target" query. 
+ * Given a basic query, generate a parent-side "target" query.
  * These are subordinate queries for missing delegation point target addresses,
  * for which only the parent of the delegation provides correct IP addresses.
  *
@@ -1913,16 +1913,16 @@ processInitRequest3(struct module_qstate* qstate, struct iter_qstate* iq,
  * @return true on success, false on failure.
  */
 static int
-generate_parentside_target_query(struct module_qstate* qstate, 
-	struct iter_qstate* iq, int id, uint8_t* name, size_t namelen, 
+generate_parentside_target_query(struct module_qstate* qstate,
+	struct iter_qstate* iq, int id, uint8_t* name, size_t namelen,
 	uint16_t qtype, uint16_t qclass)
 {
 	struct module_qstate* subq;
-	if(!generate_sub_request(name, namelen, qtype, qclass, qstate, 
+	if(!generate_sub_request(name, namelen, qtype, qclass, qstate,
 		id, iq, INIT_REQUEST_STATE, FINISHED_STATE, &subq, 0, 0))
 		return 0;
 	if(subq) {
-		struct iter_qstate* subiq = 
+		struct iter_qstate* subiq =
 			(struct iter_qstate*)subq->minfo[id];
 		/* blacklist the cache - we want to fetch parent stuff */
 		sock_list_insert(&subq->blacklist, NULL, 0, subq->region);
@@ -1930,19 +1930,19 @@ generate_parentside_target_query(struct module_qstate* qstate,
 		if(dname_subdomain_c(name, iq->dp->name)) {
 			subiq->dp = delegpt_copy(iq->dp, subq->region);
 			subiq->dnssec_expected = iter_indicates_dnssec(
-				qstate->env, subiq->dp, NULL, 
+				qstate->env, subiq->dp, NULL,
 				subq->qinfo.qclass);
 			subiq->refetch_glue = 1;
 		} else {
-			subiq->dp = dns_cache_find_delegation(qstate->env, 
+			subiq->dp = dns_cache_find_delegation(qstate->env,
 				name, namelen, qtype, qclass, subq->region,
 				&subiq->deleg_msg,
 				*qstate->env->now+subq->prefetch_leeway,
 				1, NULL, 0);
 			/* if no dp, then it's from root, refetch unneeded */
-			if(subiq->dp) { 
+			if(subiq->dp) {
 				subiq->dnssec_expected = iter_indicates_dnssec(
-					qstate->env, subiq->dp, NULL, 
+					qstate->env, subiq->dp, NULL,
 					subq->qinfo.qclass);
 				subiq->refetch_glue = 1;
 			}
@@ -1970,7 +1970,7 @@ generate_target_query(struct module_qstate* qstate, struct iter_qstate* iq,
         int id, uint8_t* name, size_t namelen, uint16_t qtype, uint16_t qclass)
 {
 	struct module_qstate* subq;
-	if(!generate_sub_request(name, namelen, qtype, qclass, qstate, 
+	if(!generate_sub_request(name, namelen, qtype, qclass, qstate,
 		id, iq, INIT_REQUEST_STATE, FINISHED_STATE, &subq, 0, 0))
 		return 0;
 	log_nametypeclass(VERB_QUERY, "new target", name, qtype, qclass);
@@ -1987,7 +1987,7 @@ generate_target_query(struct module_qstate* qstate, struct iter_qstate* iq,
  * @param id: module id.
  * @param maxtargets: The maximum number of targets to query for.
  *	if it is negative, there is no maximum number of targets.
- * @param num: returns the number of queries generated and processed, 
+ * @param num: returns the number of queries generated and processed,
  *	which may be zero if there were no missing targets.
  * @return 0 on success, nonzero on error. 1 means temporary failure and
  * 	2 means the failure can be cached.
@@ -2058,7 +2058,7 @@ query_for_targets(struct module_qstate* qstate, struct iter_qstate* iq,
 			((ns->lame && !ns->done_pside6) ||
 			(!ns->lame && !ns->got6))) {
 			/* Send the AAAA request. */
-			if(!generate_target_query(qstate, iq, id, 
+			if(!generate_target_query(qstate, iq, id,
 				ns->name, ns->namelen,
 				LDNS_RR_TYPE_AAAA, iq->qchase.qclass)) {
 				*num = query_count;
@@ -2088,8 +2088,8 @@ query_for_targets(struct module_qstate* qstate, struct iter_qstate* iq,
 		if((ie->supports_ipv4 || ie->nat64.use_nat64) &&
 			((ns->lame && !ns->done_pside4) ||
 			(!ns->lame && !ns->got4))) {
-			if(!generate_target_query(qstate, iq, id, 
-				ns->name, ns->namelen, 
+			if(!generate_target_query(qstate, iq, id,
+				ns->name, ns->namelen,
 				LDNS_RR_TYPE_A, iq->qchase.qclass)) {
 				*num = query_count;
 				if(query_count > 0)
@@ -2131,7 +2131,7 @@ query_for_targets(struct module_qstate* qstate, struct iter_qstate* iq,
  * @param ie: iterator shared global environment.
  * @param id: module id.
  * @return true if the event requires more request processing immediately,
- *         false if not. 
+ *         false if not.
  */
 static int
 processLastResort(struct module_qstate* qstate, struct iter_qstate* iq,
@@ -2144,7 +2144,7 @@ processLastResort(struct module_qstate* qstate, struct iter_qstate* iq,
 
 	if(!can_have_last_resort(qstate->env, iq->dp->name, iq->dp->namelen,
 		iq->qchase.qclass, NULL, NULL, NULL)) {
-		/* fail -- no more targets, no more hope of targets, no hope 
+		/* fail -- no more targets, no more hope of targets, no hope
 		 * of a response. */
 		errinf(qstate, "all the configured stub or forward servers failed,");
 		errinf_dname(qstate, "at zone", iq->dp->name);
@@ -2189,7 +2189,7 @@ processLastResort(struct module_qstate* qstate, struct iter_qstate* iq,
 		iq->dp->has_parent_side_NS = 1;
 	} else if(!iq->dp->has_parent_side_NS) {
 		if(!iter_lookup_parent_NS_from_cache(qstate->env, iq->dp,
-			qstate->region, &qstate->qinfo) 
+			qstate->region, &qstate->qinfo)
 			|| !iq->dp->has_parent_side_NS) {
 			/* if: malloc failure in lookup go up to try */
 			/* if: no parent NS in cache - go up one level */
@@ -2207,7 +2207,7 @@ processLastResort(struct module_qstate* qstate, struct iter_qstate* iq,
 		}
 	}
 	/* see if that makes new names available */
-	if(!cache_fill_missing(qstate->env, iq->qchase.qclass, 
+	if(!cache_fill_missing(qstate->env, iq->qchase.qclass,
 		qstate->region, iq->dp, 0))
 		log_err("out of memory in cache_fill_missing");
 	if(iq->dp->usable_list) {
@@ -2275,7 +2275,7 @@ processLastResort(struct module_qstate* qstate, struct iter_qstate* iq,
 		/* query for parent-side A and AAAA for nameservers */
 		if(ie->supports_ipv6 && !ns->done_pside6) {
 			/* Send the AAAA request. */
-			if(!generate_parentside_target_query(qstate, iq, id, 
+			if(!generate_parentside_target_query(qstate, iq, id,
 				ns->name, ns->namelen,
 				LDNS_RR_TYPE_AAAA, iq->qchase.qclass)) {
 				errinf_dname(qstate, "could not generate nameserver AAAA lookup for", ns->name);
@@ -2296,8 +2296,8 @@ processLastResort(struct module_qstate* qstate, struct iter_qstate* iq,
 		}
 		if((ie->supports_ipv4 || ie->nat64.use_nat64) && !ns->done_pside4) {
 			/* Send the A request. */
-			if(!generate_parentside_target_query(qstate, iq, id, 
-				ns->name, ns->namelen, 
+			if(!generate_parentside_target_query(qstate, iq, id,
+				ns->name, ns->namelen,
 				LDNS_RR_TYPE_A, iq->qchase.qclass)) {
 				errinf_dname(qstate, "could not generate nameserver A lookup for", ns->name);
 				return error_response(qstate, id,
@@ -2327,18 +2327,18 @@ processLastResort(struct module_qstate* qstate, struct iter_qstate* iq,
 	errinf_dname(qstate, "at zone", iq->dp->name);
 	errinf_reply(qstate, iq);
 	verbose(VERB_QUERY, "out of query targets -- returning SERVFAIL");
-	/* fail -- no more targets, no more hope of targets, no hope 
+	/* fail -- no more targets, no more hope of targets, no hope
 	 * of a response. */
 	return error_response_cache(qstate, id, LDNS_RCODE_SERVFAIL);
 }
 
-/** 
+/**
  * Try to find the NS record set that will resolve a qtype DS query. Due
  * to grandparent/grandchild reasons we did not get a proper lookup right
  * away.  We need to create type NS queries until we get the right parent
  * for this lookup.  We remove labels from the query to find the right point.
  * If we end up at the old dp name, then there is no solution.
- * 
+ *
  * @param qstate: query state.
  * @param iq: iterator query state.
  * @param id: module id.
@@ -2366,7 +2366,7 @@ processDSNSFind(struct module_qstate* qstate, struct iter_qstate* iq, int id)
 	/* go up one (more) step, until we hit the dp, if so, end */
 	dname_remove_label(&iq->dsns_point, &iq->dsns_point_len);
 	if(query_dname_compare(iq->dsns_point, iq->dp->name) == 0) {
-		/* there was no inbetween nameserver, use the old delegation
+		/* there was no in between nameserver, use the old delegation
 		 * point again.  And this time, because dsns_point is nonNULL
 		 * we are going to accept the (bad) result */
 		iq->state = QUERYTARGETS_STATE;
@@ -2375,9 +2375,9 @@ processDSNSFind(struct module_qstate* qstate, struct iter_qstate* iq, int id)
 	iq->state = DSNS_FIND_STATE;
 
 	/* spawn NS lookup (validation not needed, this is for DS lookup) */
-	log_nametypeclass(VERB_ALGO, "fetch nameservers", 
+	log_nametypeclass(VERB_ALGO, "fetch nameservers",
 		iq->dsns_point, LDNS_RR_TYPE_NS, iq->qchase.qclass);
-	if(!generate_sub_request(iq->dsns_point, iq->dsns_point_len, 
+	if(!generate_sub_request(iq->dsns_point, iq->dsns_point_len,
 		LDNS_RR_TYPE_NS, iq->qchase.qclass, qstate, id, iq,
 		INIT_REQUEST_STATE, FINISHED_STATE, &subq, 0, 0)) {
 		errinf_dname(qstate, "for DS query parent-child nameserver search, could not generate NS lookup for", iq->dsns_point);
@@ -2412,8 +2412,8 @@ check_waiting_queries(struct iter_qstate* iq, struct module_qstate* qstate,
 		qstate->ext_state[id] = module_wait_reply;
 	}
 }
-	
-/** 
+
+/**
  * This is the request event state where the request will be sent to one of
  * its current query targets. This state also handles issuing target lookup
  * queries for missing target IP addresses. Queries typically iterate on
@@ -2449,7 +2449,7 @@ processQueryTargets(struct module_qstate* qstate, struct iter_qstate* iq,
 
 	log_query_info(VERB_QUERY, "processQueryTargets:", &qstate->qinfo);
 	verbose(VERB_ALGO, "processQueryTargets: targetqueries %d, "
-		"currentqueries %d sentcount %d", iq->num_target_queries, 
+		"currentqueries %d sentcount %d", iq->num_target_queries,
 		iq->num_current_queries, iq->sent_count);
 
 	/* Make sure that we haven't run away */
@@ -2551,7 +2551,7 @@ processQueryTargets(struct module_qstate* qstate, struct iter_qstate* iq,
 			}
 		}
 	}
-	
+
 	/* Make sure we have a delegation point, otherwise priming failed
 	 * or another failure occurred */
 	if(!iq->dp) {
@@ -2580,10 +2580,10 @@ processQueryTargets(struct module_qstate* qstate, struct iter_qstate* iq,
 		 * qinfo_out is already a subdomain of dp. This happens when
 		 * increasing by more than one label at once (QNAMEs with more
 		 * than MAX_MINIMISE_COUNT labels). */
-		if(!(iq->qinfo_out.qname_len 
-			&& dname_subdomain_c(iq->qchase.qname, 
+		if(!(iq->qinfo_out.qname_len
+			&& dname_subdomain_c(iq->qchase.qname,
 				iq->qinfo_out.qname)
-			&& dname_subdomain_c(iq->qinfo_out.qname, 
+			&& dname_subdomain_c(iq->qinfo_out.qname,
 				iq->dp->name))) {
 			iq->qinfo_out.qname = iq->dp->name;
 			iq->qinfo_out.qname_len = iq->dp->namelen;
@@ -2613,15 +2613,15 @@ processQueryTargets(struct module_qstate* qstate, struct iter_qstate* iq,
 		 * than MAX_MINIMISE_COUNT labels. Send first MINIMISE_ONE_LAB
 		 * labels of QNAME always individually.
 		 */
-		if(qchaselabs > MAX_MINIMISE_COUNT && labdiff > 1 && 
+		if(qchaselabs > MAX_MINIMISE_COUNT && labdiff > 1 &&
 			iq->minimise_count > MINIMISE_ONE_LAB) {
 			if(iq->minimise_count < MAX_MINIMISE_COUNT) {
-				int multilabs = qchaselabs - 1 - 
+				int multilabs = qchaselabs - 1 -
 					MINIMISE_ONE_LAB;
-				int extralabs = multilabs / 
+				int extralabs = multilabs /
 					MINIMISE_MULTIPLE_LABS;
 
-				if (MAX_MINIMISE_COUNT - iq->minimise_count >= 
+				if (MAX_MINIMISE_COUNT - iq->minimise_count >=
 					multilabs % MINIMISE_MULTIPLE_LABS)
 					/* Default behaviour is to add 1 label
 					 * every iteration. Therefore, decrement
@@ -2640,25 +2640,25 @@ processQueryTargets(struct module_qstate* qstate, struct iter_qstate* iq,
 
 		if(labdiff > 1) {
 			verbose(VERB_QUERY, "removing %d labels", labdiff-1);
-			dname_remove_labels(&iq->qinfo_out.qname, 
-				&iq->qinfo_out.qname_len, 
+			dname_remove_labels(&iq->qinfo_out.qname,
+				&iq->qinfo_out.qname_len,
 				labdiff-1);
 		}
-		if(labdiff < 1 || (labdiff < 2 
+		if(labdiff < 1 || (labdiff < 2
 			&& (iq->qchase.qtype == LDNS_RR_TYPE_DS
 			|| iq->qchase.qtype == LDNS_RR_TYPE_A)))
 			/* Stop minimising this query, resolve "as usual" */
 			iq->minimisation_state = DONOT_MINIMISE_STATE;
 		else if(!qstate->no_cache_lookup) {
-			struct dns_msg* msg = dns_cache_lookup(qstate->env, 
-				iq->qinfo_out.qname, iq->qinfo_out.qname_len, 
-				iq->qinfo_out.qtype, iq->qinfo_out.qclass, 
-				qstate->query_flags, qstate->region, 
+			struct dns_msg* msg = dns_cache_lookup(qstate->env,
+				iq->qinfo_out.qname, iq->qinfo_out.qname_len,
+				iq->qinfo_out.qtype, iq->qinfo_out.qclass,
+				qstate->query_flags, qstate->region,
 				qstate->env->scratch, 0, iq->dp->name,
 				iq->dp->namelen);
 			if(msg && FLAGS_GET_RCODE(msg->rep->flags) ==
 				LDNS_RCODE_NOERROR)
-				/* no need to send query if it is already 
+				/* no need to send query if it is already
 				 * cached as NOERROR */
 				return 1;
 			if(msg && FLAGS_GET_RCODE(msg->rep->flags) ==
@@ -2695,7 +2695,7 @@ processQueryTargets(struct module_qstate* qstate, struct iter_qstate* iq,
 	}
 	if(iq->minimisation_state == SKIP_MINIMISE_STATE) {
 		if(iq->timeout_count < MAX_MINIMISE_TIMEOUT_COUNT)
-			/* Do not increment qname, continue incrementing next 
+			/* Do not increment qname, continue incrementing next
 			 * iteration */
 			iq->minimisation_state = MINIMISE_STATE;
 		else if(!qstate->env->cfg->qname_minimisation_strict)
@@ -2811,7 +2811,7 @@ processQueryTargets(struct module_qstate* qstate, struct iter_qstate* iq,
 			/* *2 on sentcount check because ipv6 may fail */
 			/* we're done, process the response */
 			verbose(VERB_ALGO, "0x20 fallback had %d responses "
-				"match for %d wanted, done.", 
+				"match for %d wanted, done.",
 				(int)iq->caps_server+1, (int)naddr*3);
 			iq->response = iq->caps_response;
 			iq->caps_fallback = 0;
@@ -2823,16 +2823,16 @@ processQueryTargets(struct module_qstate* qstate, struct iter_qstate* iq,
 			iq->state = QUERY_RESP_STATE;
 			return 1;
 		}
-		verbose(VERB_ALGO, "0x20 fallback number %d", 
+		verbose(VERB_ALGO, "0x20 fallback number %d",
 			(int)iq->caps_server);
 
-	/* if there is a policy to fetch missing targets 
-	 * opportunistically, do it. we rely on the fact that once a 
-	 * query (or queries) for a missing name have been issued, 
+	/* if there is a policy to fetch missing targets
+	 * opportunistically, do it. we rely on the fact that once a
+	 * query (or queries) for a missing name have been issued,
 	 * they will not show up again. */
 	} else if(tf_policy != 0) {
 		int extra = 0;
-		verbose(VERB_ALGO, "attempt to get extra %d targets", 
+		verbose(VERB_ALGO, "attempt to get extra %d targets",
 			tf_policy);
 		(void)query_for_targets(qstate, iq, ie, id, tf_policy, &extra);
 		/* errors ignored, these targets are not strictly necessary for
@@ -2913,24 +2913,24 @@ processQueryTargets(struct module_qstate* qstate, struct iter_qstate* iq,
 
 	/* If no usable target was selected... */
 	if(!target) {
-		/* Here we distinguish between three states: generate a new 
+		/* Here we distinguish between three states: generate a new
 		 * target query, just wait, or quit (with a SERVFAIL).
-		 * We have the following information: number of active 
-		 * target queries, number of active current queries, 
-		 * the presence of missing targets at this delegation 
+		 * We have the following information: number of active
+		 * target queries, number of active current queries,
+		 * the presence of missing targets at this delegation
 		 * point, and the given query target policy. */
-		
-		/* Check for the wait condition. If this is true, then 
+
+		/* Check for the wait condition. If this is true, then
 		 * an action must be taken. */
 		if(iq->num_target_queries==0 && iq->num_current_queries==0) {
-			/* If there is nothing to wait for, then we need 
-			 * to distinguish between generating (a) new target 
+			/* If there is nothing to wait for, then we need
+			 * to distinguish between generating (a) new target
 			 * query, or failing. */
 			if(delegpt_count_missing_targets(iq->dp, NULL) > 0) {
 				int qs = 0, ret;
 				verbose(VERB_ALGO, "querying for next "
 					"missing target");
-				if((ret=query_for_targets(qstate, iq, ie, id, 
+				if((ret=query_for_targets(qstate, iq, ie, id,
 					1, &qs))!=0) {
 					errinf(qstate, "could not fetch nameserver");
 					errinf_dname(qstate, "at zone", iq->dp->name);
@@ -2940,7 +2940,7 @@ processQueryTargets(struct module_qstate* qstate, struct iter_qstate* iq,
 					return error_response_cache(qstate, id,
 						LDNS_RCODE_SERVFAIL);
 				}
-				if(qs == 0 && 
+				if(qs == 0 &&
 				   delegpt_count_missing_targets(iq->dp, NULL) == 0){
 					/* it looked like there were missing
 					 * targets, but they did not turn up.
@@ -2963,7 +2963,7 @@ processQueryTargets(struct module_qstate* qstate, struct iter_qstate* iq,
 				iq->num_target_queries += qs;
 				target_count_increase(iq, qs);
 			}
-			/* Since a target query might have been made, we 
+			/* Since a target query might have been made, we
 			 * need to check again. */
 			if(iq->num_target_queries == 0) {
 				/* if in capsforid fallback, instead of last
@@ -2973,7 +2973,7 @@ processQueryTargets(struct module_qstate* qstate, struct iter_qstate* iq,
 					/* we're done, process the response */
 					verbose(VERB_ALGO, "0x20 fallback had %d responses, "
 						"but no more servers except "
-						"last resort, done.", 
+						"last resort, done.",
 						(int)iq->caps_server+1);
 					iq->response = iq->caps_response;
 					iq->caps_fallback = 0;
@@ -2989,7 +2989,7 @@ processQueryTargets(struct module_qstate* qstate, struct iter_qstate* iq,
 			}
 		}
 
-		/* otherwise, we have no current targets, so submerge 
+		/* otherwise, we have no current targets, so submerge
 		 * until one of the target or direct queries return. */
 		verbose(VERB_ALGO, "no current targets");
 		check_waiting_queries(iq, qstate, id);
@@ -3112,12 +3112,12 @@ find_NS(struct reply_info* rep, size_t from, size_t to)
 }
 
 
-/** 
+/**
  * Process the query response. All queries end up at this state first. This
  * process generally consists of analyzing the response and routing the
  * event to the next state (either bouncing it back to a request state, or
  * terminating the processing for this event).
- * 
+ *
  * @param qstate: query state.
  * @param iq: iterator query state.
  * @param ie: iterator shared global environment.
@@ -3171,17 +3171,17 @@ processQueryResponse(struct module_qstate* qstate, struct iter_qstate* iq,
 	}
 	if(type == RESPONSE_TYPE_REFERRAL && (iq->chase_flags&BIT_RD) &&
 		!iq->auth_zone_response) {
-		/* When forwarding (RD bit is set), we handle referrals 
+		/* When forwarding (RD bit is set), we handle referrals
 		 * differently. No queries should be sent elsewhere */
 		type = RESPONSE_TYPE_ANSWER;
 	}
-	if(!qstate->env->cfg->disable_dnssec_lame_check && iq->dnssec_expected 
+	if(!qstate->env->cfg->disable_dnssec_lame_check && iq->dnssec_expected
                 && !iq->dnssec_lame_query &&
-		!(iq->chase_flags&BIT_RD) 
+		!(iq->chase_flags&BIT_RD)
 		&& iq->sent_count < DNSSEC_LAME_DETECT_COUNT
-		&& type != RESPONSE_TYPE_LAME 
-		&& type != RESPONSE_TYPE_REC_LAME 
-		&& type != RESPONSE_TYPE_THROWAWAY 
+		&& type != RESPONSE_TYPE_LAME
+		&& type != RESPONSE_TYPE_REC_LAME
+		&& type != RESPONSE_TYPE_THROWAWAY
 		&& type != RESPONSE_TYPE_UNTYPED) {
 		/* a possible answer, see if it is missing DNSSEC */
 		/* but not when forwarding, so we dont mark fwder lame */
@@ -3210,11 +3210,11 @@ processQueryResponse(struct module_qstate* qstate, struct iter_qstate* iq,
 	if(type == RESPONSE_TYPE_REFERRAL) {
 		struct ub_packed_rrset_key* ns = find_NS(
 			iq->response->rep, iq->response->rep->an_numrrsets,
-			iq->response->rep->an_numrrsets 
+			iq->response->rep->an_numrrsets
 			+ iq->response->rep->ns_numrrsets);
-		if(!ns) ns = find_NS(iq->response->rep, 0, 
+		if(!ns) ns = find_NS(iq->response->rep, 0,
 				iq->response->rep->an_numrrsets);
-		if(!ns || !dname_strict_subdomain_c(ns->rk.dname, iq->dp->name) 
+		if(!ns || !dname_strict_subdomain_c(ns->rk.dname, iq->dp->name)
 			|| !dname_subdomain_c(iq->qchase.qname, ns->rk.dname)){
 			verbose(VERB_ALGO, "bad referral, throwaway");
 			type = RESPONSE_TYPE_THROWAWAY;
@@ -3258,7 +3258,7 @@ processQueryResponse(struct module_qstate* qstate, struct iter_qstate* iq,
 
 	/* handle each of the type cases */
 	if(type == RESPONSE_TYPE_ANSWER) {
-		/* ANSWER type responses terminate the query algorithm, 
+		/* ANSWER type responses terminate the query algorithm,
 		 * so they sent on their */
 		if(verbosity >= VERB_DETAIL) {
 			verbose(VERB_DETAIL, "query response was %s",
@@ -3313,7 +3313,7 @@ processQueryResponse(struct module_qstate* qstate, struct iter_qstate* iq,
 				qstate->reply->remote_addrlen, qstate->region);
 		if(iq->minimisation_state != DONOT_MINIMISE_STATE
 			&& !(iq->chase_flags & BIT_RD)) {
-			if(FLAGS_GET_RCODE(iq->response->rep->flags) != 
+			if(FLAGS_GET_RCODE(iq->response->rep->flags) !=
 				LDNS_RCODE_NOERROR) {
 				if(qstate->env->cfg->qname_minimisation_strict) {
 					if(FLAGS_GET_RCODE(iq->response->rep->flags) ==
@@ -3324,7 +3324,7 @@ processQueryResponse(struct module_qstate* qstate, struct iter_qstate* iq,
 					return error_response_cache(qstate, id,
 						LDNS_RCODE_SERVFAIL);
 				}
-				/* Best effort qname-minimisation. 
+				/* Best effort qname-minimisation.
 				 * Stop minimising and send full query when
 				 * RCODE is not NOERROR. */
 				iq->minimisation_state = DONOT_MINIMISE_STATE;
@@ -3367,15 +3367,15 @@ processQueryResponse(struct module_qstate* qstate, struct iter_qstate* iq,
 		return final_state(iq);
 	} else if(type == RESPONSE_TYPE_REFERRAL) {
 		struct delegpt* old_dp = NULL;
-		/* REFERRAL type responses get a reset of the 
+		/* REFERRAL type responses get a reset of the
 		 * delegation point, and back to the QUERYTARGETS_STATE. */
 		verbose(VERB_DETAIL, "query response was REFERRAL");
 
 		/* if hardened, only store referral if we asked for it */
 		if(!qstate->no_cache_store &&
 		(!qstate->env->cfg->harden_referral_path ||
-		    (  qstate->qinfo.qtype == LDNS_RR_TYPE_NS 
-			&& (qstate->query_flags&BIT_RD) 
+		    (  qstate->qinfo.qtype == LDNS_RR_TYPE_NS
+			&& (qstate->query_flags&BIT_RD)
 			&& !(qstate->query_flags&BIT_CD)
 			   /* we know that all other NS rrsets are scrubbed
 			    * away, thus on referral only one is left.
@@ -3395,17 +3395,17 @@ processQueryResponse(struct module_qstate* qstate, struct iter_qstate* iq,
 				iq->response->rep, 1, 0, 0, NULL, 0,
 				qstate->qstarttime, qstate->is_valrec);
 			if(iq->store_parent_NS)
-				iter_store_parentside_NS(qstate->env, 
+				iter_store_parentside_NS(qstate->env,
 					iq->response->rep);
 			if(qstate->env->neg_cache)
-				val_neg_addreferral(qstate->env->neg_cache, 
+				val_neg_addreferral(qstate->env->neg_cache,
 					iq->response->rep, iq->dp->name);
 		}
 		/* store parent-side-in-zone-glue, if directly queried for */
 		if(!qstate->no_cache_store && iq->query_for_pside_glue
 			&& !iq->pside_glue) {
-				iq->pside_glue = reply_find_rrset(iq->response->rep, 
-					iq->qchase.qname, iq->qchase.qname_len, 
+				iq->pside_glue = reply_find_rrset(iq->response->rep,
+					iq->qchase.qname, iq->qchase.qname_len,
 					iq->qchase.qtype, iq->qchase.qclass);
 				if(iq->pside_glue) {
 					log_rrset_key(VERB_ALGO, "found parent-side "
@@ -3415,7 +3415,7 @@ processQueryResponse(struct module_qstate* qstate, struct iter_qstate* iq,
 				}
 		}
 
-		/* Reset the event state, setting the current delegation 
+		/* Reset the event state, setting the current delegation
 		 * point to the referral. */
 		iq->deleg_msg = iq->response;
 		/* Keep current delegation point for label comparison */
@@ -3441,7 +3441,7 @@ processQueryResponse(struct module_qstate* qstate, struct iter_qstate* iq,
 				iq->qchase.qclass, *qstate->env->now,
 				old_dp->name, old_dp->namelen);
 		}
-		if(!cache_fill_missing(qstate->env, iq->qchase.qclass, 
+		if(!cache_fill_missing(qstate->env, iq->qchase.qclass,
 			qstate->region, iq->dp, 0)) {
 			errinf(qstate, "malloc failure, copy extra info into delegation point");
 			return error_response(qstate, id, LDNS_RCODE_SERVFAIL);
@@ -3457,7 +3457,7 @@ processQueryResponse(struct module_qstate* qstate, struct iter_qstate* iq,
 		iq->dp_target_count = 0;
 		/* see if the next dp is a trust anchor, or a DS was sent
 		 * along, indicating dnssec is expected for next zone */
-		iq->dnssec_expected = iter_indicates_dnssec(qstate->env, 
+		iq->dnssec_expected = iter_indicates_dnssec(qstate->env,
 			iq->dp, iq->response, iq->qchase.qclass);
 		/* if dnssec, validating then also fetch the key for the DS */
 		if(iq->dnssec_expected && qstate->env->cfg->prefetch_key &&
@@ -3466,12 +3466,12 @@ processQueryResponse(struct module_qstate* qstate, struct iter_qstate* iq,
 
 		/* spawn off NS and addr to auth servers for the NS we just
 		 * got in the referral. This gets authoritative answer
-		 * (answer section trust level) rrset. 
+		 * (answer section trust level) rrset.
 		 * right after, we detach the subs, answer goes to cache. */
 		if(qstate->env->cfg->harden_referral_path)
 			generate_ns_check(qstate, iq, id);
 
-		/* stop current outstanding queries. 
+		/* stop current outstanding queries.
 		 * FIXME: should the outstanding queries be waited for and
 		 * handled? Say by a subquery that inherits the outbound_entry.
 		 */
@@ -3488,12 +3488,12 @@ processQueryResponse(struct module_qstate* qstate, struct iter_qstate* iq,
 	} else if(type == RESPONSE_TYPE_CNAME) {
 		uint8_t* sname = NULL;
 		size_t snamelen = 0;
-		/* CNAME type responses get a query restart (i.e., get a 
+		/* CNAME type responses get a query restart (i.e., get a
 		 * reset of the query state and go back to INIT_REQUEST_STATE).
 		 */
 		verbose(VERB_DETAIL, "query response was CNAME");
 		if(verbosity >= VERB_ALGO)
-			log_dns_msg("cname msg", &iq->response->qinfo, 
+			log_dns_msg("cname msg", &iq->response->qinfo,
 				iq->response->rep);
 		/* if qtype is DS, check we have the right level of answer,
 		 * like grandchild answer but we need the middle, reject it */
@@ -3519,13 +3519,13 @@ processQueryResponse(struct module_qstate* qstate, struct iter_qstate* iq,
 			return next_state(iq, QUERYTARGETS_STATE);
 		}
 		/* Process the CNAME response. */
-		if(!handle_cname_response(qstate, iq, iq->response, 
+		if(!handle_cname_response(qstate, iq, iq->response,
 			&sname, &snamelen)) {
 			errinf(qstate, "malloc failure, CNAME info");
 			return error_response(qstate, id, LDNS_RCODE_SERVFAIL);
 		}
 		/* cache the CNAME response under the current query */
-		/* NOTE : set referral=1, so that rrsets get stored but not 
+		/* NOTE : set referral=1, so that rrsets get stored but not
 		 * the partial query answer (CNAME only). */
 		/* prefetchleeway applied because this updates answer parts */
 		if(!qstate->no_cache_store)
@@ -3584,7 +3584,7 @@ processQueryResponse(struct module_qstate* qstate, struct iter_qstate* iq,
 		if(qstate->env->cfg->qname_minimisation)
 			iq->minimisation_state = INIT_MINIMISE_STATE;
 
-		/* stop current outstanding queries. 
+		/* stop current outstanding queries.
 		 * FIXME: should the outstanding queries be waited for and
 		 * handled? Say by a subquery that inherits the outbound_entry.
 		 */
@@ -3630,17 +3630,17 @@ processQueryResponse(struct module_qstate* qstate, struct iter_qstate* iq,
 			/* need addr for lameness cache, but we may have
 			 * gotten this from cache, so test to be sure */
 			verbose(VERB_DETAIL, "mark as REC_LAME");
-			if(!infra_set_lame(qstate->env->infra_cache, 
+			if(!infra_set_lame(qstate->env->infra_cache,
 				&qstate->reply->remote_addr,
 				qstate->reply->remote_addrlen,
 				iq->dp->name, iq->dp->namelen,
 				*qstate->env->now, 0, 1, iq->qchase.qtype))
 				log_err("mark host lame: out of memory");
-		} 
+		}
 	} else if(type == RESPONSE_TYPE_THROWAWAY) {
-		/* LAME and THROWAWAY responses are handled the same way. 
-		 * In this case, the event is just sent directly back to 
-		 * the QUERYTARGETS_STATE without resetting anything, 
+		/* LAME and THROWAWAY responses are handled the same way.
+		 * In this case, the event is just sent directly back to
+		 * the QUERYTARGETS_STATE without resetting anything,
 		 * because, clearly, the next target must be tried. */
 		verbose(VERB_DETAIL, "query response was categorized as THROWAWAY");
 	} else {
@@ -3649,7 +3649,7 @@ processQueryResponse(struct module_qstate* qstate, struct iter_qstate* iq,
 	}
 
 	/* LAME, THROWAWAY and "unknown" all end up here.
-	 * Recycle to the QUERYTARGETS state to hopefully try a 
+	 * Recycle to the QUERYTARGETS state to hopefully try a
 	 * different target. */
 	if (qstate->env->cfg->qname_minimisation &&
 		!qstate->env->cfg->qname_minimisation_strict)
@@ -3680,7 +3680,7 @@ processQueryResponse(struct module_qstate* qstate, struct iter_qstate* iq,
 
 /**
  * Return priming query results to interested super querystates.
- * 
+ *
  * Sets the delegation point and delegation message (not nonRD queries).
  * This is a callback from walk_supers.
  *
@@ -3699,7 +3699,7 @@ prime_supers(struct module_qstate* qstate, int id, struct module_qstate* forq)
 	/* Convert our response to a delegation point */
 	dp = delegpt_from_message(qstate->return_msg, forq->region);
 	if(!dp) {
-		/* if there is no convertible delegation point, then 
+		/* if there is no convertible delegation point, then
 		 * the ANSWER type was (presumably) a negative answer. */
 		verbose(VERB_ALGO, "prime response was not a positive "
 			"ANSWER; failing");
@@ -3719,7 +3719,7 @@ prime_supers(struct module_qstate* qstate, int id, struct module_qstate* forq)
 		return;
 	}
 
-	/* root priming responses go to init stage 2, priming stub 
+	/* root priming responses go to init stage 2, priming stub
 	 * responses to to stage 3. */
 	if(foriq->wait_priming_stub) {
 		foriq->state = INIT_REQUEST_3_STATE;
@@ -3728,7 +3728,7 @@ prime_supers(struct module_qstate* qstate, int id, struct module_qstate* forq)
 	/* because we are finished, the parent will be reactivated */
 }
 
-/** 
+/**
  * This handles the response to a priming query. This is used to handle both
  * root and stub priming responses. This is basically the equivalent of the
  * QUERY_RESP_STATE, but will not handle CNAME responses and will treat
@@ -3747,7 +3747,7 @@ processPrimeResponse(struct module_qstate* qstate, int id)
 	enum response_type type;
 	iq->response->rep->flags &= ~(BIT_RD|BIT_RA); /* ignore rec-lame */
 	type = response_type_from_server(
-		(int)((iq->chase_flags&BIT_RD) || iq->chase_to_rd), 
+		(int)((iq->chase_flags&BIT_RD) || iq->chase_to_rd),
 		iq->response, &iq->qchase, iq->dp, NULL);
 	if(type == RESPONSE_TYPE_ANSWER) {
 		qstate->return_rcode = LDNS_RCODE_NOERROR;
@@ -3765,10 +3765,10 @@ processPrimeResponse(struct module_qstate* qstate, int id)
 	 * may need can be resolved. */
 	if(qstate->env->cfg->harden_referral_path) {
 		struct module_qstate* subq = NULL;
-		log_nametypeclass(VERB_ALGO, "schedule prime validation", 
+		log_nametypeclass(VERB_ALGO, "schedule prime validation",
 			qstate->qinfo.qname, qstate->qinfo.qtype,
 			qstate->qinfo.qclass);
-		if(!generate_sub_request(qstate->qinfo.qname, 
+		if(!generate_sub_request(qstate->qinfo.qname,
 			qstate->qinfo.qname_len, qstate->qinfo.qtype,
 			qstate->qinfo.qclass, qstate, id, iq,
 			INIT_REQUEST_STATE, FINISHED_STATE, &subq, 1, 0)) {
@@ -3782,13 +3782,13 @@ processPrimeResponse(struct module_qstate* qstate, int id)
 	return 0;
 }
 
-/** 
+/**
  * Do final processing on responses to target queries. Events reach this
  * state after the iterative resolution algorithm terminates. This state is
  * responsible for reactivating the original event, and housekeeping related
  * to received target responses (caching, updating the current delegation
  * point, etc).
- * Callback from walk_supers for every super state that is interested in 
+ * Callback from walk_supers for every super state that is interested in
  * the results from this query.
  *
  * @param qstate: query state.
@@ -3834,9 +3834,9 @@ processTargetResponse(struct module_qstate* qstate, int id,
 		/* if the pside_glue is NULL, then it could not be found,
 		 * the done_pside is already set when created and a cache
 		 * entry created in processFinished so nothing to do here */
-		log_rrset_key(VERB_ALGO, "add parentside glue to dp", 
+		log_rrset_key(VERB_ALGO, "add parentside glue to dp",
 			iq->pside_glue);
-		if(!delegpt_add_rrset(foriq->dp, forq->region, 
+		if(!delegpt_add_rrset(foriq->dp, forq->region,
 			iq->pside_glue, 1, NULL))
 			log_err("out of memory adding pside glue");
 	}
@@ -3860,7 +3860,7 @@ processTargetResponse(struct module_qstate* qstate, int id,
 				log_err("out of memory adding cnamed-ns");
 		}
 		/* if dpns->lame then set the address(es) lame too */
-		if(!delegpt_add_rrset(foriq->dp, forq->region, rrset, 
+		if(!delegpt_add_rrset(foriq->dp, forq->region, rrset,
 			dpns->lame, &additions))
 			log_err("out of memory adding targets");
 		if(!additions) {
@@ -3948,13 +3948,13 @@ processClassResponse(struct module_qstate* qstate, int id,
 		/* allocate the response: copy RCODE, sec_state */
 		foriq->response = dns_copy_msg(from, forq->region);
 		if(!foriq->response) {
-			log_err("malloc failed for qclass ANY response"); 
+			log_err("malloc failed for qclass ANY response");
 			foriq->state = FINISHED_STATE;
 			return;
 		}
 		foriq->response->qinfo.qclass = forq->qinfo.qclass;
 		/* qclass ANY does not receive the AA flag on replies */
-		foriq->response->rep->authoritative = 0; 
+		foriq->response->rep->authoritative = 0;
 	} else {
 		struct dns_msg* to = foriq->response;
 		/* add _from_ this response _to_ existing collection */
@@ -3968,13 +3968,13 @@ processClassResponse(struct module_qstate* qstate, int id,
 			/* copy rrsets */
 			if(from->rep->rrset_count > RR_COUNT_MAX ||
 				to->rep->rrset_count > RR_COUNT_MAX) {
-				log_err("malloc failed (too many rrsets) in collect ANY"); 
+				log_err("malloc failed (too many rrsets) in collect ANY");
 				foriq->state = FINISHED_STATE;
 				return; /* integer overflow protection */
 			}
 			dest = regional_alloc(forq->region, sizeof(dest[0])*n);
 			if(!dest) {
-				log_err("malloc failed in collect ANY"); 
+				log_err("malloc failed in collect ANY");
 				foriq->state = FINISHED_STATE;
 				return;
 			}
@@ -4026,8 +4026,8 @@ processClassResponse(struct module_qstate* qstate, int id,
 	if(foriq->num_current_queries == 0)
 		foriq->state = FINISHED_STATE;
 }
-	
-/** 
+
+/**
  * Collect class ANY responses and make them into one response.  This
  * state is started and it creates queries for all classes (that have
  * root hints).  The answers are then collected.
@@ -4056,11 +4056,11 @@ processCollectClass(struct module_qstate* qstate, int id)
 			if(!generate_sub_request(qstate->qinfo.qname,
 				qstate->qinfo.qname_len, qstate->qinfo.qtype,
 				c, qstate, id, iq, INIT_REQUEST_STATE,
-				FINISHED_STATE, &subq, 
+				FINISHED_STATE, &subq,
 				(int)!(qstate->query_flags&BIT_CD), 0)) {
 				errinf(qstate, "could not generate class ANY"
 					" lookup query");
-				return error_response(qstate, id, 
+				return error_response(qstate, id,
 					LDNS_RCODE_SERVFAIL);
 			}
 			/* ignore subq, no special init required */
@@ -4081,7 +4081,7 @@ processCollectClass(struct module_qstate* qstate, int id)
 	return 0;
 }
 
-/** 
+/**
  * This handles the final state for first-tier responses (i.e., responses to
  * externally generated queries).
  *
@@ -4095,7 +4095,7 @@ static int
 processFinished(struct module_qstate* qstate, struct iter_qstate* iq,
 	int id)
 {
-	log_query_info(VERB_QUERY, "finishing processing for", 
+	log_query_info(VERB_QUERY, "finishing processing for",
 		&qstate->qinfo);
 
 	/* store negative cache element for parent side glue. */
@@ -4110,7 +4110,7 @@ processFinished(struct module_qstate* qstate, struct iter_qstate* iq,
 		return error_response(qstate, id, LDNS_RCODE_SERVFAIL);
 	}
 
-	/* Make sure that the RA flag is set (since the presence of 
+	/* Make sure that the RA flag is set (since the presence of
 	 * this module means that recursion is available) */
 	iq->response->rep->flags |= BIT_RA;
 
@@ -4153,7 +4153,7 @@ processFinished(struct module_qstate* qstate, struct iter_qstate* iq,
 		 * but only if we did recursion. The nonrecursion referral
 		 * from cache does not need to be stored in the msg cache. */
 		if(!qstate->no_cache_store && (qstate->query_flags&BIT_RD)) {
-			iter_dns_store(qstate->env, &qstate->qinfo, 
+			iter_dns_store(qstate->env, &qstate->qinfo,
 				iq->response->rep, 0, qstate->prefetch_leeway,
 				iq->dp&&iq->dp->has_parent_side_NS,
 				qstate->region, qstate->query_flags,
@@ -4167,7 +4167,7 @@ processFinished(struct module_qstate* qstate, struct iter_qstate* iq,
 
 /*
  * Return priming query results to interested super querystates.
- * 
+ *
  * Sets the delegation point and delegation message (not nonRD queries).
  * This is a callback from walk_supers.
  *
@@ -4176,7 +4176,7 @@ processFinished(struct module_qstate* qstate, struct iter_qstate* iq,
  * @param super: the qstate to inform.
  */
 void
-iter_inform_super(struct module_qstate* qstate, int id, 
+iter_inform_super(struct module_qstate* qstate, int id,
 	struct module_qstate* super)
 {
 	if(!qstate->is_priming && super->qinfo.qclass == LDNS_RR_CLASS_ANY)
@@ -4248,7 +4248,7 @@ iter_handle(struct module_qstate* qstate, struct iter_qstate* iq,
 	}
 }
 
-/** 
+/**
  * This is the primary entry point for processing request events. Note that
  * this method should only be used by external modules.
  * @param qstate: query state.
@@ -4270,7 +4270,7 @@ process_request(struct module_qstate* qstate, struct iter_qstate* iq,
 
 /** process authoritative server reply */
 static void
-process_response(struct module_qstate* qstate, struct iter_qstate* iq, 
+process_response(struct module_qstate* qstate, struct iter_qstate* iq,
 	struct iter_env* ie, int id, struct outbound_entry* outbound,
 	enum module_ev event)
 {
@@ -4313,7 +4313,7 @@ process_response(struct module_qstate* qstate, struct iter_qstate* iq,
 	/* parse message */
 	fill_fail_addr(iq, &qstate->reply->remote_addr,
 		qstate->reply->remote_addrlen);
-	prs = (struct msg_parse*)regional_alloc(qstate->env->scratch, 
+	prs = (struct msg_parse*)regional_alloc(qstate->env->scratch,
 		sizeof(struct msg_parse));
 	if(!prs) {
 		log_err("out of memory on incoming message");
@@ -4356,7 +4356,7 @@ process_response(struct module_qstate* qstate, struct iter_qstate* iq,
 	prs->flags &= ~BIT_CD;
 
 	/* normalize and sanitize: easy to delete items from linked lists */
-	if(!scrub_message(pkt, prs, &iq->qinfo_out, iq->dp->name, 
+	if(!scrub_message(pkt, prs, &iq->qinfo_out, iq->dp->name,
 		qstate->env->scratch, qstate->env, qstate, ie)) {
 		/* if 0x20 enabled, start fallback, but we have no message */
 		if(event == module_event_capsfail && !iq->caps_fallback) {
@@ -4381,7 +4381,7 @@ process_response(struct module_qstate* qstate, struct iter_qstate* iq,
 	log_name_addr(VERB_DETAIL, "reply from", iq->dp->name,
 		&qstate->reply->remote_addr, qstate->reply->remote_addrlen);
 	if(verbosity >= VERB_ALGO)
-		log_dns_msg("incoming scrubbed packet:", &iq->response->qinfo, 
+		log_dns_msg("incoming scrubbed packet:", &iq->response->qinfo,
 			iq->response->rep);
 
 	if(qstate->env->cfg->aggressive_nsec) {
@@ -4394,7 +4394,7 @@ process_response(struct module_qstate* qstate, struct iter_qstate* iq,
 			 * one has to match the current query. */
 			iq->minimisation_state = SKIP_MINIMISE_STATE;
 		}
-		/* for fallback we care about main answer, not additionals */
+		/* for fallback we care about main answer, not additional records */
 		/* removing that makes comparison more likely to succeed */
 		caps_strip_reply(iq->response->rep);
 
@@ -4430,7 +4430,7 @@ process_response(struct module_qstate* qstate, struct iter_qstate* iq,
 				iq->caps_response = iq->response;
 			} else if(!caps_failed_rcode(iq->caps_reply) &&
 				caps_failed_rcode(iq->response->rep)) {
-				/* if we have non-SERVFAIL as answer then 
+				/* if we have non-SERVFAIL as answer then
 				 * we can ignore SERVFAILs for the equality
 				 * comparison */
 				/* no instructions here, skip other else */
@@ -4464,22 +4464,22 @@ handle_it:
 	iter_handle(qstate, iq, ie, id);
 }
 
-void 
+void
 iter_operate(struct module_qstate* qstate, enum module_ev event, int id,
 	struct outbound_entry* outbound)
 {
 	struct iter_env* ie = (struct iter_env*)qstate->env->modinfo[id];
 	struct iter_qstate* iq = (struct iter_qstate*)qstate->minfo[id];
-	verbose(VERB_QUERY, "iterator[module %d] operate: extstate:%s event:%s", 
+	verbose(VERB_QUERY, "iterator[module %d] operate: extstate:%s event:%s",
 		id, strextstate(qstate->ext_state[id]), strmodulevent(event));
-	if(iq) log_query_info(VERB_QUERY, "iterator operate: query", 
+	if(iq) log_query_info(VERB_QUERY, "iterator operate: query",
 		&qstate->qinfo);
 	if(iq && qstate->qinfo.qname != iq->qchase.qname)
-		log_query_info(VERB_QUERY, "iterator operate: chased to", 
+		log_query_info(VERB_QUERY, "iterator operate: chased to",
 			&iq->qchase);
 
 	/* perform iterator state machine */
-	if((event == module_event_new || event == module_event_pass) && 
+	if((event == module_event_new || event == module_event_pass) &&
 		iq == NULL) {
 		if(!iter_new(qstate, id)) {
 			errinf(qstate, "malloc failure, new iterator module allocation");
@@ -4510,7 +4510,7 @@ iter_operate(struct module_qstate* qstate, enum module_ev event, int id,
 	(void)error_response(qstate, id, LDNS_RCODE_SERVFAIL);
 }
 
-void 
+void
 iter_clear(struct module_qstate* qstate, int id)
 {
 	struct iter_qstate* iq;
@@ -4529,7 +4529,7 @@ iter_clear(struct module_qstate* qstate, int id)
 	qstate->minfo[id] = NULL;
 }
 
-size_t 
+size_t
 iter_get_mem(struct module_env* env, int id)
 {
 	struct iter_env* ie = (struct iter_env*)env->modinfo[id];
@@ -4540,7 +4540,7 @@ iter_get_mem(struct module_env* env, int id)
 }
 
 /**
- * The iterator function block 
+ * The iterator function block
  */
 static struct module_func_block iter_block = {
 	"iterator",
@@ -4548,13 +4548,13 @@ static struct module_func_block iter_block = {
 	&iter_inform_super, &iter_clear, &iter_get_mem
 };
 
-struct module_func_block* 
+struct module_func_block*
 iter_get_funcblock(void)
 {
 	return &iter_block;
 }
 
-const char* 
+const char*
 iter_state_to_string(enum iter_state state)
 {
 	switch (state)
@@ -4582,7 +4582,7 @@ iter_state_to_string(enum iter_state state)
 	}
 }
 
-int 
+int
 iter_state_is_responsestate(enum iter_state s)
 {
 	switch(s) {

--- a/pythonmod/ubmodule-msg.py
+++ b/pythonmod/ubmodule-msg.py
@@ -8,18 +8,18 @@
  Copyright (c) 2008. All rights reserved.
 
  This software is open source.
- 
+
  Redistribution and use in source and binary forms, with or without
  modification, are permitted provided that the following conditions
  are met:
- 
+
  Redistributions of source code must retain the above copyright notice,
  this list of conditions and the following disclaimer.
- 
+
  Redistributions in binary form must reproduce the above copyright notice,
  this list of conditions and the following disclaimer in the documentation
  and/or other materials provided with the distribution.
- 
+
  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
  TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
@@ -105,7 +105,7 @@ def operate(id, event, qstate, qdata):
     if (event == MODULE_EVENT_NEW) and (qstate.qinfo.qname_str.endswith(".seznam.cz.")): #pokud mame "python validator iterator"
         print qstate.qinfo.qname_str
 
-        qstate.ext_state[id] = MODULE_FINISHED 
+        qstate.ext_state[id] = MODULE_FINISHED
 
         msg = DNSMessage(qstate.qinfo.qname_str, RR_TYPE_A, RR_CLASS_IN, PKT_QR | PKT_RA | PKT_AA) #, 300)
         #msg.authority.append("xxx.seznam.cz. 10 IN A 192.168.1.1")
@@ -119,10 +119,10 @@ def operate(id, event, qstate, qdata):
             msg.answer.append("%s 10 IN TXT path=/" % qstate.qinfo.qname_str)
 
         if not msg.set_return_msg(qstate):
-            qstate.ext_state[id] = MODULE_ERROR 
+            qstate.ext_state[id] = MODULE_ERROR
             return True
 
-        #qstate.return_msg.rep.security = 2 #pokud nebude nasledovat validator, je zapotrebi nastavit security, aby nebyl paket zahozen v mesh_send_reply
+        #qstate.return_msg.rep.security = 2 #pokud nebude nasledovat validator, je zapotrebi nastavit security, aby nebyl packet zahozen v mesh_send_reply
         printReturnMsg(qstate)
 
         #Authoritative result can't be stored in cache
@@ -136,17 +136,17 @@ def operate(id, event, qstate, qdata):
         return True
 
     if event == MODULE_EVENT_NEW:
-        qstate.ext_state[id] = MODULE_WAIT_MODULE 
+        qstate.ext_state[id] = MODULE_WAIT_MODULE
         return True
 
     if event == MODULE_EVENT_MODDONE:
         log_info("pythonmod: previous module done")
-        qstate.ext_state[id] = MODULE_FINISHED 
+        qstate.ext_state[id] = MODULE_FINISHED
         return True
-      
+
     if event == MODULE_EVENT_PASS:
         log_info("pythonmod: event_pass")
-        qstate.ext_state[id] = MODULE_WAIT_MODULE 
+        qstate.ext_state[id] = MODULE_WAIT_MODULE
         return True
 
     log_err("pythonmod: BAD event")

--- a/sldns/parseutil.h
+++ b/sldns/parseutil.h
@@ -16,9 +16,9 @@
 #define LDNS_PARSEUTIL_H
 struct tm;
 
-/** 
+/**
  *  A general purpose lookup table
- *  
+ *
  *  Lookup tables are arrays of (id, name) pairs,
  *  So you can for instance lookup the RCODE 3, which is "NXDOMAIN",
  *  and vice versa. The lookup tables themselves are defined wherever needed,
@@ -56,13 +56,13 @@ time_t sldns_mktime_from_utc(const struct tm *tm);
 
 /**
  * The function interprets time as the number of seconds since epoch
- * with respect to now using serial arithmetics (rfc1982).
+ * with respect to now using serial arithmetic (rfc1982).
  * That number of seconds is then converted to broken-out time information.
  * This is especially useful when converting the inception and expiration
  * fields of RRSIG records.
  *
  * \param[in] time number of seconds since epoch (midnight, January 1st, 1970)
- *            to be interpreted as a serial arithmetics number relative to now.
+ *            to be interpreted as a serial arithmetic number relative to now.
  * \param[in] now number of seconds since epoch (midnight, January 1st, 1970)
  *            to which the time value is compared to determine the final value.
  * \param[out] result the struct with the broken-out time information
@@ -143,7 +143,7 @@ int sldns_b32_pton_extended_hex(const char* src_text, size_t src_text_length,
  */
 int sldns_parse_escape(uint8_t *ch_p, const char** str_p);
 
-/** 
+/**
  * Parse one character, with escape codes,
  * @param ch_p: the parsed character
  * @param str_p: the string. moved along for characters read.

--- a/sldns/wire2str.h
+++ b/sldns/wire2str.h
@@ -261,7 +261,7 @@ int sldns_wire2str_rdata_unknown_scan(uint8_t** data, size_t* data_len,
  * @param str_len: length of string buffer.
  * @param pkt: packet for decompression, if NULL no decompression.
  * @param pktlen: length of packet buffer.
- * @param comprloop: inout bool, that is set true if compression loop failure
+ * @param comprloop: in/out bool, that is set true if compression loop failure
  * 	happens.  Pass in 0, if passed in as true, a lower bound is set
  * 	on compression loops to stop arbitrary long packet parse times.
  * 	This is meant so you can set it to 0 at the start of a list of dnames,

--- a/smallapp/unbound-checkconf.c
+++ b/smallapp/unbound-checkconf.c
@@ -1069,7 +1069,7 @@ int main(int argc, char* argv[])
 	log_ident_set("unbound-checkconf");
 	log_init(NULL, 0, NULL);
 #ifdef USE_WINSOCK
-	/* use registry config file in preference to compiletime location */
+	/* use registry config file in preference to compile time location */
 	if(!(cfgfile=w_lookup_reg_str("Software\\Unbound", "ConfigFile")))
 		cfgfile = CONFIGFILE;
 #endif /* USE_WINSOCK */

--- a/smallapp/unbound-control.c
+++ b/smallapp/unbound-control.c
@@ -990,7 +990,7 @@ int main(int argc, char* argv[])
 	log_ident_set("unbound-control");
 	log_init(NULL, 0, NULL);
 #ifdef USE_WINSOCK
-	/* use registry config file in preference to compiletime location */
+	/* use registry config file in preference to compile time location */
 	if(!(cfgfile=w_lookup_reg_str("Software\\Unbound", "ConfigFile")))
 		cfgfile = CONFIGFILE;
 #endif

--- a/util/config_file.h
+++ b/util/config_file.h
@@ -570,7 +570,7 @@ struct config_file {
 	/* DNS64 prefix */
 	char* dns64_prefix;
 
-	/* Synthetize all AAAA record despite the presence of an authoritative one */
+	/* Synthesize all AAAA record despite the presence of an authoritative one */
 	int dns64_synthall;
 	/** ignore AAAAs for these domain names and use A record anyway */
 	struct config_strlist* dns64_ignore_aaaa;

--- a/util/data/msgparse.h
+++ b/util/data/msgparse.h
@@ -1,25 +1,25 @@
 /*
  * util/data/msgparse.h - parse wireformat DNS messages.
- * 
+ *
  * Copyright (c) 2007, NLnet Labs. All rights reserved.
- * 
+ *
  * This software is open source.
- * 
+ *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
  * are met:
- * 
+ *
  * Redistributions of source code must retain the above copyright notice,
  * this list of conditions and the following disclaimer.
- * 
+ *
  * Redistributions in binary form must reproduce the above copyright notice,
  * this list of conditions and the following disclaimer in the documentation
  * and/or other materials provided with the distribution.
- * 
+ *
  * Neither the name of the NLNET LABS nor the names of its contributors may
  * be used to endorse or promote products derived from this software without
  * specific prior written permission.
- * 
+ *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
  * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
  * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
@@ -102,7 +102,7 @@ extern int SERVE_ORIGINAL_TTL;
  * without numerical overflow (uin32_t) */
 #define PREFETCH_TTL_CALC(ttl) ((ttl) - (ttl)/10)
 
-/*  caclulate the TTL used for expired answers to somewhat make sense wrt the
+/*  calculate the TTL used for expired answers to somewhat make sense wrt the
  *  original TTL; don't reply with higher TTL than the original */
 #ifdef UNBOUND_DEBUG
 time_t debug_expired_reply_ttl_calc(time_t ttl, time_t ttl_add);
@@ -143,7 +143,7 @@ struct msg_parse {
 	/** count of RRsets per section. */
 	size_t an_rrsets;
 	/** count of RRsets per section. */
-	size_t ns_rrsets; 
+	size_t ns_rrsets;
 	/** count of RRsets per section. */
 	size_t ar_rrsets;
 	/** total number of rrsets found. */
@@ -163,7 +163,7 @@ struct msg_parse {
 	 * Based on name, type, class.  Same hash value as in rrset cache.
 	 */
 	struct rrset_parse* hashtable[PARSE_TABLE_SIZE];
-	
+
 	/** linked list of rrsets that have been found (in order). */
 	struct rrset_parse* rrset_first;
 	/** last element of rrset list. */
@@ -214,7 +214,7 @@ struct rrset_parse {
  * Data stored for an RR during parsing.
  */
 struct rr_parse {
-	/** 
+	/**
 	 * Pointer to the RR. Points to start of TTL value in the packet.
 	 * Rdata length and rdata follow it.
 	 * its dname, type and class are the same and stored for the rrset.
@@ -275,7 +275,7 @@ struct edns_data {
 	unsigned int cookie_valid   : 1;
 	/** if the cookie holds only the client part */
 	unsigned int cookie_client  : 1;
-};	
+};
 
 /**
  * EDNS option
@@ -307,7 +307,7 @@ size_t get_rdf_size(sldns_rdf_type rdf);
  * @param region: how to alloc results.
  * @return: 0 if OK, or rcode on error.
  */
-int parse_packet(struct sldns_buffer* pkt, struct msg_parse* msg, 
+int parse_packet(struct sldns_buffer* pkt, struct msg_parse* msg,
 	struct regional* region);
 
 /**
@@ -383,8 +383,8 @@ hashvalue_type pkt_hash_rrset(struct sldns_buffer* pkt, uint8_t* dname,
  * @param dclass: rrset class, network order.
  * @return NULL or the rrset_parse if found.
  */
-struct rrset_parse* msgparse_hashtable_lookup(struct msg_parse* msg, 
-	struct sldns_buffer* pkt, hashvalue_type h, uint32_t rrset_flags, 
+struct rrset_parse* msgparse_hashtable_lookup(struct msg_parse* msg,
+	struct sldns_buffer* pkt, hashvalue_type h, uint32_t rrset_flags,
 	uint8_t* dname, size_t dnamelen, uint16_t type, uint16_t dclass);
 
 /**

--- a/validator/val_neg.c
+++ b/validator/val_neg.c
@@ -4,22 +4,22 @@
  * Copyright (c) 2008, NLnet Labs. All rights reserved.
  *
  * This software is open source.
- * 
+ *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
  * are met:
- * 
+ *
  * Redistributions of source code must retain the above copyright notice,
  * this list of conditions and the following disclaimer.
- * 
+ *
  * Redistributions in binary form must reproduce the above copyright notice,
  * this list of conditions and the following disclaimer in the documentation
  * and/or other materials provided with the distribution.
- * 
+ *
  * Neither the name of the NLNET LABS nor the names of its contributors may
  * be used to endorse or promote products derived from this software without
  * specific prior written permission.
- * 
+ *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
  * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
  * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
@@ -85,7 +85,7 @@ int val_neg_zone_compare(const void* a, const void* b)
 
 struct val_neg_cache* val_neg_create(struct config_file* cfg, size_t maxiter)
 {
-	struct val_neg_cache* neg = (struct val_neg_cache*)calloc(1, 
+	struct val_neg_cache* neg = (struct val_neg_cache*)calloc(1,
 		sizeof(*neg));
 	if(!neg) {
 		log_err("Could not create neg cache: out of memory");
@@ -109,7 +109,7 @@ size_t val_neg_get_mem(struct val_neg_cache* neg)
 	return result;
 }
 
-/** clear datas on cache deletion */
+/** clear data on cache deletion */
 static void
 neg_clear_datas(rbnode_type* n, void* ATTR_UNUSED(arg))
 {
@@ -144,7 +144,7 @@ void neg_cache_delete(struct val_neg_cache* neg)
  * @param neg: negative cache with LRU start and end.
  * @param data: this data is fronted.
  */
-static void neg_lru_front(struct val_neg_cache* neg, 
+static void neg_lru_front(struct val_neg_cache* neg,
 	struct val_neg_data* data)
 {
 	data->prev = NULL;
@@ -160,7 +160,7 @@ static void neg_lru_front(struct val_neg_cache* neg,
  * @param neg: negative cache with LRU start and end.
  * @param data: this data is removed from the list.
  */
-static void neg_lru_remove(struct val_neg_cache* neg, 
+static void neg_lru_remove(struct val_neg_cache* neg,
 	struct val_neg_data* data)
 {
 	if(data->prev)
@@ -176,7 +176,7 @@ static void neg_lru_remove(struct val_neg_cache* neg,
  * @param neg: negative cache with LRU start and end.
  * @param data: this data is used.
  */
-static void neg_lru_touch(struct val_neg_cache* neg, 
+static void neg_lru_touch(struct val_neg_cache* neg,
 	struct val_neg_data* data)
 {
 	if(data == neg->first)
@@ -222,7 +222,7 @@ static void neg_delete_zone(struct val_neg_cache* neg, struct val_neg_zone* z)
 		p = np;
 	}
 }
-	
+
 void neg_delete_data(struct val_neg_cache* neg, struct val_neg_data* el)
 {
 	struct val_neg_zone* z;
@@ -236,7 +236,7 @@ void neg_delete_data(struct val_neg_cache* neg, struct val_neg_data* el)
 	/* remove it from the lru list */
 	neg_lru_remove(neg, el);
 	log_assert(neg->first != el && neg->last != el);
-	
+
 	/* go up the tree and reduce counts */
 	p = el;
 	while(p) {
@@ -277,7 +277,7 @@ static void neg_make_space(struct val_neg_cache* neg, size_t need)
 	}
 }
 
-struct val_neg_zone* neg_find_zone(struct val_neg_cache* neg, 
+struct val_neg_zone* neg_find_zone(struct val_neg_cache* neg,
 	uint8_t* nm, size_t len, uint16_t dclass)
 {
 	struct val_neg_zone lookfor;
@@ -301,7 +301,7 @@ struct val_neg_zone* neg_find_zone(struct val_neg_cache* neg,
  * @param labs: labels in nm
  * @return data or NULL if not found.
  */
-static struct val_neg_data* neg_find_data(struct val_neg_zone* zone, 
+static struct val_neg_data* neg_find_data(struct val_neg_zone* zone,
 	uint8_t* nm, size_t len, int labs)
 {
 	struct val_neg_data lookfor;
@@ -449,7 +449,7 @@ static struct val_neg_data* neg_closest_data_parent(
 static struct val_neg_zone* neg_setup_zone_node(
 	uint8_t* nm, size_t nm_len, int labs, uint16_t dclass)
 {
-	struct val_neg_zone* zone = 
+	struct val_neg_zone* zone =
 		(struct val_neg_zone*)calloc(1, sizeof(*zone));
 	if(!zone) {
 		return NULL;
@@ -513,7 +513,7 @@ static struct val_neg_zone* neg_zone_chain(
 		dname_remove_label(&nm, &nm_len);
 	}
 	return first;
-}	
+}
 
 void val_neg_zone_take_inuse(struct val_neg_zone* zone)
 {
@@ -670,7 +670,7 @@ static struct val_neg_data* neg_data_chain(
  * @param el: element to start walking at.
  * @param nsec: the nsec record with the end point
  */
-static void wipeout(struct val_neg_cache* neg, struct val_neg_zone* zone, 
+static void wipeout(struct val_neg_cache* neg, struct val_neg_zone* zone,
 	struct val_neg_data* el, struct ub_packed_rrset_key* nsec)
 {
 	struct packed_rrset_data* d = (struct packed_rrset_data*)nsec->
@@ -697,7 +697,7 @@ static void wipeout(struct val_neg_cache* neg, struct val_neg_zone* zone,
 	}
 
 	/* sanity check, both owner and end must be below the zone apex */
-	if(!dname_subdomain_c(el->name, zone->name) || 
+	if(!dname_subdomain_c(el->name, zone->name) ||
 		!dname_subdomain_c(end, zone->name))
 		return;
 
@@ -710,7 +710,7 @@ static void wipeout(struct val_neg_cache* neg, struct val_neg_zone* zone,
 	while(walk && walk != RBTREE_NULL) {
 		cur = (struct val_neg_data*)walk;
 		/* sanity check: must be larger than start */
-		if(dname_canon_lab_cmp(cur->name, cur->labs, 
+		if(dname_canon_lab_cmp(cur->name, cur->labs,
 			el->name, el->labs, &m) <= 0) {
 			/* r == 0 skip original record. */
 			/* r < 0  too small! */
@@ -718,7 +718,7 @@ static void wipeout(struct val_neg_cache* neg, struct val_neg_zone* zone,
 			continue;
 		}
 		/* stop at endpoint, also data at empty nonterminals must be
-		 * removed (no NSECs there) so everything between 
+		 * removed (no NSECs there) so everything between
 		 * start and end */
 		if(end && dname_canon_lab_cmp(cur->name, cur->labs,
 			end, end_labs, &m) >= 0) {
@@ -734,7 +734,7 @@ static void wipeout(struct val_neg_cache* neg, struct val_neg_zone* zone,
 		 * But it may trigger delete of other data and the
 		 * entire zone. However, if that happens, this is done
 		 * by deleting the *parents* of the element for deletion,
-		 * and maybe also the entire zone if it is empty. 
+		 * and maybe also the entire zone if it is empty.
 		 * But parents are smaller in canonical compare, thus,
 		 * if a larger element exists, then it is not a parent,
 		 * it cannot get deleted, the zone cannot get empty.
@@ -745,7 +745,7 @@ static void wipeout(struct val_neg_cache* neg, struct val_neg_zone* zone,
 	}
 }
 
-void neg_insert_data(struct val_neg_cache* neg, 
+void neg_insert_data(struct val_neg_cache* neg,
 	struct val_neg_zone* zone, struct ub_packed_rrset_key* nsec)
 {
 	struct packed_rrset_data* d;
@@ -759,8 +759,8 @@ void neg_insert_data(struct val_neg_cache* neg,
 	if( !(d->security == sec_status_secure ||
 		(d->security == sec_status_unchecked && d->rrsig_count > 0)))
 		return;
-	log_nametypeclass(VERB_ALGO, "negcache rr", 
-		nsec->rk.dname, ntohs(nsec->rk.type), 
+	log_nametypeclass(VERB_ALGO, "negcache rr",
+		nsec->rk.dname, ntohs(nsec->rk.type),
 		ntohs(nsec->rk.rrset_class));
 
 	/* find closest enclosing parent data that (still) exists */
@@ -769,7 +769,7 @@ void neg_insert_data(struct val_neg_cache* neg,
 		/* perfect match already exists */
 		log_assert(parent->count > 0);
 		el = parent;
-	} else { 
+	} else {
 		struct val_neg_data* p, *np;
 
 		/* create subtree for perfect match */
@@ -822,7 +822,7 @@ void neg_insert_data(struct val_neg_cache* neg,
 		if(nsec3_get_params(nsec, 0, &h, &it, &s, &slen) &&
 			it <= neg->nsec3_max_iter &&
 			(h != zone->nsec3_hash || it != zone->nsec3_iter ||
-			slen != zone->nsec3_saltlen || 
+			slen != zone->nsec3_saltlen ||
 			(slen != 0 && zone->nsec3_salt && s
 			  && memcmp(zone->nsec3_salt, s, slen) != 0))) {
 
@@ -894,7 +894,7 @@ void val_neg_addreply(struct val_neg_cache* neg, struct reply_info* rep)
 		rrset_class = ntohs(soa->rk.rrset_class);
 	}
 	else {
-		/* No SOA in positive (wildcard) answer. Use signer from the 
+		/* No SOA in positive (wildcard) answer. Use signer from the
 		 * validated answer RRsets' signature. */
 		if(!(dname = reply_nsec_signer(rep, &dname_len, &rrset_class)))
 			return;
@@ -902,9 +902,9 @@ void val_neg_addreply(struct val_neg_cache* neg, struct reply_info* rep)
 
 	log_nametypeclass(VERB_ALGO, "negcache insert for zone",
 		dname, LDNS_RR_TYPE_SOA, rrset_class);
-	
+
 	/* ask for enough space to store all of it */
-	need = calc_data_need(rep) + 
+	need = calc_data_need(rep) +
 		calc_zone_need(dname, dname_len);
 	lock_basic_lock(&neg->lock);
 	neg_make_space(neg, need);
@@ -925,7 +925,7 @@ void val_neg_addreply(struct val_neg_cache* neg, struct reply_info* rep)
 	for(i=rep->an_numrrsets; i< rep->an_numrrsets+rep->ns_numrrsets; i++){
 		if(ntohs(rep->rrsets[i]->rk.type) != LDNS_RR_TYPE_NSEC)
 			continue;
-		if(!dname_subdomain_c(rep->rrsets[i]->rk.dname, 
+		if(!dname_subdomain_c(rep->rrsets[i]->rk.dname,
 			zone->name)) continue;
 		/* insert NSEC into this zone's tree */
 		neg_insert_data(neg, zone, rep->rrsets[i]);
@@ -977,7 +977,7 @@ void val_neg_addreferral(struct val_neg_cache* neg, struct reply_info* rep,
 	/* no SOA in this message, find RRSIG over NSEC's signer name.
 	 * note the NSEC records are maybe not validated yet */
 	signer = reply_nsec_signer(rep, &signer_len, &dclass);
-	if(!signer) 
+	if(!signer)
 		return;
 	if(!dname_subdomain_c(signer, zone_name)) {
 		/* the signer is not in the bailiwick, throw it out */
@@ -986,7 +986,7 @@ void val_neg_addreferral(struct val_neg_cache* neg, struct reply_info* rep,
 
 	log_nametypeclass(VERB_ALGO, "negcache insert referral ",
 		signer, LDNS_RR_TYPE_NS, dclass);
-	
+
 	/* ask for enough space to store all of it */
 	need = calc_data_need(rep) + calc_zone_need(signer, signer_len);
 	lock_basic_lock(&neg->lock);
@@ -995,7 +995,7 @@ void val_neg_addreferral(struct val_neg_cache* neg, struct reply_info* rep,
 	/* find or create the zone entry */
 	zone = neg_find_zone(neg, signer, signer_len, dclass);
 	if(!zone) {
-		if(!(zone = neg_create_zone(neg, signer, signer_len, 
+		if(!(zone = neg_create_zone(neg, signer, signer_len,
 			dclass))) {
 			lock_basic_unlock(&neg->lock);
 			log_err("out of memory adding negative zone");
@@ -1009,7 +1009,7 @@ void val_neg_addreferral(struct val_neg_cache* neg, struct reply_info* rep,
 		if(ntohs(rep->rrsets[i]->rk.type) != LDNS_RR_TYPE_NSEC &&
 			ntohs(rep->rrsets[i]->rk.type) != LDNS_RR_TYPE_NSEC3)
 			continue;
-		if(!dname_subdomain_c(rep->rrsets[i]->rk.dname, 
+		if(!dname_subdomain_c(rep->rrsets[i]->rk.dname,
 			zone->name)) continue;
 		/* insert NSEC into this zone's tree */
 		neg_insert_data(neg, zone, rep->rrsets[i]);
@@ -1058,8 +1058,8 @@ static int nsec3_no_type(struct ub_packed_rrset_key* k, uint16_t t)
  */
 static struct ub_packed_rrset_key*
 grab_nsec(struct rrset_cache* rrset_cache, uint8_t* qname, size_t qname_len,
-	uint16_t qtype, uint16_t qclass, uint32_t flags, 
-	struct regional* region, int checkbit, uint16_t checktype, 
+	uint16_t qtype, uint16_t qclass, uint32_t flags,
+	struct regional* region, int checkbit, uint16_t checktype,
 	time_t now)
 {
 	struct ub_packed_rrset_key* r, *k = rrset_cache_lookup(rrset_cache,
@@ -1169,8 +1169,8 @@ neg_find_nsec3_ce(struct val_neg_zone* zone, uint8_t* qname, size_t qname_len,
 	*nclen = 0;
 	while(qlabs > 0) {
 		/* hash */
-		if(!(celen=nsec3_get_hashed(buf, qname, qname_len, 
-			zone->nsec3_hash, zone->nsec3_iter, zone->nsec3_salt, 
+		if(!(celen=nsec3_get_hashed(buf, qname, qname_len,
+			zone->nsec3_hash, zone->nsec3_iter, zone->nsec3_salt,
 			zone->nsec3_saltlen, hashce, sizeof(hashce))))
 			return NULL;
 		if(!(b32len=nsec3_hash_to_b32(hashce, celen, zone->name,
@@ -1210,7 +1210,7 @@ neg_params_ok(struct val_neg_zone* zone, struct ub_packed_rrset_key* rrset)
 /** get next closer for nsec3 proof */
 static struct ub_packed_rrset_key*
 neg_nsec3_getnc(struct val_neg_zone* zone, uint8_t* hashnc, size_t nclen,
-	struct rrset_cache* rrset_cache, struct regional* region, 
+	struct rrset_cache* rrset_cache, struct regional* region,
 	time_t now, uint8_t* b32, size_t maxb32)
 {
 	struct ub_packed_rrset_key* nc_rrset;
@@ -1231,7 +1231,7 @@ neg_nsec3_getnc(struct val_neg_zone* zone, uint8_t* hashnc, size_t nclen,
 	if(!data)
 		return NULL;
 	/* got a data element in tree, grab it */
-	nc_rrset = grab_nsec(rrset_cache, data->name, data->len, 
+	nc_rrset = grab_nsec(rrset_cache, data->name, data->len,
 		LDNS_RR_TYPE_NSEC3, zone->dclass, 0, region, 0, 0, now);
 	if(!nc_rrset)
 		return NULL;
@@ -1256,13 +1256,13 @@ neg_nsec3_proof_ds(struct val_neg_zone* zone, uint8_t* qname, size_t qname_len,
 
 	/* for NSEC3 ; determine the closest encloser for which we
 	 * can find an exact match. Remember the hashed lower name,
-	 * since that is the one we need a closest match for. 
+	 * since that is the one we need a closest match for.
 	 * If we find a match straight away, then it becomes NODATA.
 	 * Otherwise, NXDOMAIN or if OPTOUT, an insecure delegation.
 	 * Also check that parameters are the same on closest encloser
 	 * and on closest match.
 	 */
-	if(!zone->nsec3_hash) 
+	if(!zone->nsec3_hash)
 		return NULL; /* not nsec3 zone */
 
 	if(!(data=neg_find_nsec3_ce(zone, qname, qname_len, qlabs, buf,
@@ -1271,8 +1271,8 @@ neg_nsec3_proof_ds(struct val_neg_zone* zone, uint8_t* qname, size_t qname_len,
 	}
 
 	/* grab the ce rrset */
-	ce_rrset = grab_nsec(rrset_cache, data->name, data->len, 
-		LDNS_RR_TYPE_NSEC3, zone->dclass, 0, region, 1, 
+	ce_rrset = grab_nsec(rrset_cache, data->name, data->len,
+		LDNS_RR_TYPE_NSEC3, zone->dclass, 0, region, 1,
 		LDNS_RR_TYPE_DS, now);
 	if(!ce_rrset)
 		return NULL;
@@ -1286,11 +1286,11 @@ neg_nsec3_proof_ds(struct val_neg_zone* zone, uint8_t* qname, size_t qname_len,
 			nsec3_has_type(ce_rrset, 0, LDNS_RR_TYPE_DS) ||
 			!nsec3_has_type(ce_rrset, 0, LDNS_RR_TYPE_NS))
 			return NULL;
-		if(!(msg = dns_msg_create(qname, qname_len, 
-			LDNS_RR_TYPE_DS, zone->dclass, region, 1))) 
+		if(!(msg = dns_msg_create(qname, qname_len,
+			LDNS_RR_TYPE_DS, zone->dclass, region, 1)))
 			return NULL;
 		/* TTL reduced in grab_nsec */
-		if(!dns_msg_authadd(msg, region, ce_rrset, 0)) 
+		if(!dns_msg_authadd(msg, region, ce_rrset, 0))
 			return NULL;
 		return msg;
 	}
@@ -1302,9 +1302,9 @@ neg_nsec3_proof_ds(struct val_neg_zone* zone, uint8_t* qname, size_t qname_len,
 
 	/* if there is no exact match, it must be in an optout span
 	 * (an existing DS implies an NSEC3 must exist) */
-	nc_rrset = neg_nsec3_getnc(zone, hashnc, nclen, rrset_cache, 
+	nc_rrset = neg_nsec3_getnc(zone, hashnc, nclen, rrset_cache,
 		region, now, nc_b32, sizeof(nc_b32));
-	if(!nc_rrset) 
+	if(!nc_rrset)
 		return NULL;
 	if(!neg_params_ok(zone, nc_rrset))
 		return NULL;
@@ -1320,13 +1320,13 @@ neg_nsec3_proof_ds(struct val_neg_zone* zone, uint8_t* qname, size_t qname_len,
 		 * nc_rrset is optout.
 		 * No need to check wildcard for type DS */
 		/* capacity=3: ce + nc + soa(if needed) */
-		if(!(msg = dns_msg_create(qname, qname_len, 
-			LDNS_RR_TYPE_DS, zone->dclass, region, 3))) 
+		if(!(msg = dns_msg_create(qname, qname_len,
+			LDNS_RR_TYPE_DS, zone->dclass, region, 3)))
 			return NULL;
 		/* now=0 because TTL was reduced in grab_nsec */
-		if(!dns_msg_authadd(msg, region, ce_rrset, 0)) 
+		if(!dns_msg_authadd(msg, region, ce_rrset, 0))
 			return NULL;
-		if(!dns_msg_authadd(msg, region, nc_rrset, 0)) 
+		if(!dns_msg_authadd(msg, region, nc_rrset, 0))
 			return NULL;
 		return msg;
 	}
@@ -1356,10 +1356,10 @@ static int add_soa(struct rrset_cache* rrset_cache, time_t now,
 	} else {
 		/* Assumes the signer is the zone SOA to add */
 		nm = reply_nsec_signer(msg->rep, &nmlen, &dclass);
-		if(!nm) 
+		if(!nm)
 			return 0;
 	}
-	soa = rrset_cache_lookup(rrset_cache, nm, nmlen, LDNS_RR_TYPE_SOA, 
+	soa = rrset_cache_lookup(rrset_cache, nm, nmlen, LDNS_RR_TYPE_SOA,
 		dclass, PACKED_RRSET_SOA_NEG, now, 0);
 	if(!soa)
 		return 0;
@@ -1371,9 +1371,9 @@ static int add_soa(struct rrset_cache* rrset_cache, time_t now,
 	return 1;
 }
 
-struct dns_msg* 
-val_neg_getmsg(struct val_neg_cache* neg, struct query_info* qinfo, 
-	struct regional* region, struct rrset_cache* rrset_cache, 
+struct dns_msg*
+val_neg_getmsg(struct val_neg_cache* neg, struct query_info* qinfo,
+	struct regional* region, struct rrset_cache* rrset_cache,
 	sldns_buffer* buf, time_t now, int addsoa, uint8_t* topname,
 	struct config_file* cfg)
 {
@@ -1410,10 +1410,10 @@ val_neg_getmsg(struct val_neg_cache* neg, struct query_info* qinfo,
 		 * qtype ANY, in the else branch. */
 		if(qinfo->qtype == LDNS_RR_TYPE_ANY)
 			return NULL;
-		if(!(msg = dns_msg_create(qinfo->qname, qinfo->qname_len, 
-			qinfo->qtype, qinfo->qclass, region, 2))) 
+		if(!(msg = dns_msg_create(qinfo->qname, qinfo->qname_len,
+			qinfo->qtype, qinfo->qclass, region, 2)))
 			return NULL;
-		if(!dns_msg_authadd(msg, region, nsec, 0)) 
+		if(!dns_msg_authadd(msg, region, nsec, 0))
 			return NULL;
 		if(addsoa && !add_soa(rrset_cache, now, region, msg, NULL))
 			return NULL;
@@ -1423,8 +1423,8 @@ val_neg_getmsg(struct val_neg_cache* neg, struct query_info* qinfo,
 		lock_basic_unlock(&neg->lock);
 		return msg;
 	} else if(nsec && val_nsec_proves_name_error(nsec, qinfo->qname)) {
-		if(!(msg = dns_msg_create(qinfo->qname, qinfo->qname_len, 
-			qinfo->qtype, qinfo->qclass, region, 3))) 
+		if(!(msg = dns_msg_create(qinfo->qname, qinfo->qname_len,
+			qinfo->qtype, qinfo->qclass, region, 3)))
 			return NULL;
 		if(!(ce = nsec_closest_encloser(qinfo->qname, nsec)))
 			return NULL;
@@ -1526,7 +1526,7 @@ val_neg_getmsg(struct val_neg_cache* neg, struct query_info* qinfo,
 
 	/* lookup closest zone */
 	lock_basic_lock(&neg->lock);
-	zone = neg_closest_zone_parent(neg, zname, zname_len, zname_labs, 
+	zone = neg_closest_zone_parent(neg, zname, zname_len, zname_labs,
 		qinfo->qclass);
 	while(zone && !zone->in_use)
 		zone = zone->parent;
@@ -1541,7 +1541,7 @@ val_neg_getmsg(struct val_neg_cache* neg, struct query_info* qinfo,
 		return NULL;
 	}
 
-	msg = neg_nsec3_proof_ds(zone, qinfo->qname, qinfo->qname_len, 
+	msg = neg_nsec3_proof_ds(zone, qinfo->qname, qinfo->qname_len,
 		zname_labs+1, buf, rrset_cache, region, now, topname);
 	if(msg && addsoa && !add_soa(rrset_cache, now, region, msg, zone)) {
 		lock_basic_unlock(&neg->lock);


### PR DESCRIPTION
    What I changed:

    Respected repo rules / avoided generated & third‑party artifacts

    Skipped Autotools/libtool generated files like configure, aclocal.m4, ltmain.sh, config.guess, config.sub.
    Skipped large test vectors (testdata/, dnscrypt/testdata/) and non-UTF8 sample data (pythonmod/examples/dict_data.txt).
    Skipped contrib/fastrpz.patch (patch content is effectively third‑party / not meant to be edited in-tree).

    Fixed typos in maintained sources/docs

    Various doc/comment spelling fixes (e.g. doc/Changelog, doc/example.conf.in, headers, etc.).
    Fixed a real typo in a runtime log message: cachedb/redis.c ("%swith" -> "%s with").
    Updated Makefile.in to avoid the misspelling Decomissioned while still matching both spellings via regex.
    Fixed Synthetize -> Synthesize and other comment-level typos.
    Improved a few “codespell false-positive” tokens by adjusting comments (e.g. inout -> in/out).

    Repaired an accidental corruption

    During edits, daemon/remote.c got partially mangled around the view local-data handlers. I restored it by:
    Reintroducing do_view_data_remove()
    Repairing do_view_datas_add() and its end-of-function logic
    Cleaning up the remaining removed 0 ... message text

    Added future-proof configuration

    Created repo-root .codespellrc with:

    skip = ... list matching the “do not edit / generated / testdata” policy
    ignore-words-list = ... for known project terms / false positives
    ignore-regex = ... to preserve your existing ignore patterns

    Verification

    codespell --config ./.codespellrc . now exits 0 (clean run).
    Summary
    Typos were fixed where safe, generated/third-party areas were excluded, .codespellrc was added for repeatable checks, and codespell now passes cleanly using that config.

    Signed-off-by: rezky_nightky <with.rezky@gmail.com>