### PR TITLE
Fix #1412: local zone data bypassed during CNAME chain resolution with forwarders

### DIFF
--- a/daemon/daemon.c
+++ b/daemon/daemon.c
@@ -782,6 +782,7 @@ daemon_fork(struct daemon* daemon)
 		fatal_exit("Could not create local zones: out of memory");
 	if(!local_zones_apply_cfg(daemon->local_zones, daemon->cfg))
 		fatal_exit("Could not set up local zones");
+	daemon->env->local_zones = daemon->local_zones;
 	if(!(daemon->env->fwds = forwards_create()) ||
 		!forwards_apply_cfg(daemon->env->fwds, daemon->cfg))
 		fatal_exit("Could not set forward zones");
@@ -918,6 +919,7 @@ daemon_cleanup(struct daemon* daemon)
 	daemon->env->hints = NULL;
 	local_zones_delete(daemon->local_zones);
 	daemon->local_zones = NULL;
+	daemon->env->local_zones = NULL;
 	respip_set_delete(daemon->env->respip_set);
 	daemon->env->respip_set = NULL;
 	views_delete(daemon->env->views);

--- a/iterator/iterator.c
+++ b/iterator/iterator.c
@@ -55,6 +55,7 @@
 #include "services/cache/rrset.h"
 #include "services/cache/infra.h"
 #include "services/authzone.h"
+#include "services/localzone.h"
 #include "util/module.h"
 #include "util/netevent.h"
 #include "util/net_help.h"
@@ -1479,39 +1480,61 @@ processInitRequest(struct module_qstate* qstate, struct iter_qstate* iq,
 		}
 	}
 
