### PR TITLE
Fix buffer overrun in doq_repinfo_retrieve_localaddr()

### DIFF
--- a/services/listen_dnsport.c
+++ b/services/listen_dnsport.c
@@ -3767,7 +3767,7 @@ doq_repinfo_retrieve_localaddr(struct comm_reply* repinfo,
 		memset(sa6, 0, *localaddrlen);
 		sa6->sin6_family = AF_INET6;
 		memmove(&sa6->sin6_addr, &repinfo->pktinfo.v6info.ipi6_addr,
-			*localaddrlen);
+			sizeof(struct in_addr6));
 		sa6->sin6_port = repinfo->doq_srcport;
 #endif
 	} else {
@@ -3777,7 +3777,7 @@ doq_repinfo_retrieve_localaddr(struct comm_reply* repinfo,
 		memset(sa, 0, *localaddrlen);
 		sa->sin_family = AF_INET;
 		memmove(&sa->sin_addr, &repinfo->pktinfo.v4info.ipi_addr,
-			*localaddrlen);
+			sizeof(struct in_addr));
 		sa->sin_port = repinfo->doq_srcport;
 #elif defined(IP_RECVDSTADDR)
 		struct sockaddr_in* sa = (struct sockaddr_in*)localaddr;


### PR DESCRIPTION
SAST finding.

`struct in_addr{,6}` and `struct sockaddr_in{,6}` are different structures, with the latter including the former and generally being bigger. In case of the IPv6 path, the `memmove()` call could write past `struct doq_addr_storage`, most likely overwriting the `addrlen` field of `struct doq_pkt_addr`.

Not sure what the implications are of this error, but I would expect for `doq_lookup_repinfo()` to fail to find anything for IPv6 replies. Tried to look for issues related to QUIC & IPv6 and found only #1258, maybe it's somehow related?