### PR TITLE
Add new static zone type block_aaaa to suppress AAAA queries

### DIFF
--- a/doc/example.conf.in
+++ b/doc/example.conf.in
@@ -896,6 +896,8 @@ server:
 	#   that name
 	# o block_a resolves all records normally but returns
 	#   NODATA for A queries and ignores local data for that name
+	# o block_aaaa similarly to block_a, resolves all records normally but
+	#   returns NODATA for AAAA queries and ignores local data for that name
 	# o always_null returns 0.0.0.0 or ::0 for any name in the zone.
 	# o noview breaks out of that view towards global local-zones.
 	#

--- a/doc/unbound.conf.5.in
+++ b/doc/unbound.conf.5.in
@@ -2920,6 +2920,7 @@ The types are
 \fI\%inform_redirect\fP,
 \fI\%always_transparent\fP,
 \fI\%block_a\fP,
+\fI\%block_aaaa\fP,
 \fI\%always_refuse\fP,
 \fI\%always_nxdomain\fP,
 \fI\%always_null\fP,
@@ -3107,6 +3108,15 @@ ignores local data and resolves normally all query types excluding A.
 For A queries it unconditionally returns NODATA.
 Useful in cases when there is a need to explicitly force all apps to
 use IPv6 protocol and avoid any queries to IPv4.
+.UNINDENT
+.INDENT 7.0
+.TP
+.B block_aaaa 
+Like \fI\%transparent\fP or \fI\%block_a\fP, but
+ignores local data and resolves normally all query types excluding AAAA.
+For AAAA queries it unconditionally returns NODATA.
+Useful in cases when there is a need to explicitly force all apps to
+use IPv4 protocol and avoid any queries to IPv6.
 .UNINDENT
 .INDENT 7.0
 .TP

--- a/doc/unbound.conf.rst
+++ b/doc/unbound.conf.rst
@@ -2592,6 +2592,7 @@ These options are part of the ``server:`` section.
     :ref:`inform_redirect<unbound.conf.local-zone.type.inform_redirect>`,
     :ref:`always_transparent<unbound.conf.local-zone.type.always_transparent>`,
     :ref:`block_a<unbound.conf.local-zone.type.block_a>`,
+    :ref:`block_aaaa<unbound.conf.local-zone.type.block_aaaa>`,
     :ref:`always_refuse<unbound.conf.local-zone.type.always_refuse>`,
     :ref:`always_nxdomain<unbound.conf.local-zone.type.always_nxdomain>`,
     :ref:`always_null<unbound.conf.local-zone.type.always_null>`,
@@ -2740,6 +2741,14 @@ These options are part of the ``server:`` section.
         For A queries it unconditionally returns NODATA.
         Useful in cases when there is a need to explicitly force all apps to
         use IPv6 protocol and avoid any queries to IPv4.
+
+    @@UAHL@unbound.conf.local-zone.type@block_aaaa@@
+        Like :ref:`transparent<unbound.conf.local-zone.type.transparent>` or
+        :ref:`block_a<unbound.conf.local-zone.type.block_a>`, but
+        ignores local data and resolves normally all query types excluding AAAA.
+        For AAAA queries it unconditionally returns NODATA.
+        Useful in cases when there is a need to explicitly force all apps to
+        use IPv4 protocol and avoid any queries to IPv6.
 
     @@UAHL@unbound.conf.local-zone.type@always_refuse@@
         Like :ref:`refuse<unbound.conf.local-zone.type.refuse>`, but ignores