-	if (iter_stub_fwd_no_cache(qstate, &iq->qchase, &dpname, &dpnamelen,
-		dpname_storage, sizeof(dpname_storage))) {
-		/* Asked to not query cache. */
-		verbose(VERB_ALGO, "no-cache set, going to the network");
-		qstate->no_cache_lookup = 1;
-		qstate->no_cache_store = 1;
-		msg = NULL;
-	} else if(qstate->blacklist) {
-		/* if cache, or anything else, was blacklisted then
-		 * getting older results from cache is a bad idea, no cache */
-		verbose(VERB_ALGO, "cache blacklisted, going to the network");
-		msg = NULL;
-	} else if(!qstate->no_cache_lookup) {
-		msg = dns_cache_lookup(qstate->env, iq->qchase.qname, 
-			iq->qchase.qname_len, iq->qchase.qtype, 
-			iq->qchase.qclass, qstate->query_flags,
-			qstate->region, qstate->env->scratch, 0, dpname,
-			dpnamelen);
-		if(!msg && qstate->env->neg_cache &&
-			iter_qname_indicates_dnssec(qstate->env, &iq->qchase)) {
-			/* lookup in negative cache; may result in
-			 * NOERROR/NODATA or NXDOMAIN answers that need validation */
-			msg = val_neg_getmsg(qstate->env->neg_cache, &iq->qchase,
-				qstate->region, qstate->env->rrset_cache,
-				qstate->env->scratch_buffer, 
-				*qstate->env->now, 1/*add SOA*/, NULL, 
-				qstate->env->cfg);
+	/* local zones are not consulted during CNAME restarts;
+	 * check them here before the cache lookup */
+	if(iq->query_restart_count > 0 && qstate->env->local_zones) {
+		int is_local = 0;
+		msg = local_zones_lookup_msg(qstate->env->local_zones,
+			&iq->qchase, qstate->region, &is_local);
+		if(msg) {
+			verbose(VERB_ALGO, "local zone answer for "
+				"CNAME target");
+		} else if(is_local) {
+			verbose(VERB_ALGO, "local zone has no data "
+				"for CNAME target");
 		}
-		/* item taken from cache does not match our query name, thus
-		 * security needs to be re-examined later */
-		if(msg && query_dname_compare(qstate->qinfo.qname,
-			iq->qchase.qname) != 0)
-			msg->rep->security = sec_status_unchecked;
+	}
+
+	if(!msg) {
+		if(iter_stub_fwd_no_cache(qstate, &iq->qchase, &dpname,
+			&dpnamelen, dpname_storage,
+			sizeof(dpname_storage))) {
+			verbose(VERB_ALGO, "no-cache, going to "
+				"the network");
+			qstate->no_cache_lookup = 1;
+			qstate->no_cache_store = 1;
+		} else if(qstate->blacklist) {
+			verbose(VERB_ALGO, "blacklisted, going "
+				"to the network");
+		} else if(!qstate->no_cache_lookup) {
+			msg = dns_cache_lookup(qstate->env,
+				iq->qchase.qname,
+				iq->qchase.qname_len,
+				iq->qchase.qtype,
+				iq->qchase.qclass,
+				qstate->query_flags,
+				qstate->region,
+				qstate->env->scratch, 0,
+				dpname, dpnamelen);
+			if(!msg && qstate->env->neg_cache &&
+				iter_qname_indicates_dnssec(
+				qstate->env, &iq->qchase)) {
+				msg = val_neg_getmsg(
+					qstate->env->neg_cache,
+					&iq->qchase,
+					qstate->region,
+					qstate->env->rrset_cache,
+					qstate->env->scratch_buffer,
+					*qstate->env->now,
+					1/*add SOA*/, NULL,
+					qstate->env->cfg);
+			}
+			if(msg && query_dname_compare(
+				qstate->qinfo.qname,
+				iq->qchase.qname) != 0)
+				msg->rep->security =
+					sec_status_unchecked;
+		}
 	}
 	if(msg) {
 		/* handle positive cache response */
@@ -3528,12 +3551,48 @@ processQueryResponse(struct module_qstate* qstate, struct iter_qstate* iq,
 		/* NOTE : set referral=1, so that rrsets get stored but not 
 		 * the partial query answer (CNAME only). */
 		/* prefetchleeway applied because this updates answer parts */
-		if(!qstate->no_cache_store)
-			iter_dns_store(qstate->env, &iq->response->qinfo,
-				iq->response->rep, 1, qstate->prefetch_leeway,
-				iq->dp&&iq->dp->has_parent_side_NS, NULL,
-				qstate->query_flags, qstate->qstarttime,
-				qstate->is_valrec);
+		if(!qstate->no_cache_store) {
+			int skip_store = 0;
+			/* skip storing rrsets that belong to a local zone
+			 * to prevent upstream TTLs from overriding
+			 * local-data */
+			if(qstate->env->local_zones) {
+				size_t ii;
+				struct reply_info* rrep = iq->response->rep;
+				for(ii=0; ii<rrep->rrset_count; ii++) {
+					int is_lz = 0;
+					struct query_info lzqi;
+					struct ub_packed_rrset_key* rs =
+						rrep->rrsets[ii];
+					memset(&lzqi, 0, sizeof(lzqi));
+					lzqi.qname = rs->rk.dname;
+					lzqi.qname_len = rs->rk.dname_len;
+					lzqi.qtype = ntohs(rs->rk.type);
+					lzqi.qclass = ntohs(
+						rs->rk.rrset_class);
+					(void)local_zones_lookup_msg(
+						qstate->env->local_zones,
+						&lzqi, qstate->region,
+						&is_lz);
+					if(is_lz) {
+						verbose(VERB_ALGO,
+							"skip cache store, "
+							"rrset in local zone");
+						skip_store = 1;
+						break;
+					}
+				}
+			}
+			if(!skip_store)
+				iter_dns_store(qstate->env,
+					&iq->response->qinfo,
+					iq->response->rep, 1,
+					qstate->prefetch_leeway,
+					iq->dp&&iq->dp->has_parent_side_NS,
+					NULL, qstate->query_flags,
+					qstate->qstarttime,
+					qstate->is_valrec);
+		}
 		/* set the current request's qname to the new value. */
 		iq->qchase.qname = sname;
 		iq->qchase.qname_len = snamelen;

--- a/services/localzone.c
+++ b/services/localzone.c
@@ -51,6 +51,7 @@
 #include "util/data/msgreply.h"
 #include "util/data/msgparse.h"
 #include "util/as112.h"
+#include "services/cache/dns.h"
 
 /* maximum RRs in an RRset, to cap possible 'endless' list RRs.
  * with 16 bytes for an A record, a 64K packet has about 4000 max */
@@ -2274,4 +2275,182 @@ void local_zones_swap_tree(struct local_zones* zones, struct local_zones* data)
 	rbtree_type oldtree = zones->ztree;
 	zones->ztree = data->ztree;
 	data->ztree = oldtree;
+}
+
+/** return true if zone type provides authoritative answers */
+static int
+lz_type_is_answer(enum localzone_type t)
+{
+	switch(t) {
+	case local_zone_redirect:
+	case local_zone_static:
+	case local_zone_deny:
+	case local_zone_refuse:
+	case local_zone_inform_deny:
+	case local_zone_inform_redirect:
+	case local_zone_always_refuse:
+	case local_zone_always_nxdomain:
+	case local_zone_always_nodata:
+	case local_zone_always_deny:
+	case local_zone_always_null:
+	case local_zone_truncate:
+		return 1;
+	default:
+		return 0;
+	}
+}
+
+struct dns_msg*
+local_zones_lookup_msg(struct local_zones* zones, struct query_info* qinfo,
+	struct regional* region, int* is_local_zone)
+{
+	struct local_zone* z;
+	struct local_data key;
+	struct local_data* ld;
+	struct local_rrset* lr;
+	struct dns_msg* msg;
+	struct packed_rrset_data* d;
+	struct packed_rrset_data* newd;
+	int labs;
+	size_t i, total;
+
+	*is_local_zone = 0;
+	if(!zones) return NULL;
+
+	labs = dname_count_labels(qinfo->qname);
+
+	lock_rw_rdlock(&zones->lock);
+	z = local_zones_lookup(zones, qinfo->qname, qinfo->qname_len,
+		labs, qinfo->qclass, qinfo->qtype, 0);
+	if(!z) {
+		lock_rw_unlock(&zones->lock);
+		return NULL;
+	}
+	lock_rw_rdlock(&z->lock);
+	lock_rw_unlock(&zones->lock);
+
+	if(!lz_type_is_answer(z->type)) {
+		lock_rw_unlock(&z->lock);
+		return NULL;
+	}
+	*is_local_zone = 1;
+
+	/* redirect zones store data under the zone apex */
+	key.node.key = &key;
+	if(z->type == local_zone_redirect ||
+		z->type == local_zone_inform_redirect) {
+		key.name = z->name;
+		key.namelen = z->namelen;
+		key.namelabs = z->namelabs;
+	} else {
+		key.name = qinfo->qname;
+		key.namelen = qinfo->qname_len;
+		key.namelabs = labs;
+	}
+
+	ld = (struct local_data*)rbtree_search(&z->data, &key.node);
+	if(!ld) {
+		lock_rw_unlock(&z->lock);
+		return NULL;
+	}
+
+	lr = local_data_find_type(ld, qinfo->qtype, 1);
+	if(!lr) {
+		lock_rw_unlock(&z->lock);
+		return NULL;
+	}
+
+	d = (struct packed_rrset_data*)lr->rrset->entry.data;
+
+	msg = (struct dns_msg*)regional_alloc_zero(region, sizeof(*msg));
+	if(!msg) {
+		lock_rw_unlock(&z->lock);
+		return NULL;
+	}
+	msg->qinfo = *qinfo;
+	msg->qinfo.qname = regional_alloc_init(region, qinfo->qname,
+		qinfo->qname_len);
+	if(!msg->qinfo.qname) {
+		lock_rw_unlock(&z->lock);
+		return NULL;
+	}
+	msg->qinfo.local_alias = NULL;
+
+	/* non-packed reply_info, rrsets array allocated separately */
+	msg->rep = (struct reply_info*)regional_alloc_zero(region,
+		sizeof(struct reply_info) - sizeof(struct rrset_ref));
+	if(!msg->rep) {
+		lock_rw_unlock(&z->lock);
+		return NULL;
+	}
+	msg->rep->rrsets = (struct ub_packed_rrset_key**)
+		regional_alloc(region, sizeof(struct ub_packed_rrset_key*));
+	if(!msg->rep->rrsets) {
+		lock_rw_unlock(&z->lock);
+		return NULL;
+	}
+	msg->rep->flags = BIT_QR | BIT_AA;
+	msg->rep->qdcount = 1;
+	msg->rep->an_numrrsets = 1;
+	msg->rep->rrset_count = 1;
+	msg->rep->ttl = d->ttl;
+	msg->rep->prefetch_ttl = PREFETCH_TTL_CALC(d->ttl);
+	msg->rep->serve_expired_ttl = d->ttl + SERVE_EXPIRED_TTL;
+	msg->rep->security = sec_status_insecure;
+	msg->rep->reason_bogus = LDNS_EDE_NONE;
+
+	/* deep-copy the rrset into the caller's region */
+	msg->rep->rrsets[0] = (struct ub_packed_rrset_key*)
+		regional_alloc_zero(region, sizeof(struct ub_packed_rrset_key));
+	if(!msg->rep->rrsets[0]) {
+		lock_rw_unlock(&z->lock);
+		return NULL;
+	}
+	msg->rep->rrsets[0]->entry.key = msg->rep->rrsets[0];
+	msg->rep->rrsets[0]->rk = lr->rrset->rk;
+	/* rewrite dname for redirect zones (stored as zone apex) */
+	msg->rep->rrsets[0]->rk.dname = regional_alloc_init(region,
+		qinfo->qname, qinfo->qname_len);
+	if(!msg->rep->rrsets[0]->rk.dname) {
+		lock_rw_unlock(&z->lock);
+		return NULL;
+	}
+	msg->rep->rrsets[0]->rk.dname_len = qinfo->qname_len;
+	msg->rep->rrsets[0]->entry.hash =
+		rrset_key_hash(&msg->rep->rrsets[0]->rk);
+
+	total = d->count + d->rrsig_count;
+	newd = (struct packed_rrset_data*)regional_alloc_zero(region,
+		sizeof(struct packed_rrset_data)
+		+ total * (sizeof(size_t) + sizeof(uint8_t*)
+			   + sizeof(time_t)));
+	if(!newd) {
+		lock_rw_unlock(&z->lock);
+		return NULL;
+	}
+	newd->ttl = d->ttl;
+	newd->count = d->count;
+	newd->rrsig_count = d->rrsig_count;
+	newd->trust = rrset_trust_prim_noglue;
+	newd->security = sec_status_insecure;
+	newd->rr_len = (size_t*)((uint8_t*)newd
+		+ sizeof(struct packed_rrset_data));
+	newd->rr_data = (uint8_t**)((uint8_t*)newd->rr_len
+		+ total * sizeof(size_t));
+	newd->rr_ttl = (time_t*)((uint8_t*)newd->rr_data
+		+ total * sizeof(uint8_t*));
+	for(i = 0; i < total; i++) {
+		newd->rr_len[i] = d->rr_len[i];
+		newd->rr_ttl[i] = d->rr_ttl[i];
+		newd->rr_data[i] = regional_alloc_init(region,
+			d->rr_data[i], d->rr_len[i]);
+		if(!newd->rr_data[i]) {
+			lock_rw_unlock(&z->lock);
+			return NULL;
+		}
+	}
+	msg->rep->rrsets[0]->entry.data = newd;
+
+	lock_rw_unlock(&z->lock);
+	return msg;
 }

--- a/services/localzone.h
+++ b/services/localzone.h
@@ -56,6 +56,7 @@ struct query_info;
 struct sldns_buffer;
 struct comm_reply;
 struct config_strlist;
+struct dns_msg;
 
 /**
  * Local zone type
@@ -679,4 +680,17 @@ lz_enter_zone(struct local_zones* zones, const char* name, const char* type,
  */
 void
 lz_init_parents(struct local_zones* zones);
+
+/**
+ * Look up a query in local zones and return a dns_msg if the zone
+ * provides authoritative data (redirect, static, etc.).
+ * @param zones: local zones tree.
+ * @param qinfo: query name, type, class.
+ * @param region: regional allocator for the dns_msg.
+ * @param is_local_zone: set to 1 if name is in an authoritative local zone.
+ * @return dns_msg with answer, or NULL if no match or no data.
+ */
+struct dns_msg* local_zones_lookup_msg(struct local_zones* zones,
+	struct query_info* qinfo, struct regional* region, int* is_local_zone);
+
 #endif /* SERVICES_LOCALZONE_H */

--- a/testdata/iter_localzone_cname.rpl
+++ b/testdata/iter_localzone_cname.rpl
@@ -1,0 +1,298 @@
+; config options
+; Test that local zones are consulted during iterator CNAME restarts.
+; When a forwarder returns a CNAME whose target is covered by an
+; authoritative local zone (redirect, static), the local zone data
+; must be used instead of forwarding the target query upstream.
+; Also tests that upstream rrsets for local zone names are not cached.
+server:
+	target-fetch-policy: "0 0 0 0 0"
+	rrset-roundrobin: no
+
+	; localhost redirect zone with custom TTL (the production use case)
+	local-zone: "localhost." redirect
+	local-data: "localhost. 70 IN A 127.0.0.1"
+	local-data: "localhost. 70 IN AAAA ::1"
+
+	; static zone for reverse lookup
+	local-zone: "mylocal.example." static
+	local-data: "mylocal.example. IN A 10.20.30.40"
+	local-data: "mylocal.example. IN SOA ns.mylocal.example. nobody.invalid. 1 3600 1200 604800 70"
+
+	; transparent zone: should NOT intercept CNAME targets
+	local-zone: "passthru.example." transparent
+	local-data: "passthru.example. IN A 1.2.3.4"
+
+forward-zone:
+	name: "."
+	forward-addr: 10.0.10.3
+CONFIG_END
+
+SCENARIO_BEGIN Test local zone lookup during CNAME restarts with forwarders
+
+; Upstream forwarder answers
+RANGE_BEGIN 0 1000
+	ADDRESS 10.0.10.3
+
+; Query for ftphost.example.com returns CNAME -> localhost.
+; This simulates the production scenario: fqdnd queries a hostname
+; that is a CNAME pointing to localhost.
+ENTRY_BEGIN
+MATCH opcode qtype qname
+ADJUST copy_id
+REPLY QR NOERROR
+SECTION QUESTION
+ftphost.example.com. IN A
+SECTION ANSWER
+ftphost.example.com. 3600 IN CNAME localhost.
+localhost. 86400 IN A 127.0.0.1
+SECTION AUTHORITY
+SECTION ADDITIONAL
+ENTRY_END
+
+; AAAA query for the same CNAME
+ENTRY_BEGIN
+MATCH opcode qtype qname
+ADJUST copy_id
+REPLY QR NOERROR
+SECTION QUESTION
+ftphost.example.com. IN AAAA
+SECTION ANSWER
+ftphost.example.com. 3600 IN CNAME localhost.
+localhost. 86400 IN AAAA ::1
+SECTION AUTHORITY
+SECTION ADDITIONAL
+ENTRY_END
+
+; CNAME target in a static local zone
+ENTRY_BEGIN
+MATCH opcode qtype qname
+ADJUST copy_id
+REPLY QR NOERROR
+SECTION QUESTION
+redir.example.com. IN A
+SECTION ANSWER
+redir.example.com. 3600 IN CNAME mylocal.example.
+mylocal.example. 86400 IN A 99.99.99.99
+SECTION AUTHORITY
+SECTION ADDITIONAL
+ENTRY_END
+
+; CNAME target in a transparent zone: upstream answer should be used
+ENTRY_BEGIN
+MATCH opcode qtype qname
+ADJUST copy_id
+REPLY QR NOERROR
+SECTION QUESTION
+tpass.example.com. IN A
+SECTION ANSWER
+tpass.example.com. 3600 IN CNAME passthru.example.
+passthru.example. 86400 IN A 5.6.7.8
+SECTION AUTHORITY
+SECTION ADDITIONAL
+ENTRY_END
+
+; Direct query for passthru.example (used when transparent falls through)
+ENTRY_BEGIN
+MATCH opcode qtype qname
+ADJUST copy_id
+REPLY QR NOERROR
+SECTION QUESTION
+passthru.example. IN A
+SECTION ANSWER
+passthru.example. 86400 IN A 5.6.7.8
+SECTION AUTHORITY
+SECTION ADDITIONAL
+ENTRY_END
+
+; Two-hop chain: external -> CNAME -> intermediate -> CNAME -> localhost.
+ENTRY_BEGIN
+MATCH opcode qtype qname
+ADJUST copy_id
+REPLY QR NOERROR
+SECTION QUESTION
+chain.example.com. IN A
+SECTION ANSWER
+chain.example.com. 3600 IN CNAME hop.example.com.
+SECTION AUTHORITY
+SECTION ADDITIONAL
+ENTRY_END
+
+ENTRY_BEGIN
+MATCH opcode qtype qname
+ADJUST copy_id
+REPLY QR NOERROR
+SECTION QUESTION
+hop.example.com. IN A
+SECTION ANSWER
+hop.example.com. 3600 IN CNAME localhost.
+localhost. 86400 IN A 127.0.0.1
+SECTION AUTHORITY
+SECTION ADDITIONAL
+ENTRY_END
+
+; Direct localhost query from upstream (should not be needed if
+; local zone intercepts, but provided as fallback for verification)
+ENTRY_BEGIN
+MATCH opcode qtype qname
+ADJUST copy_id
+REPLY QR NOERROR
+SECTION QUESTION
+localhost. IN A
+SECTION ANSWER
+localhost. 86400 IN A 127.0.0.1
+SECTION AUTHORITY
+SECTION ADDITIONAL
+ENTRY_END
+
+RANGE_END
+
+; -----------------------------------------------------------------
+; Test 1: CNAME -> localhost (redirect zone)
+; The upstream returns localhost A with TTL 86400, but the local zone
+; has TTL 70.  The answer must use the local zone TTL.
+; -----------------------------------------------------------------
+STEP 10 QUERY
+ENTRY_BEGIN
+REPLY RD
+SECTION QUESTION
+ftphost.example.com. IN A
+ENTRY_END
+
+STEP 11 CHECK_ANSWER
+ENTRY_BEGIN
+MATCH all
+REPLY QR RD RA NOERROR
+SECTION QUESTION
+ftphost.example.com. IN A
+SECTION ANSWER
+ftphost.example.com. 3600 IN CNAME localhost.
+localhost. 70 IN A 127.0.0.1
+SECTION AUTHORITY
+SECTION ADDITIONAL
+ENTRY_END
+
+; -----------------------------------------------------------------
+; Test 2: Same with AAAA — CNAME -> localhost AAAA
+; -----------------------------------------------------------------
+STEP 20 QUERY
+ENTRY_BEGIN
+REPLY RD
+SECTION QUESTION
+ftphost.example.com. IN AAAA
+ENTRY_END
+
+STEP 21 CHECK_ANSWER
+ENTRY_BEGIN
+MATCH all
+REPLY QR RD RA NOERROR
+SECTION QUESTION
+ftphost.example.com. IN AAAA
+SECTION ANSWER
+ftphost.example.com. 3600 IN CNAME localhost.
+localhost. 70 IN AAAA ::1
+SECTION AUTHORITY
+SECTION ADDITIONAL
+ENTRY_END
+
+; -----------------------------------------------------------------
+; Test 3: CNAME -> static local zone
+; Upstream returns mylocal.example A 99.99.99.99 with TTL 86400,
+; but local zone has 10.20.30.40.  Local data must win.
+; -----------------------------------------------------------------
+STEP 30 QUERY
+ENTRY_BEGIN
+REPLY RD
+SECTION QUESTION
+redir.example.com. IN A
+ENTRY_END
+
+STEP 31 CHECK_ANSWER
+ENTRY_BEGIN
+MATCH all
+REPLY QR RD RA NOERROR
+SECTION QUESTION
+redir.example.com. IN A
+SECTION ANSWER
+redir.example.com. 3600 IN CNAME mylocal.example.
+mylocal.example. IN A 10.20.30.40
+SECTION AUTHORITY
+SECTION ADDITIONAL
+ENTRY_END
+
+; -----------------------------------------------------------------
+; Test 4: CNAME -> transparent local zone (should NOT intercept)
+; Transparent zones allow normal resolution, so the upstream answer
+; should be used, not the local-data.
+; -----------------------------------------------------------------
+STEP 40 QUERY
+ENTRY_BEGIN
+REPLY RD
+SECTION QUESTION
+tpass.example.com. IN A
+ENTRY_END
+
+STEP 41 CHECK_ANSWER
+ENTRY_BEGIN
+MATCH all
+REPLY QR RD RA NOERROR
+SECTION QUESTION
+tpass.example.com. IN A
+SECTION ANSWER
+tpass.example.com. 3600 IN CNAME passthru.example.
+passthru.example. 86400 IN A 5.6.7.8
+SECTION AUTHORITY
+SECTION ADDITIONAL
+ENTRY_END
+
+; -----------------------------------------------------------------
+; Test 5: Two-hop CNAME chain ending at localhost
+; chain.example.com -> hop.example.com -> localhost.
+; Verifies local zone intercept works after multiple restarts.
+; -----------------------------------------------------------------
+STEP 50 QUERY
+ENTRY_BEGIN
+REPLY RD
+SECTION QUESTION
+chain.example.com. IN A
+ENTRY_END
+
+STEP 51 CHECK_ANSWER
+ENTRY_BEGIN
+MATCH all
+REPLY QR RD RA NOERROR
+SECTION QUESTION
+chain.example.com. IN A
+SECTION ANSWER
+chain.example.com. 3600 IN CNAME hop.example.com.
+hop.example.com. 3600 IN CNAME localhost.
+localhost. 70 IN A 127.0.0.1
+SECTION AUTHORITY
+SECTION ADDITIONAL
+ENTRY_END
+
+; -----------------------------------------------------------------
+; Test 6: Repeat test 1 to verify cache was not contaminated.
+; If the upstream 86400 TTL leaked into the rrset cache, this would
+; return TTL ~86400 instead of 70.
+; -----------------------------------------------------------------
+STEP 60 QUERY
+ENTRY_BEGIN
+REPLY RD
+SECTION QUESTION
+ftphost.example.com. IN A
+ENTRY_END
+
+STEP 61 CHECK_ANSWER
+ENTRY_BEGIN
+MATCH all
+REPLY QR RD RA NOERROR
+SECTION QUESTION
+ftphost.example.com. IN A
+SECTION ANSWER
+ftphost.example.com. 3600 IN CNAME localhost.
+localhost. 70 IN A 127.0.0.1
+SECTION AUTHORITY
+SECTION ADDITIONAL
+ENTRY_END
+
+SCENARIO_END

--- a/util/module.h
+++ b/util/module.h
@@ -519,6 +519,8 @@ struct module_env {
 	struct comm_timer* probe_timer;
 	/** auth zones */
 	struct auth_zones* auth_zones;
+	/** local authority zones */
+	struct local_zones* local_zones;
 	/** Mapping of forwarding zones to targets.
 	 * iterator forwarder information. */
 	struct iter_forwards* fwds;


### PR DESCRIPTION
**Summary**
When Unbound is configured with a forwarder and a local zone (e.g., local-zone: "localhost." redirect with local-data: "localhost. 70 IN A 127.0.0.1"), querying a name that the forwarder resolves as a CNAME pointing into the local zone (e.g., ftphost.example.com CNAME localhost.) causes the iterator to forward the CNAME target upstream instead of using local zone data. This results in the upstream TTL (e.g., 86400) being returned instead of the configured local-data TTL (e.g., 70), and the upstream answer contaminating the rrset cache.
The root cause is that local_zones_answer() in the worker layer only runs for the original client query. When the iterator follows a CNAME chain and restarts the query for the target name, it stays entirely within the iterator module -- local zones are never consulted for the restarted query.

**Changes**
1. Expose local zones to the module environment
util/module.h -- Add struct local_zones* local_zones to struct module_env so iterator (and other modules) can access local zone data. Placed alongside auth_zones where zone-related members are grouped.
daemon/daemon.c -- Initialize daemon->env->local_zones after local_zones_apply_cfg() succeeds in daemon_fork(). Clear it in daemon_cleanup() after local_zones_delete() to prevent dangling pointers. This is a borrowed pointer (daemon retains ownership), following the same pattern used for auth_zones, fwds, and hints.

2. New local zone lookup function
services/localzone.h -- Declare local_zones_lookup_msg() with forward declaration for struct dns_msg.
services/localzone.c -- Two new functions:
- lz_type_is_answer() (static): Returns true for zone types that provide authoritative answers and should intercept resolution -- redirect, static, deny, refuse, inform_deny, inform_redirect, always_refuse, always_nxdomain, always_nodata, always_deny, always_null, truncate. Returns false for transparent, typetransparent, inform, and nodefault (which allow fallthrough).
- local_zones_lookup_msg() (public): Looks up a query in local zones and constructs a dns_msg if the zone provides authoritative data. Key design decisions:
- [ ] Locking: Read-lock escalation (zones->lock -> lookup -> z->lock -> release zones->lock) matching the established pattern throughout localzone.c.
- [ ] Redirect zones: Data is looked up under the zone apex name (not the query name), matching lz_zone_answer() semantics.
- [ ] Deep copy: The rrset and its packed_rrset_data are fully deep-copied into the caller's regional allocator. Local zone data lives in its own region with relative TTLs, so a shallow reference would be unsafe.
- [ ] entry.key self-pointer: Set after regional_alloc_zero to ensure hash table operations work correctly.
- [ ] is_local_zone output: Set to 1 when the name falls in an authoritative local zone, even if no data is found for the queried type. This is used by the cache contamination guard.

3. Iterator integration -- two changes in iterator.c
Change A -- processInitRequest(): Local zone intercept during CNAME restarts
Before the existing cache/network lookup block, a new check is added:
- Guarded by iq->query_restart_count > 0 -- only runs during CNAME restarts, not the initial query (which already goes through local_zones_answer() in the worker).
- Guarded by qstate->env->local_zones != NULL.
- If local_zones_lookup_msg() returns a dns_msg, it is used directly (the existing if(msg) block below processes it as a cache hit).
- The original cache/network lookup is wrapped in if(!msg) so it is skipped when a local zone already answered.
Change B -- processQueryResponse(): Cache contamination guard
Before calling iter_dns_store() for CNAME responses, each rrset in the upstream response is checked against local zones:
- For each rrset, a query_info is constructed from rk.dname, rk.type, rk.rrset_class.
- If any rrset falls in an authoritative local zone, the entire iter_dns_store() call is skipped.
- This prevents upstream TTLs from being written into the rrset cache and overriding local-data on subsequent queries.
- Skipping the full store (rather than individual rrsets) is intentional: iter_dns_store with referral=1 caches rrsets individually, and caching the CNAME without its target would leave an incomplete chain.
4. Test coverage
testdata/iter_localzone_cname.rpl -- New test file with 6 test cases using a forwarder configuration:

Test | Scenario | Validates
-- | -- | --
1 | CNAME -> localhost. (redirect zone, A) | Local zone TTL 70 used, not upstream 86400
2 | CNAME -> localhost. (redirect zone, AAAA) | Same for AAAA records
3 | CNAME -> mylocal.example. (static zone) | Local zone IP 10.20.30.40 used, not upstream 99.99.99.99
4 | CNAME -> passthru.example. (transparent zone) | Transparent zone does NOT intercept -- upstream answer passes through
5 | Two-hop chain -> hop -> localhost. | Local zone intercept works after multiple CNAME restarts
6 | Repeat of test 1 | Cache contamination guard -- TTL still 70, not cached 86400