--- a/services/localzone.c
+++ b/services/localzone.c
@@ -1650,7 +1650,7 @@ local_zone_does_not_cover(struct local_zone* z, struct query_info* qinfo,
 	struct local_data key;
 	struct local_data* ld = NULL;
 	struct local_rrset* lr = NULL;
-	if(z->type == local_zone_always_transparent || z->type == local_zone_block_a)
+	if(z->type == local_zone_always_transparent || z->type == local_zone_block_a || z->type == local_zone_block_aaaa)
 		return 1;
 	if(z->type != local_zone_transparent
 		&& z->type != local_zone_typetransparent
@@ -1730,6 +1730,16 @@ local_zones_zone_answer(struct local_zone* z, struct module_env* env,
 	} else if(lz_type == local_zone_block_a) {
 		/* Return NODATA for all A queries */
 		if(qinfo->qtype == LDNS_RR_TYPE_A) {
+			local_error_encode(qinfo, env, edns, repinfo, buf, temp,
+				LDNS_RCODE_NOERROR, (LDNS_RCODE_NOERROR|BIT_AA),
+				LDNS_EDE_NONE, NULL);
+				return 1;
+		}
+
+		return 0;
+	} else if(lz_type == local_zone_block_aaaa) {
+		/* Return NODATA for all AAAA queries */
+		if(qinfo->qtype == LDNS_RR_TYPE_AAAA) {
 			local_error_encode(qinfo, env, edns, repinfo, buf, temp,
 				LDNS_RCODE_NOERROR, (LDNS_RCODE_NOERROR|BIT_AA),
 				LDNS_EDE_NONE, NULL);
@@ -1904,7 +1914,8 @@ local_zones_answer(struct local_zones* zones, struct module_env* env,
 			lzt == local_zone_typetransparent ||
 			lzt == local_zone_inform ||
 			lzt == local_zone_always_transparent ||
-			lzt == local_zone_block_a) &&
+			lzt == local_zone_block_a ||
+			lzt == local_zone_block_aaaa) &&
 			local_zone_does_not_cover(z, qinfo, labs)) {
 			lock_rw_unlock(&z->lock);
 			z = NULL;
@@ -1953,6 +1964,7 @@ local_zones_answer(struct local_zones* zones, struct module_env* env,
 	if(lzt != local_zone_always_refuse
 		&& lzt != local_zone_always_transparent
 		&& lzt != local_zone_block_a
+		&& lzt != local_zone_block_aaaa
 		&& lzt != local_zone_always_nxdomain
 		&& lzt != local_zone_always_nodata
 		&& lzt != local_zone_always_deny
@@ -1984,6 +1996,7 @@ const char* local_zone_type2str(enum localzone_type t)
 		case local_zone_inform_redirect: return "inform_redirect";
 		case local_zone_always_transparent: return "always_transparent";
 		case local_zone_block_a: return "block_a";
+		case local_zone_block_aaaa: return "block_aaaa";
 		case local_zone_always_refuse: return "always_refuse";
 		case local_zone_always_nxdomain: return "always_nxdomain";
 		case local_zone_always_nodata: return "always_nodata";
@@ -2020,6 +2033,8 @@ int local_zone_str2type(const char* type, enum localzone_type* t)
 		*t = local_zone_always_transparent;
 	else if(strcmp(type, "block_a") == 0)
 		*t = local_zone_block_a;
+	else if(strcmp(type, "block_aaaa") == 0)
+		*t = local_zone_block_aaaa;
 	else if(strcmp(type, "always_refuse") == 0)
 		*t = local_zone_always_refuse;
 	else if(strcmp(type, "always_nxdomain") == 0)

--- a/services/localzone.h
+++ b/services/localzone.h
@@ -93,6 +93,8 @@ enum localzone_type {
 	local_zone_always_transparent,
 	/** resolve normally, even when there is local data but return NODATA for A queries */
 	local_zone_block_a,
+	/** resolve normally, even when there is local data, but return NODATA for AAAA queries */
+	local_zone_block_aaaa,
 	/** answer with error, even when there is local data */	
 	local_zone_always_refuse,
 	/** answer with nxdomain, even when there is local data */

--- a/util/configparser.y
+++ b/util/configparser.y
@@ -2387,6 +2387,7 @@ server_local_zone: VAR_LOCAL_ZONE STRING_ARG STRING_ARG
 		   && strcmp($3, "typetransparent")!=0
 		   && strcmp($3, "always_transparent")!=0
 		   && strcmp($3, "block_a")!=0
+		   && strcmp($3, "block_aaaa")!=0
 		   && strcmp($3, "always_refuse")!=0
 		   && strcmp($3, "always_nxdomain")!=0
 		   && strcmp($3, "always_nodata")!=0
@@ -2399,7 +2400,8 @@ server_local_zone: VAR_LOCAL_ZONE STRING_ARG STRING_ARG
 			yyerror("local-zone type: expected static, deny, "
 				"refuse, redirect, transparent, "
 				"typetransparent, inform, inform_deny, "
-				"inform_redirect, always_transparent, block_a, "
+				"inform_redirect, always_transparent, "
+				"block_a, block_aaaa, "
 				"always_refuse, always_nxdomain, "
 				"always_nodata, always_deny, always_null, "
 				"noview, nodefault or ipset");


### PR DESCRIPTION
Following d5b9a790f lead for block_a - this would allow suppressing AAAA queries instead for sticking to IPV4.

My use-case in mind is being able to filter certain video providers that consider he.net tunnels as VPNs in a simple*r* way, keeping unbound as my resolver, without needing to involve [python plugins](https://gist.github.com/FiloSottile/e2cffde2bae1ea0c14eada229543aebd), or having to enumerate every subdomain in the `local-data` for a `typetransparent` `local-zone` (as in [here](https://gist.github.com/jamesmacwhite/6a642cb6bad00c5cefa91ec3d742e2a6?permalink_comment_id=4712308#gistcomment-4712308), given the sensible decision of local-data not supporting wildcards). 

It also has a certain nice simmetry with the preexisting `block_a` setting I used as a model.

Checked that it builds, links & passes tests locally only - change seemed straightforward, only being somewhat uncertain on whether something on the response needs to change compared to the A version (I assume not with both being effectively NODATA?). 

I believe this should also close https://github.com/NLnetLabs/unbound/issues/551 for good?


*(and yes, in the year of 2026 there are still ISPs which won't support a proper dual stack configuration, only offering a choice between a non-PD cgnat, or an ipv4-only offering. Shame!)*