### PR TITLE
Add client-wait-timeout server option

### DIFF
--- a/daemon/remote.c
+++ b/daemon/remote.c
@@ -821,6 +821,8 @@ print_stats(RES* ssl, const char* nm, struct ub_stats_info* s)
 		(unsigned long)s->svr.num_queries_cookie_invalid)) return 0;
 	if(!ssl_printf(ssl, "%s.num.queries_discard_timeout"SQ"%lu\n", nm,
 		(unsigned long)s->svr.num_queries_discard_timeout)) return 0;
+	if(!ssl_printf(ssl, "%s.num.queries_client_wait_timeout"SQ"%lu\n", nm,
+		(unsigned long)s->svr.num_queries_client_wait_timeout)) return 0;
 	if(!ssl_printf(ssl, "%s.num.queries_replyaddr_limit"SQ"%lu\n", nm,
 		(unsigned long)s->svr.num_queries_replyaddr_limit)) return 0;
 	if(!ssl_printf(ssl, "%s.num.queries_wait_limit"SQ"%lu\n", nm,
@@ -6263,6 +6265,7 @@ fr_atomic_copy_cfg(struct config_file* oldcfg, struct config_file* cfg,
 	COPY_VAR_int(rrset_roundrobin);
 	COPY_VAR_int(unknown_server_time_limit);
 	COPY_VAR_int(discard_timeout);
+	COPY_VAR_int(client_wait_timeout);
 	COPY_VAR_int(wait_limit);
 	COPY_VAR_int(wait_limit_cookie);
 	COPY_VAR_ptr(wait_limit_netblock);

--- a/daemon/stats.c
+++ b/daemon/stats.c
@@ -285,6 +285,8 @@ server_stats_compile(struct worker* worker, struct ub_stats_info* s, int reset)
 		NUM_BUCKETS_HIST);
 	s->svr.num_queries_discard_timeout +=
 		(long long)worker->env.mesh->num_queries_discard_timeout;
+	s->svr.num_queries_client_wait_timeout +=
+		(long long)worker->env.mesh->num_queries_client_wait_timeout;
 	s->svr.num_queries_replyaddr_limit +=
 		(long long)worker->env.mesh->num_queries_replyaddr_limit;
 	s->svr.num_queries_wait_limit +=
@@ -451,6 +453,8 @@ void server_stats_add(struct ub_stats_info* total, struct ub_stats_info* a)
 	total->svr.num_queries_cookie_invalid += a->svr.num_queries_cookie_invalid;
 	total->svr.num_queries_discard_timeout +=
 		a->svr.num_queries_discard_timeout;
+	total->svr.num_queries_client_wait_timeout +=
+		a->svr.num_queries_client_wait_timeout;
 	total->svr.num_queries_replyaddr_limit +=
 		a->svr.num_queries_replyaddr_limit;
 	total->svr.num_queries_wait_limit += a->svr.num_queries_wait_limit;

--- a/doc/Changelog
+++ b/doc/Changelog
@@ -8,7 +8,6 @@
 
 28 May 2026: Wouter
 	- Fix #1457: race condition causes segfault when starting
-	  threads.
 
 27 May 2026: Wouter
 	- Fix for autotrust state-file line overflow, that can give
@@ -18,7 +17,6 @@
 	  to Qifan Zhang, Palo Alto Networks, for the report.
 	- Fix that the ratelimit is decremented on successful
 	  referrals. Thanks to Qifan Zhang, Palo Alto Networks, for
-	  the report.
 	- Fix that msgencode insert_query has the correct assertion,
 	  for a local_alias. Thanks to Qifan Zhang, Palo Alto Networks,
 	  for the report.
@@ -129,6 +127,15 @@
 	- Fix DNSKEY size calculation for noncanonical RSA DNSKEYs
 	  with leading zeroes for n. Thanks to Xin Wang and Jiajia Liu,
 	  Northwestern Polytechnical University, for the report.
+=======
+30 May 2026: Nikolay Shopik
+	- Add client-wait-timeout: server option that sends SERVFAIL with
+	  EDE 22 (No Reachable Authority) and text "client wait timeout
+	  exceeded" to a client whose query has been waiting longer than the
+	  configured milliseconds. Background resolution continues so the
+	  cache is populated for subsequent identical queries. Default 0
+	  (disabled). Off by default; opt-in.
+>>>>>>> 47c9108b8 (Changelog: add client-wait-timeout)
 
 11 May 2026: Yorgos
 	- Fix comment and verbose logging for EDNS fallback buffer size.

--- a/doc/Changelog
+++ b/doc/Changelog
@@ -8,6 +8,7 @@
 
 28 May 2026: Wouter
 	- Fix #1457: race condition causes segfault when starting
+	  threads.
 
 27 May 2026: Wouter
 	- Fix for autotrust state-file line overflow, that can give
@@ -17,6 +18,7 @@
 	  to Qifan Zhang, Palo Alto Networks, for the report.
 	- Fix that the ratelimit is decremented on successful
 	  referrals. Thanks to Qifan Zhang, Palo Alto Networks, for
+	  the report.
 	- Fix that msgencode insert_query has the correct assertion,
 	  for a local_alias. Thanks to Qifan Zhang, Palo Alto Networks,
 	  for the report.
@@ -127,15 +129,6 @@
 	- Fix DNSKEY size calculation for noncanonical RSA DNSKEYs
 	  with leading zeroes for n. Thanks to Xin Wang and Jiajia Liu,
 	  Northwestern Polytechnical University, for the report.
-=======
-30 May 2026: Nikolay Shopik
-	- Add client-wait-timeout: server option that sends SERVFAIL with
-	  EDE 22 (No Reachable Authority) and text "client wait timeout
-	  exceeded" to a client whose query has been waiting longer than the
-	  configured milliseconds. Background resolution continues so the
-	  cache is populated for subsequent identical queries. Default 0
-	  (disabled). Off by default; opt-in.
->>>>>>> 47c9108b8 (Changelog: add client-wait-timeout)
 
 11 May 2026: Yorgos
 	- Fix comment and verbose logging for EDNS fallback buffer size.

--- a/doc/example.conf.in
+++ b/doc/example.conf.in
@@ -210,6 +210,11 @@ server:
 	# msec before recursion replies are dropped. The work item continues.
 	# discard-timeout: 1900
 
+	# msec before a waiting client is answered with SERVFAIL and EDE 22
+	# (No Reachable Authority); recursion continues in the background to warm
+	# the cache. Default is 0 (disabled, opt-in).
+	# client-wait-timeout: 0
+
 	# Max number of replies waiting for recursion per IP address.
 	# wait-limit: 1000
 

--- a/doc/unbound-control.8.in
+++ b/doc/unbound-control.8.in
@@ -877,17 +877,17 @@ number of queries with an invalid DNS Cookie by thread
 .UNINDENT
 .INDENT 0.0
 .TP
-.B threadX.num.queries_discard_timeout
+.B threadX.num.queries_discard_timeout 
 number of queries removed due to discard\-timeout by thread
 .UNINDENT
 .INDENT 0.0
 .TP
-.B threadX.num.queries_client_wait_timeout
+.B threadX.num.queries_client_wait_timeout 
 number of queries answered with SERVFAIL because the client\-wait\-timeout was exceeded by thread
 .UNINDENT
 .INDENT 0.0
 .TP
-.B threadX.num.queries_replyaddr_limit
+.B threadX.num.queries_replyaddr_limit 
 number of queries removed due to replyaddr limits by thread
 .UNINDENT
 .INDENT 0.0
@@ -1072,17 +1072,17 @@ summed over threads.
 .UNINDENT
 .INDENT 0.0
 .TP
-.B total.num.queries_discard_timeout
+.B total.num.queries_discard_timeout 
 summed over threads.
 .UNINDENT
 .INDENT 0.0
 .TP
-.B total.num.queries_client_wait_timeout
+.B total.num.queries_client_wait_timeout 
 summed over threads.
 .UNINDENT
 .INDENT 0.0
 .TP
-.B total.num.queries_replyaddr_limit
+.B total.num.queries_replyaddr_limit 
 summed over threads.
 .UNINDENT
 .INDENT 0.0

--- a/doc/unbound-control.8.in
+++ b/doc/unbound-control.8.in
@@ -877,12 +877,17 @@ number of queries with an invalid DNS Cookie by thread
 .UNINDENT
 .INDENT 0.0
 .TP
-.B threadX.num.queries_discard_timeout 
+.B threadX.num.queries_discard_timeout
 number of queries removed due to discard\-timeout by thread
 .UNINDENT
 .INDENT 0.0
 .TP
-.B threadX.num.queries_replyaddr_limit 
+.B threadX.num.queries_client_wait_timeout
+number of queries answered with SERVFAIL because the client\-wait\-timeout was exceeded by thread
+.UNINDENT
+.INDENT 0.0
+.TP
+.B threadX.num.queries_replyaddr_limit
 number of queries removed due to replyaddr limits by thread
 .UNINDENT
 .INDENT 0.0
@@ -1067,12 +1072,17 @@ summed over threads.
 .UNINDENT
 .INDENT 0.0
 .TP
-.B total.num.queries_discard_timeout 
+.B total.num.queries_discard_timeout
 summed over threads.
 .UNINDENT
 .INDENT 0.0
 .TP
-.B total.num.queries_replyaddr_limit 
+.B total.num.queries_client_wait_timeout
+summed over threads.
+.UNINDENT
+.INDENT 0.0
+.TP
+.B total.num.queries_replyaddr_limit
 summed over threads.
 .UNINDENT
 .INDENT 0.0

--- a/doc/unbound-control.rst
+++ b/doc/unbound-control.rst
@@ -817,6 +817,11 @@ number of statistic counters:
     number of queries removed due to discard-timeout by thread
 
 
+@@UAHL@unbound-control.stats@threadX.num.queries_client_wait_timeout@@
+    number of queries answered with SERVFAIL because the
+    client-wait-timeout was exceeded by thread
+
+
 @@UAHL@unbound-control.stats@threadX.num.queries_replyaddr_limit@@
     number of queries removed due to replyaddr limits by thread
 
@@ -974,6 +979,10 @@ number of statistic counters:
 
 
 @@UAHL@unbound-control.stats@total.num.queries_discard_timeout@@
+    summed over threads.
+
+
+@@UAHL@unbound-control.stats@total.num.queries_client_wait_timeout@@
     summed over threads.
 
 

--- a/doc/unbound.conf.5.in
+++ b/doc/unbound.conf.5.in
@@ -598,7 +598,7 @@ Default: 376
 .UNINDENT
 .INDENT 0.0
 .TP
-.B discard\-timeout: \fI<msec>\fP
+.B discard\-timeout: \fI<msec>\fP 
 The wait time in msec where recursion requests are dropped.
 This is to stop a large number of replies from accumulating.
 They receive no reply, the work item continues to recurse.
@@ -615,7 +615,7 @@ Default: 1900
 .UNINDENT
 .INDENT 0.0
 .TP
-.B client\-wait\-timeout: \fI<msec>\fP
+.B client\-wait\-timeout: \fI<msec>\fP 
 The wait time in msec before a client query that is still waiting for
 recursion is answered with SERVFAIL and Extended DNS Error code 22
 (No Reachable Authority).

--- a/doc/unbound.conf.5.in
+++ b/doc/unbound.conf.5.in
@@ -598,7 +598,7 @@ Default: 376
 .UNINDENT
 .INDENT 0.0
 .TP
-.B discard\-timeout: \fI<msec>\fP 
+.B discard\-timeout: \fI<msec>\fP
 The wait time in msec where recursion requests are dropped.
 This is to stop a large number of replies from accumulating.
 They receive no reply, the work item continues to recurse.
@@ -612,6 +612,47 @@ A value of \fB1900\fP msec is suggested.
 The value \fB0\fP disables it.
 .sp
 Default: 1900
+.UNINDENT
+.INDENT 0.0
+.TP
+.B client\-wait\-timeout: \fI<msec>\fP
+Time in milliseconds before a client query that is still waiting for
+recursion is answered with SERVFAIL and Extended DNS Error code 22
+(No Reachable Authority) with the extra text \(dqclient wait timeout exceeded\(dq.
+Recursion continues in the background so that the cache is populated for
+subsequent identical queries.
+Setting this to \fB0\fP disables the feature.
+.sp
+Useful values are typically in the range 1500 to 4000 ms.
+A value close to the stub resolver\(aqs own query timeout minimises spurious
+client retries to other resolvers but also reduces the latency benefit,
+while a lower value returns an answer to the client sooner at the cost of
+more retries.
+.sp
+Cache warming is best\-effort: if the upstream ultimately fails, that
+failure may itself be briefly cached, and in an anycast deployment a
+retried client may reach a different instance whose cache was not warmed.
+.sp
+This option bounds only the client\(aqs wait time, not the lifetime of the
+background recursion.
+In\-flight upstream queries persist until they complete or
+\fBinfra\-cache\-max\-rtt\fR elapses, so under a flood of slow or unreachable
+names many states can keep resolving simultaneously.
+Consider pairing this option with \fBwait\-limit\fR and a conservative
+\fBinfra\-cache\-max\-rtt\fR in hostile environments.
+.sp
+The Extended DNS Error option is attached only when \fBede:\fR is enabled
+and only on the UDP/TCP client path; libunbound callers receive a plain
+SERVFAIL without an EDE option.
+.sp
+If both \fBclient\-wait\-timeout\fR and
+\fI\%serve\-expired\-client\-timeout\fP
+are configured, whichever timer fires first delivers its answer and the
+later timer becomes a no\-op.
+\fBunbound\-checkconf\fR warns when client\-wait\-timeout is less than
+serve\-expired\-client\-timeout while serve\-expired is enabled.
+.sp
+Default: 0
 .UNINDENT
 .INDENT 0.0
 .TP

--- a/doc/unbound.conf.5.in
+++ b/doc/unbound.conf.5.in
@@ -616,41 +616,16 @@ Default: 1900
 .INDENT 0.0
 .TP
 .B client\-wait\-timeout: \fI<msec>\fP
-Time in milliseconds before a client query that is still waiting for
+The wait time in msec before a client query that is still waiting for
 recursion is answered with SERVFAIL and Extended DNS Error code 22
-(No Reachable Authority) with the extra text \(dqclient wait timeout exceeded\(dq.
-Recursion continues in the background so that the cache is populated for
+(No Reachable Authority).
+Recursion continues in the background so the cache is populated for
 subsequent identical queries.
-Setting this to \fB0\fP disables the feature.
-.sp
-Useful values are typically in the range 1500 to 4000 ms.
-A value close to the stub resolver\(aqs own query timeout minimises spurious
-client retries to other resolvers but also reduces the latency benefit,
-while a lower value returns an answer to the client sooner at the cost of
-more retries.
-.sp
-Cache warming is best\-effort: if the upstream ultimately fails, that
-failure may itself be briefly cached, and in an anycast deployment a
-retried client may reach a different instance whose cache was not warmed.
-.sp
-This option bounds only the client\(aqs wait time, not the lifetime of the
-background recursion.
-In\-flight upstream queries persist until they complete or
-\fBinfra\-cache\-max\-rtt\fR elapses, so under a flood of slow or unreachable
-names many states can keep resolving simultaneously.
-Consider pairing this option with \fBwait\-limit\fR and a conservative
-\fBinfra\-cache\-max\-rtt\fR in hostile environments.
-.sp
-The Extended DNS Error option is attached only when \fBede:\fR is enabled
-and only on the UDP/TCP client path; libunbound callers receive a plain
-SERVFAIL without an EDE option.
-.sp
-If both \fBclient\-wait\-timeout\fR and
+The EDE code is only attached when \fBede:\fR is enabled.
+If both this and
 \fI\%serve\-expired\-client\-timeout\fP
-are configured, whichever timer fires first delivers its answer and the
-later timer becomes a no\-op.
-\fBunbound\-checkconf\fR warns when client\-wait\-timeout is less than
-serve\-expired\-client\-timeout while serve\-expired is enabled.
+are set, whichever timer fires first answers and the other becomes a no\-op.
+The value \fB0\fP disables it.
 .sp
 Default: 0
 .UNINDENT

--- a/doc/unbound.conf.5.in
+++ b/doc/unbound.conf.5.in
@@ -625,6 +625,10 @@ The EDE code is only attached when \fBede:\fR is enabled.
 If both this and
 \fI\%serve\-expired\-client\-timeout\fP
 are set, whichever timer fires first answers and the other becomes a no\-op.
+Keep the value smaller than
+\fI\%discard\-timeout\fP;
+UDP replies that arrive between the two timeouts are discarded before
+this timeout can answer, and those clients receive no response at all.
 The value \fB0\fP disables it.
 .sp
 Default: 0

--- a/doc/unbound.conf.rst
+++ b/doc/unbound.conf.rst
@@ -571,6 +571,27 @@ These options are part of the ``server:`` section.
     Default: 1900
 
 
+@@UAHL@unbound.conf@client-wait-timeout@@: *<msec>*
+    The wait time in msec before a client query that is still waiting for
+    recursion is answered with SERVFAIL and Extended DNS Error code 22
+    (No Reachable Authority).
+    Recursion continues in the background so the cache is populated for
+    subsequent identical queries.
+    The EDE code is only attached when :ref:`ede<unbound.conf.ede>` is
+    enabled.
+    If both this and
+    :ref:`serve-expired-client-timeout<unbound.conf.serve-expired-client-timeout>`
+    are set, whichever timer fires first answers and the other becomes a
+    no-op.
+    Keep the value smaller than
+    :ref:`discard-timeout<unbound.conf.discard-timeout>`;
+    UDP replies that arrive between the two timeouts are discarded before
+    this timeout can answer, and those clients receive no response at all.
+    The value ``0`` disables it.
+
+    Default: 0
+
+
 @@UAHL@unbound.conf@wait-limit@@: *<number>*
     The number of replies that can wait for recursion, for an IP address.
     This makes a ratelimit per IP address of waiting replies for recursion.

--- a/libunbound/unbound.h
+++ b/libunbound/unbound.h
@@ -853,6 +853,8 @@ struct ub_server_stats {
 	long long qquic;
 	/** number of queries removed due to discard-timeout */
 	long long num_queries_discard_timeout;
+	/** number of queries SERVFAILed due to client-wait-timeout */
+	long long num_queries_client_wait_timeout;
 	/** number of queries removed due to replyaddr limit */
 	long long num_queries_replyaddr_limit;
 	/** number of queries removed due to wait-limit */

--- a/libunbound/unbound.h
+++ b/libunbound/unbound.h
@@ -853,14 +853,14 @@ struct ub_server_stats {
 	long long qquic;
 	/** number of queries removed due to discard-timeout */
 	long long num_queries_discard_timeout;
-	/** number of queries SERVFAILed due to client-wait-timeout */
-	long long num_queries_client_wait_timeout;
 	/** number of queries removed due to replyaddr limit */
 	long long num_queries_replyaddr_limit;
 	/** number of queries removed due to wait-limit */
 	long long num_queries_wait_limit;
 	/** number of dns error reports generated */
 	long long num_dns_error_reports;
+	/** number of queries SERVFAILed due to client-wait-timeout */
+	long long num_queries_client_wait_timeout;
 };
 
 /**

--- a/services/mesh.c
+++ b/services/mesh.c
@@ -231,6 +231,7 @@ mesh_create(struct module_stack* stack, struct module_env* env)
 	mesh->ans_expired = 0;
 	mesh->ans_cachedb = 0;
 	mesh->num_queries_discard_timeout = 0;
+	mesh->num_queries_client_wait_timeout = 0;
 	mesh->num_queries_replyaddr_limit = 0;
 	mesh->num_queries_wait_limit = 0;
 	mesh->num_dns_error_reports = 0;
@@ -2358,6 +2359,7 @@ mesh_stats_clear(struct mesh_area* mesh)
 	memset(&mesh->rpz_action[0], 0, sizeof(size_t)*UB_STATS_RPZ_ACTION_NUM);
 	mesh->ans_nodata = 0;
 	mesh->num_queries_discard_timeout = 0;
+	mesh->num_queries_client_wait_timeout = 0;
 	mesh->num_queries_replyaddr_limit = 0;
 	mesh->num_queries_wait_limit = 0;
 	mesh->num_dns_error_reports = 0;

--- a/services/mesh.c
+++ b/services/mesh.c
@@ -463,6 +463,60 @@ mesh_remove_callback_without_accounting(struct mesh_state* s,
 	}
 }
 
+/** Return milliseconds elapsed from start to now; never negative. */
+static int
+age_ms(struct timeval* now, struct timeval* start)
+{
+	struct timeval diff;
+	if(timeval_smaller(now, start))
+		return 0;
+	timeval_subtract(&diff, now, start);
+	return (int)(diff.tv_sec * 1000 + diff.tv_usec / 1000);
+}
+
+/** Compute absolute deadline (start + timeout_ms) into out. */
+static void
+client_wait_deadline(struct timeval* out, struct timeval* start, int timeout_ms)
+{
+	out->tv_sec = start->tv_sec + timeout_ms / 1000;
+	out->tv_usec = start->tv_usec + (timeout_ms % 1000) * 1000;
+	if(out->tv_usec >= 1000000) {
+		out->tv_sec++;
+		out->tv_usec -= 1000000;
+	}
+}
+
+/** Init the client_wait_data structure and arm the timer (idempotent). */
+static int
+mesh_client_wait_init(struct mesh_state* mstate, int timeout_ms)
+{
+	struct timeval t;
+	if(!mstate->s.client_wait_data) {
+		mstate->s.client_wait_data = (struct client_wait_data*)
+			regional_alloc_zero(mstate->s.region,
+				sizeof(struct client_wait_data));
+		if(!mstate->s.client_wait_data)
+			return 0;
+	}
+	/* Create+arm the timer once. After a full sweep the callback deletes
+	 * the timer (NULLs it); a later-arriving client re-creates and re-arms
+	 * it here. A second concurrent client finds the timer already present
+	 * and does not disturb the earlier client's earlier deadline. */
+	if(!mstate->s.client_wait_data->timer) {
+		mstate->s.client_wait_data->timer = comm_timer_create(
+			mstate->s.env->worker_base, mesh_client_wait_callback,
+			mstate);
+		if(!mstate->s.client_wait_data->timer)
+			return 0;
+#ifndef S_SPLINT_S
+		t.tv_sec = timeout_ms / 1000;
+		t.tv_usec = (timeout_ms % 1000) * 1000;
+#endif
+		comm_timer_set(mstate->s.client_wait_data->timer, &t);
+	}
+	return 1;
+}
+
 void mesh_new_client(struct mesh_area* mesh, struct query_info* qinfo,
 	struct respip_client_info* cinfo, uint16_t qflags,
 	struct edns_data* edns, struct comm_reply* rep, uint16_t qid,
@@ -600,6 +654,14 @@ void mesh_new_client(struct mesh_area* mesh, struct query_info* qinfo,
 		log_err("mesh_new_client: out of memory initializing serve expired");
 		goto servfail_mem;
 	}
+	/* arm client-wait-timeout timer (idempotent; re-armed after a sweep) */
+	if(mesh->env->cfg->client_wait_timeout > 0) {
+		if(!mesh_client_wait_init(s,
+			mesh->env->cfg->client_wait_timeout))
+			log_err("mesh_new_client: out of memory "
+				"initializing client-wait-timeout");
+		/* soft-fail: query proceeds without the deadline */
+	}
 #ifdef USE_CACHEDB
 	if(!timeout && mesh->env->cfg->serve_expired &&
 		!mesh->env->cfg->serve_expired_client_timeout &&
@@ -729,6 +791,14 @@ mesh_new_callback(struct mesh_area* mesh, struct query_info* qinfo,
 		if(added)
 			mesh_state_delete(&s->s);
 		return 0;
+	}
+	/* arm client-wait-timeout timer (idempotent; re-armed after a sweep) */
+	if(mesh->env->cfg->client_wait_timeout > 0) {
+		if(!mesh_client_wait_init(s,
+			mesh->env->cfg->client_wait_timeout))
+			log_err("mesh_new_callback: out of memory "
+				"initializing client-wait-timeout");
+		/* soft-fail */
 	}
 #ifdef USE_CACHEDB
 	if(!timeout && mesh->env->cfg->serve_expired &&
@@ -1125,6 +1195,11 @@ mesh_state_cleanup(struct mesh_state* mstate)
 	if(mstate->s.serve_expired_data && mstate->s.serve_expired_data->timer) {
 		comm_timer_delete(mstate->s.serve_expired_data->timer);
 		mstate->s.serve_expired_data->timer = NULL;
+	}
+	/* Stop and delete the client-wait-timeout timer */
+	if(mstate->s.client_wait_data && mstate->s.client_wait_data->timer) {
+		comm_timer_delete(mstate->s.client_wait_data->timer);
+		mstate->s.client_wait_data->timer = NULL;
 	}
 	/* drop unsent replies */
 	if(!mstate->replies_sent) {
@@ -1777,6 +1852,11 @@ void mesh_query_done(struct mesh_state* mstate)
 		comm_timer_delete(mstate->s.serve_expired_data->timer);
 		mstate->s.serve_expired_data->timer = NULL;
 	}
+	/* No need for the client-wait-timeout timer anymore either. */
+	if(mstate->s.client_wait_data && mstate->s.client_wait_data->timer) {
+		comm_timer_delete(mstate->s.client_wait_data->timer);
+		mstate->s.client_wait_data->timer = NULL;
+	}
 	if(mstate->s.return_rcode == LDNS_RCODE_SERVFAIL ||
 		(rep && FLAGS_GET_RCODE(rep->flags) == LDNS_RCODE_SERVFAIL)) {
 		if(mstate->s.env->cfg->serve_expired) {
@@ -1931,6 +2011,132 @@ void mesh_query_done(struct mesh_state* mstate)
 	}
 }
 
+/** EDE text sent to clients that exceeded the client-wait-timeout. */
+static const char* CLIENT_WAIT_TIMEOUT_EDE_TEXT = "client wait timeout exceeded";
+
+void
+mesh_client_wait_callback(void* arg)
+{
+	struct mesh_state* mstate = (struct mesh_state*)arg;
+	struct module_qstate* qstate = &mstate->s;
+	struct mesh_area* mesh = qstate->env->mesh;
+	struct timeval now = *qstate->env->now_tv;
+	int deadline_ms = qstate->env->cfg->client_wait_timeout;
+	struct timeval next_fire, tv = {0, 0};
+	int have_next = 0;
+	int was_reply_state;
+	struct mesh_reply** prev;
+	struct mesh_reply* r;
+	struct mesh_cb** cprev;
+	struct mesh_cb* c;
+
+	if(!qstate->client_wait_data || !qstate->client_wait_data->timer)
+		return;
+	was_reply_state = (mstate->reply_list != NULL ||
+		mstate->cb_list != NULL);
+
+	/* reply_list: SERVFAIL+EDE22 each aged reply; track the earliest of the
+	 * remaining ones for rescheduling. Route through mesh_send_reply so the
+	 * reply_list=NULL re-entrancy guard, num_reply_addrs--, and
+	 * infra_wait_limit_dec happen exactly as on every other reply path. */
+	prev = &mstate->reply_list;
+	r = mstate->reply_list;
+	while(r) {
+		if(age_ms(&now, &r->start_time) >= deadline_ms) {
+			struct mesh_reply* next = r->next;
+			struct sldns_buffer* r_buffer = r->query_reply.c->buffer;
+			if(r->query_reply.c->tcp_req_info)
+				r_buffer = r->query_reply.c->tcp_req_info->spool_buffer;
+			/* EDE 22, gated on the global ede: switch; pre-appended so
+			 * mesh_send_reply's error_encode emits it. */
+			if(qstate->env->cfg->ede && r->edns.edns_present)
+				edns_opt_list_append_ede(&r->edns.opt_list_out,
+					qstate->region,
+					LDNS_EDE_NO_REACHABLE_AUTHORITY,
+					CLIENT_WAIT_TIMEOUT_EDE_TEXT);
+			if(verbosity >= VERB_ALGO) {
+				char addr_str[128];
+				addr_to_str(&r->query_reply.client_addr,
+					r->query_reply.client_addrlen,
+					addr_str, sizeof(addr_str));
+				verbose(VERB_ALGO, "client-wait-timeout: "
+					"SERVFAIL+EDE 22 to %s after %d ms",
+					addr_str, deadline_ms);
+			}
+			/* unlink before send; nodes are region-allocated so `next`
+			 * stays valid, and mesh_send_reply NULLs reply_list during
+			 * comm_point_send_reply to block re-entrant cleanup. */
+			*prev = next;
+			mesh_send_reply(mstate, LDNS_RCODE_SERVFAIL, NULL, r,
+				r_buffer, NULL, NULL);
+			if(r->query_reply.c->tcp_req_info)
+				tcp_req_info_remove_mesh_state(
+					r->query_reply.c->tcp_req_info, mstate);
+			mesh->num_queries_client_wait_timeout++;
+			r = next;
+		} else {
+			struct timeval d;
+			client_wait_deadline(&d, &r->start_time, deadline_ms);
+			if(!have_next || timeval_smaller(&d, &next_fire)) {
+				next_fire = d;
+				have_next = 1;
+			}
+			prev = &r->next;
+			r = r->next;
+		}
+	}
+
+	/* cb_list (libunbound): plain SERVFAIL, no EDE (intentional asymmetry). */
+	cprev = &mstate->cb_list;
+	c = mstate->cb_list;
+	while(c) {
+		if(age_ms(&now, &c->start_time) >= deadline_ms) {
+			struct mesh_cb* next = c->next;
+			*cprev = next;
+			mesh_do_callback(mstate, LDNS_RCODE_SERVFAIL, NULL, c,
+				&tv);
+			mesh->num_queries_client_wait_timeout++;
+			c = next;
+		} else {
+			struct timeval d;
+			client_wait_deadline(&d, &c->start_time, deadline_ms);
+			if(!have_next || timeval_smaller(&d, &next_fire)) {
+				next_fire = d;
+				have_next = 1;
+			}
+			cprev = &c->next;
+			c = c->next;
+		}
+	}
+
+	/* Per-state accounting: a state stops being a reply state only when it
+	 * has no more waiting replies/cbs. Mirrors mesh_query_done's transition;
+	 * decrement at most once. */
+	if(was_reply_state && !mstate->reply_list && !mstate->cb_list) {
+		log_assert(mesh->num_reply_states > 0);
+		mesh->num_reply_states--;
+		if(mstate->super_set.count == 0)
+			mesh->num_detached_states++;
+	}
+
+	/* Reschedule to the earliest remaining deadline, or delete the timer so
+	 * a later client re-arms it (serve-expired delete-in-callback pattern).
+	 * The state is kept alive for background resolution / cache warming. */
+	if(have_next) {
+		struct timeval delta;
+		if(timeval_smaller(&now, &next_fire))
+			timeval_subtract(&delta, &next_fire, &now);
+		else {
+			delta.tv_sec = 0;
+			delta.tv_usec = 1;
+		}
+		comm_timer_set(qstate->client_wait_data->timer, &delta);
+	} else {
+		comm_timer_delete(qstate->client_wait_data->timer);
+		qstate->client_wait_data->timer = NULL;
+	}
+}
+
 void mesh_walk_supers(struct mesh_area* mesh, struct mesh_state* mstate)
 {
 	struct mesh_state_ref* ref;
@@ -2013,6 +2219,7 @@ int mesh_state_add_cb(struct mesh_state* s, struct edns_data* edns,
 		return 0;
 	r->qid = qid;
 	r->qflags = qflags;
+	r->start_time = *s->s.env->now_tv;
 	r->next = s->cb_list;
 	s->cb_list = r;
 	*result = r;

--- a/services/mesh.c
+++ b/services/mesh.c
@@ -463,17 +463,6 @@ mesh_remove_callback_without_accounting(struct mesh_state* s,
 	}
 }
 
-/** Return milliseconds elapsed from start to now; never negative. */
-static int
-age_ms(struct timeval* now, struct timeval* start)
-{
-	struct timeval diff;
-	if(timeval_smaller(now, start))
-		return 0;
-	timeval_subtract(&diff, now, start);
-	return (int)(diff.tv_sec * 1000 + diff.tv_usec / 1000);
-}
-
 /** Compute absolute deadline (start + timeout_ms) into out. */
 static void
 client_wait_deadline(struct timeval* out, struct timeval* start, int timeout_ms)
@@ -486,35 +475,30 @@ client_wait_deadline(struct timeval* out, struct timeval* start, int timeout_ms)
 	}
 }
 
-/** Init the client_wait_data structure and arm the timer (idempotent). */
-static int
+/** Create+arm the client-wait timer once (idempotent). After a full sweep
+ * the callback deletes the timer (NULLs it); a later-arriving client
+ * re-creates and re-arms it here. A second concurrent client finds the
+ * timer already present and does not disturb the earlier client's earlier
+ * deadline. Soft-fails on malloc failure: the query proceeds without the
+ * deadline. */
+static void
 mesh_client_wait_init(struct mesh_state* mstate, int timeout_ms)
 {
 	struct timeval t;
-	if(!mstate->s.client_wait_data) {
-		mstate->s.client_wait_data = (struct client_wait_data*)
-			regional_alloc_zero(mstate->s.region,
-				sizeof(struct client_wait_data));
-		if(!mstate->s.client_wait_data)
-			return 0;
+	if(mstate->s.client_wait_timer)
+		return;
+	mstate->s.client_wait_timer = comm_timer_create(
+		mstate->s.env->worker_base, mesh_client_wait_callback, mstate);
+	if(!mstate->s.client_wait_timer) {
+		log_err("mesh_client_wait_init: out of memory "
+			"initializing client-wait-timeout");
+		return;
 	}
-	/* Create+arm the timer once. After a full sweep the callback deletes
-	 * the timer (NULLs it); a later-arriving client re-creates and re-arms
-	 * it here. A second concurrent client finds the timer already present
-	 * and does not disturb the earlier client's earlier deadline. */
-	if(!mstate->s.client_wait_data->timer) {
-		mstate->s.client_wait_data->timer = comm_timer_create(
-			mstate->s.env->worker_base, mesh_client_wait_callback,
-			mstate);
-		if(!mstate->s.client_wait_data->timer)
-			return 0;
 #ifndef S_SPLINT_S
-		t.tv_sec = timeout_ms / 1000;
-		t.tv_usec = (timeout_ms % 1000) * 1000;
+	t.tv_sec = timeout_ms / 1000;
+	t.tv_usec = (timeout_ms % 1000) * 1000;
 #endif
-		comm_timer_set(mstate->s.client_wait_data->timer, &t);
-	}
-	return 1;
+	comm_timer_set(mstate->s.client_wait_timer, &t);
 }
 
 void mesh_new_client(struct mesh_area* mesh, struct query_info* qinfo,
@@ -655,13 +639,8 @@ void mesh_new_client(struct mesh_area* mesh, struct query_info* qinfo,
 		goto servfail_mem;
 	}
 	/* arm client-wait-timeout timer (idempotent; re-armed after a sweep) */
-	if(mesh->env->cfg->client_wait_timeout > 0) {
-		if(!mesh_client_wait_init(s,
-			mesh->env->cfg->client_wait_timeout))
-			log_err("mesh_new_client: out of memory "
-				"initializing client-wait-timeout");
-		/* soft-fail: query proceeds without the deadline */
-	}
+	if(mesh->env->cfg->client_wait_timeout > 0)
+		mesh_client_wait_init(s, mesh->env->cfg->client_wait_timeout);
 #ifdef USE_CACHEDB
 	if(!timeout && mesh->env->cfg->serve_expired &&
 		!mesh->env->cfg->serve_expired_client_timeout &&
@@ -793,13 +772,8 @@ mesh_new_callback(struct mesh_area* mesh, struct query_info* qinfo,
 		return 0;
 	}
 	/* arm client-wait-timeout timer (idempotent; re-armed after a sweep) */
-	if(mesh->env->cfg->client_wait_timeout > 0) {
-		if(!mesh_client_wait_init(s,
-			mesh->env->cfg->client_wait_timeout))
-			log_err("mesh_new_callback: out of memory "
-				"initializing client-wait-timeout");
-		/* soft-fail */
-	}
+	if(mesh->env->cfg->client_wait_timeout > 0)
+		mesh_client_wait_init(s, mesh->env->cfg->client_wait_timeout);
 #ifdef USE_CACHEDB
 	if(!timeout && mesh->env->cfg->serve_expired &&
 		!mesh->env->cfg->serve_expired_client_timeout &&
@@ -1197,9 +1171,9 @@ mesh_state_cleanup(struct mesh_state* mstate)
 		mstate->s.serve_expired_data->timer = NULL;
 	}
 	/* Stop and delete the client-wait-timeout timer */
-	if(mstate->s.client_wait_data && mstate->s.client_wait_data->timer) {
-		comm_timer_delete(mstate->s.client_wait_data->timer);
-		mstate->s.client_wait_data->timer = NULL;
+	if(mstate->s.client_wait_timer) {
+		comm_timer_delete(mstate->s.client_wait_timer);
+		mstate->s.client_wait_timer = NULL;
 	}
 	/* drop unsent replies */
 	if(!mstate->replies_sent) {
@@ -1853,9 +1827,9 @@ void mesh_query_done(struct mesh_state* mstate)
 		mstate->s.serve_expired_data->timer = NULL;
 	}
 	/* No need for the client-wait-timeout timer anymore either. */
-	if(mstate->s.client_wait_data && mstate->s.client_wait_data->timer) {
-		comm_timer_delete(mstate->s.client_wait_data->timer);
-		mstate->s.client_wait_data->timer = NULL;
+	if(mstate->s.client_wait_timer) {
+		comm_timer_delete(mstate->s.client_wait_timer);
+		mstate->s.client_wait_timer = NULL;
 	}
 	if(mstate->s.return_rcode == LDNS_RCODE_SERVFAIL ||
 		(rep && FLAGS_GET_RCODE(rep->flags) == LDNS_RCODE_SERVFAIL)) {
@@ -2011,9 +1985,6 @@ void mesh_query_done(struct mesh_state* mstate)
 	}
 }
 
-/** EDE text sent to clients that exceeded the client-wait-timeout. */
-static const char* CLIENT_WAIT_TIMEOUT_EDE_TEXT = "client wait timeout exceeded";
-
 void
 mesh_client_wait_callback(void* arg)
 {
@@ -2022,7 +1993,7 @@ mesh_client_wait_callback(void* arg)
 	struct mesh_area* mesh = qstate->env->mesh;
 	struct timeval now = *qstate->env->now_tv;
 	int deadline_ms = qstate->env->cfg->client_wait_timeout;
-	struct timeval next_fire, tv = {0, 0};
+	struct timeval next_fire;
 	int have_next = 0;
 	int was_reply_state;
 	struct mesh_reply** prev;
@@ -2032,8 +2003,18 @@ mesh_client_wait_callback(void* arg)
 	struct mesh_cb* timed_out_cbs = NULL;
 	struct mesh_cb** ctail = &timed_out_cbs;
 
-	if(!qstate->client_wait_data || !qstate->client_wait_data->timer)
+	if(!qstate->client_wait_timer)
 		return;
+	/* The timeout can have been set to 0 (or negative) since arming, by
+	 * set_option or fast-reload; with deadline_ms <= 0 every waiter would
+	 * time out at once instead of the documented disable. Policy-dropped
+	 * queries must stay silent like every other reply path. In both cases
+	 * stop the timer and leave the replies to the normal completion. */
+	if(deadline_ms <= 0 || qstate->is_drop) {
+		comm_timer_delete(qstate->client_wait_timer);
+		qstate->client_wait_timer = NULL;
+		return;
+	}
 	was_reply_state = (mstate->reply_list != NULL ||
 		mstate->cb_list != NULL);
 
@@ -2044,7 +2025,9 @@ mesh_client_wait_callback(void* arg)
 	prev = &mstate->reply_list;
 	r = mstate->reply_list;
 	while(r) {
-		if(age_ms(&now, &r->start_time) >= deadline_ms) {
+		struct timeval d;
+		client_wait_deadline(&d, &r->start_time, deadline_ms);
+		if(!timeval_smaller(&now, &d)) {
 			struct mesh_reply* next = r->next;
 			struct sldns_buffer* r_buffer = r->query_reply.c->buffer;
 			if(r->query_reply.c->tcp_req_info)
@@ -2055,7 +2038,7 @@ mesh_client_wait_callback(void* arg)
 				edns_opt_list_append_ede(&r->edns.opt_list_out,
 					qstate->region,
 					LDNS_EDE_NO_REACHABLE_AUTHORITY,
-					CLIENT_WAIT_TIMEOUT_EDE_TEXT);
+					"client wait timeout exceeded");
 			if(verbosity >= VERB_ALGO) {
 				char addr_str[128];
 				addr_to_str(&r->query_reply.client_addr,
@@ -2077,8 +2060,6 @@ mesh_client_wait_callback(void* arg)
 			mesh->num_queries_client_wait_timeout++;
 			r = next;
 		} else {
-			struct timeval d;
-			client_wait_deadline(&d, &r->start_time, deadline_ms);
 			if(!have_next || timeval_smaller(&d, &next_fire)) {
 				next_fire = d;
 				have_next = 1;
@@ -2100,14 +2081,14 @@ mesh_client_wait_callback(void* arg)
 	c = mstate->cb_list;
 	while(c) {
 		struct mesh_cb* next = c->next;
-		if(age_ms(&now, &c->start_time) >= deadline_ms) {
+		struct timeval d;
+		client_wait_deadline(&d, &c->start_time, deadline_ms);
+		if(!timeval_smaller(&now, &d)) {
 			*cprev = next;
 			c->next = NULL;
 			*ctail = c;
 			ctail = &c->next;
 		} else {
-			struct timeval d;
-			client_wait_deadline(&d, &c->start_time, deadline_ms);
 			if(!have_next || timeval_smaller(&d, &next_fire)) {
 				next_fire = d;
 				have_next = 1;
@@ -2138,10 +2119,10 @@ mesh_client_wait_callback(void* arg)
 			delta.tv_sec = 0;
 			delta.tv_usec = 1;
 		}
-		comm_timer_set(qstate->client_wait_data->timer, &delta);
+		comm_timer_set(qstate->client_wait_timer, &delta);
 	} else {
-		comm_timer_delete(qstate->client_wait_data->timer);
-		qstate->client_wait_data->timer = NULL;
+		comm_timer_delete(qstate->client_wait_timer);
+		qstate->client_wait_timer = NULL;
 	}
 
 	/* Invoke the timed-out callbacks now that the state's accounting and
@@ -2149,7 +2130,8 @@ mesh_client_wait_callback(void* arg)
 	 * for this state re-arms the timer and re-counts the state cleanly. */
 	while((c = timed_out_cbs) != NULL) {
 		timed_out_cbs = c->next;
-		mesh_do_callback(mstate, LDNS_RCODE_SERVFAIL, NULL, c, &tv);
+		mesh_do_callback(mstate, LDNS_RCODE_SERVFAIL, NULL, c,
+			&c->start_time);
 		mesh->num_queries_client_wait_timeout++;
 	}
 }

--- a/services/mesh.c
+++ b/services/mesh.c
@@ -2029,6 +2029,8 @@ mesh_client_wait_callback(void* arg)
 	struct mesh_reply* r;
 	struct mesh_cb** cprev;
 	struct mesh_cb* c;
+	struct mesh_cb* timed_out_cbs = NULL;
+	struct mesh_cb** ctail = &timed_out_cbs;
 
 	if(!qstate->client_wait_data || !qstate->client_wait_data->timer)
 		return;
@@ -2086,17 +2088,23 @@ mesh_client_wait_callback(void* arg)
 		}
 	}
 
-	/* cb_list (libunbound): plain SERVFAIL, no EDE (intentional asymmetry). */
+	/* cb_list (libunbound): plain SERVFAIL, no EDE (intentional asymmetry).
+	 * First unlink all aged entries onto a local list without invoking
+	 * anything: callbacks can re-enter the mesh at once (mesh_new_callback
+	 * prepends to cb_list, mesh_remove_callback unlinks), which would
+	 * invalidate a cached predecessor pointer mid-sweep. Same reason
+	 * mesh_query_done and mesh_serve_expired_callback drain from the list
+	 * head. The callbacks run below, after the per-state accounting and
+	 * the timer are settled. */
 	cprev = &mstate->cb_list;
 	c = mstate->cb_list;
 	while(c) {
+		struct mesh_cb* next = c->next;
 		if(age_ms(&now, &c->start_time) >= deadline_ms) {
-			struct mesh_cb* next = c->next;
 			*cprev = next;
-			mesh_do_callback(mstate, LDNS_RCODE_SERVFAIL, NULL, c,
-				&tv);
-			mesh->num_queries_client_wait_timeout++;
-			c = next;
+			c->next = NULL;
+			*ctail = c;
+			ctail = &c->next;
 		} else {
 			struct timeval d;
 			client_wait_deadline(&d, &c->start_time, deadline_ms);
@@ -2105,8 +2113,8 @@ mesh_client_wait_callback(void* arg)
 				have_next = 1;
 			}
 			cprev = &c->next;
-			c = c->next;
 		}
+		c = next;
 	}
 
 	/* Per-state accounting: a state stops being a reply state only when it
@@ -2134,6 +2142,15 @@ mesh_client_wait_callback(void* arg)
 	} else {
 		comm_timer_delete(qstate->client_wait_data->timer);
 		qstate->client_wait_data->timer = NULL;
+	}
+
+	/* Invoke the timed-out callbacks now that the state's accounting and
+	 * timer are consistent; a callback that re-enters mesh_new_callback
+	 * for this state re-arms the timer and re-counts the state cleanly. */
+	while((c = timed_out_cbs) != NULL) {
+		timed_out_cbs = c->next;
+		mesh_do_callback(mstate, LDNS_RCODE_SERVFAIL, NULL, c, &tv);
+		mesh->num_queries_client_wait_timeout++;
 	}
 }
 

--- a/services/mesh.h
+++ b/services/mesh.h
@@ -141,6 +141,8 @@ struct mesh_area {
 	size_t rpz_action[UB_STATS_RPZ_ACTION_NUM];
 	/** stats, number of queries removed due to discard-timeout */
 	size_t num_queries_discard_timeout;
+	/** stats, number of queries SERVFAILed due to client-wait-timeout */
+	size_t num_queries_client_wait_timeout;
 	/** stats, number of queries removed due to replyaddr limit */
 	size_t num_queries_replyaddr_limit;
 	/** stats, number of queries removed due to wait-limit */
@@ -271,6 +273,8 @@ typedef void (*mesh_cb_func_type)(void* cb_arg, int rcode, struct sldns_buffer*,
 struct mesh_cb {
 	/** next in list */
 	struct mesh_cb* next;
+	/** the time when the callback was attached */
+	struct timeval start_time;
 	/** edns data from query */
 	struct edns_data edns;
 	/** id of query, in network byteorder. */
@@ -739,5 +743,11 @@ void mesh_respond_serve_expired(struct mesh_state* mstate);
  */
 void mesh_remove_callback(struct mesh_area* mesh, struct query_info* qinfo,
 	uint16_t qflags, mesh_cb_func_type cb, void* cb_arg);
+
+/**
+ * Timer callback for client-wait-timeout: SERVFAILs aged replies.
+ * @param arg: the mesh_state* that owns this timer.
+ */
+void mesh_client_wait_callback(void* arg);
 
 #endif /* SERVICES_MESH_H */

--- a/smallapp/unbound-checkconf.c
+++ b/smallapp/unbound-checkconf.c
@@ -1014,6 +1014,19 @@ morechecks(struct config_file* cfg)
 	if(cfg->remote_control_enable)
 		controlinterfacechecks(cfg);
 
+	if(cfg->client_wait_timeout < 0)
+		fatal_exit("client-wait-timeout must be 0 or greater");
+	if(cfg->client_wait_timeout > 0 && cfg->serve_expired &&
+		cfg->serve_expired_client_timeout > 0 &&
+		cfg->client_wait_timeout < cfg->serve_expired_client_timeout) {
+		fprintf(stderr, "unbound-checkconf: warning: client-wait-timeout "
+			"(%d ms) is less than serve-expired-client-timeout (%d ms); "
+			"client-wait-timeout will fire first, making "
+			"serve-expired-client-timeout ineffective for first-time "
+			"queries\n", cfg->client_wait_timeout,
+			cfg->serve_expired_client_timeout);
+	}
+
 	donotquerylocalhostcheck(cfg);
 	localzonechecks(cfg);
 	view_and_respipchecks(cfg);

--- a/smallapp/unbound-checkconf.c
+++ b/smallapp/unbound-checkconf.c
@@ -1021,9 +1021,10 @@ morechecks(struct config_file* cfg)
 		cfg->client_wait_timeout < cfg->serve_expired_client_timeout) {
 		fprintf(stderr, "unbound-checkconf: warning: client-wait-timeout "
 			"(%d ms) is less than serve-expired-client-timeout (%d ms); "
-			"client-wait-timeout will fire first, making "
-			"serve-expired-client-timeout ineffective for first-time "
-			"queries\n", cfg->client_wait_timeout,
+			"client-wait-timeout fires first and answers SERVFAIL, "
+			"pre-empting the stale answers that "
+			"serve-expired-client-timeout would give\n",
+			cfg->client_wait_timeout,
 			cfg->serve_expired_client_timeout);
 	}
 	if(cfg->client_wait_timeout > 0 && cfg->discard_timeout > 0 &&

--- a/smallapp/unbound-checkconf.c
+++ b/smallapp/unbound-checkconf.c
@@ -1026,6 +1026,15 @@ morechecks(struct config_file* cfg)
 			"queries\n", cfg->client_wait_timeout,
 			cfg->serve_expired_client_timeout);
 	}
+	if(cfg->client_wait_timeout > 0 && cfg->discard_timeout > 0 &&
+		cfg->client_wait_timeout >= cfg->discard_timeout) {
+		fprintf(stderr, "unbound-checkconf: warning: client-wait-timeout "
+			"(%d ms) is not smaller than discard-timeout (%d ms); "
+			"UDP replies that arrive between the two timeouts are "
+			"discarded before client-wait-timeout can send SERVFAIL, "
+			"so those clients get no response at all\n",
+			cfg->client_wait_timeout, cfg->discard_timeout);
+	}
 
 	donotquerylocalhostcheck(cfg);
 	localzonechecks(cfg);

--- a/smallapp/unbound-control.c
+++ b/smallapp/unbound-control.c
@@ -236,6 +236,8 @@ static void pr_stats(const char* nm, struct ub_stats_info* s)
 		s->svr.num_queries_cookie_invalid);
 	PR_UL_NM("num.queries_discard_timeout",
 		s->svr.num_queries_discard_timeout);
+	PR_UL_NM("num.queries_client_wait_timeout",
+		s->svr.num_queries_client_wait_timeout);
 	PR_UL_NM("num.queries_replyaddr_limit",
 		s->svr.num_queries_replyaddr_limit);
 	PR_UL_NM("num.queries_wait_limit", s->svr.num_queries_wait_limit);

--- a/testdata/04-checkconf.tdir/04-checkconf.test
+++ b/testdata/04-checkconf.tdir/04-checkconf.test
@@ -79,4 +79,65 @@ else
 	exit 1
 fi
 
+# test client-wait-timeout warning (serve-expired pre-emption)
+cat > tmpconf_cwt_warn.conf << 'EOF'
+server:
+	chroot: ""
+	directory: ""
+	pidfile: ""
+	username: ""
+	logfile: ""
+	serve-expired: yes
+	serve-expired-client-timeout: 10000
+	client-wait-timeout: 1000
+EOF
+echo $PRE/unbound-checkconf tmpconf_cwt_warn.conf
+$PRE/unbound-checkconf tmpconf_cwt_warn.conf > outfile 2>&1
+if test $? != 0; then
+	cat outfile
+	echo "wrong exit code, client-wait-timeout warning should not fail with error"
+	exit 1
+fi
+cat outfile
+if grep "client-wait-timeout" outfile; then
+	echo "OK"
+else
+	echo "Failed, should print client-wait-timeout warning"
+	exit 1
+fi
+
+# test client-wait-timeout positive value (accepted)
+cat > tmpconf_cwt_pos.conf << 'EOF'
+server:
+	chroot: ""
+	directory: ""
+	pidfile: ""
+	username: ""
+	logfile: ""
+	client-wait-timeout: 4000
+EOF
+echo $PRE/unbound-checkconf tmpconf_cwt_pos.conf
+$PRE/unbound-checkconf tmpconf_cwt_pos.conf
+if test $? != 0; then
+	echo "wrong exit code, client-wait-timeout: 4000 should be accepted"
+	exit 1
+fi
+
+# test client-wait-timeout negative value (rejected)
+cat > tmpconf_cwt_neg.conf << 'EOF'
+server:
+	chroot: ""
+	directory: ""
+	pidfile: ""
+	username: ""
+	logfile: ""
+	client-wait-timeout: -1
+EOF
+echo $PRE/unbound-checkconf tmpconf_cwt_neg.conf
+$PRE/unbound-checkconf tmpconf_cwt_neg.conf
+if test $? = 0; then
+	echo "wrong exit code, client-wait-timeout: -1 should be rejected"
+	exit 1
+fi
+
 exit 0

--- a/testdata/04-checkconf.tdir/04-checkconf.test
+++ b/testdata/04-checkconf.tdir/04-checkconf.test
@@ -99,10 +99,10 @@ if test $? != 0; then
 	exit 1
 fi
 cat outfile
-if grep "client-wait-timeout" outfile; then
+if grep "serve-expired-client-timeout" outfile; then
 	echo "OK"
 else
-	echo "Failed, should print client-wait-timeout warning"
+	echo "Failed, should print serve-expired-client-timeout warning"
 	exit 1
 fi
 
@@ -132,7 +132,7 @@ else
 	exit 1
 fi
 
-# test client-wait-timeout positive value (accepted)
+# test client-wait-timeout positive value (accepted, no warnings)
 cat > tmpconf_cwt_pos.conf << 'EOF'
 server:
 	chroot: ""
@@ -140,12 +140,17 @@ server:
 	pidfile: ""
 	username: ""
 	logfile: ""
-	client-wait-timeout: 4000
+	client-wait-timeout: 1000
 EOF
 echo $PRE/unbound-checkconf tmpconf_cwt_pos.conf
-$PRE/unbound-checkconf tmpconf_cwt_pos.conf
+$PRE/unbound-checkconf tmpconf_cwt_pos.conf > outfile 2>&1
 if test $? != 0; then
-	echo "wrong exit code, client-wait-timeout: 4000 should be accepted"
+	cat outfile
+	echo "wrong exit code, client-wait-timeout: 1000 should be accepted"
+	exit 1
+fi
+if grep -i "warning" outfile; then
+	echo "Failed, client-wait-timeout: 1000 should not warn"
 	exit 1
 fi
 
@@ -160,9 +165,17 @@ server:
 	client-wait-timeout: -1
 EOF
 echo $PRE/unbound-checkconf tmpconf_cwt_neg.conf
-$PRE/unbound-checkconf tmpconf_cwt_neg.conf
+$PRE/unbound-checkconf tmpconf_cwt_neg.conf > outfile 2>&1
 if test $? = 0; then
+	cat outfile
 	echo "wrong exit code, client-wait-timeout: -1 should be rejected"
+	exit 1
+fi
+cat outfile
+if grep "must be 0 or greater" outfile; then
+	echo "OK"
+else
+	echo "Failed, should print the negative value error"
 	exit 1
 fi
 

--- a/testdata/04-checkconf.tdir/04-checkconf.test
+++ b/testdata/04-checkconf.tdir/04-checkconf.test
@@ -106,6 +106,32 @@ else
 	exit 1
 fi
 
+# test client-wait-timeout warning (discard-timeout masks it)
+cat > tmpconf_cwt_discard.conf << 'EOF'
+server:
+	chroot: ""
+	directory: ""
+	pidfile: ""
+	username: ""
+	logfile: ""
+	discard-timeout: 1900
+	client-wait-timeout: 2500
+EOF
+echo $PRE/unbound-checkconf tmpconf_cwt_discard.conf
+$PRE/unbound-checkconf tmpconf_cwt_discard.conf > outfile 2>&1
+if test $? != 0; then
+	cat outfile
+	echo "wrong exit code, client-wait-timeout discard warning should not fail with error"
+	exit 1
+fi
+cat outfile
+if grep "discard-timeout" outfile; then
+	echo "OK"
+else
+	echo "Failed, should print discard-timeout warning"
+	exit 1
+fi
+
 # test client-wait-timeout positive value (accepted)
 cat > tmpconf_cwt_pos.conf << 'EOF'
 server:

--- a/testdata/04-checkconf.tdir/good.all
+++ b/testdata/04-checkconf.tdir/good.all
@@ -225,6 +225,8 @@ server:
 	# IP packets
 	ip-dscp: 5
 
+	client-wait-timeout: 4000
+
 # Stub zones.
 # Create entries like below, to make all queries for 'example.com' and 
 # 'example.org' go to the given list of nameservers. list zero or more 

--- a/testdata/04-checkconf.tdir/good.all
+++ b/testdata/04-checkconf.tdir/good.all
@@ -225,7 +225,7 @@ server:
 	# IP packets
 	ip-dscp: 5
 
-	client-wait-timeout: 4000
+	client-wait-timeout: 1000
 
 # Stub zones.
 # Create entries like below, to make all queries for 'example.com' and 

--- a/testdata/client_wait_timeout_basic.rpl
+++ b/testdata/client_wait_timeout_basic.rpl
@@ -1,0 +1,64 @@
+; config options
+server:
+	module-config: "iterator"
+	qname-minimisation: "no"
+	minimal-responses: no
+	client-wait-timeout: 1
+	ede: yes
+
+stub-zone:
+	name: "example.com"
+	stub-addr: 1.2.3.4
+CONFIG_END
+
+SCENARIO_BEGIN Test client-wait-timeout basic SERVFAIL+EDE22
+
+; The stub answers NS referrals but never the A query.
+; This keeps the upstream A query outstanding until the client-wait timer fires.
+RANGE_BEGIN 0 100
+	ADDRESS 1.2.3.4
+	ENTRY_BEGIN
+		MATCH opcode qtype qname
+		ADJUST copy_id
+		REPLY QR NOERROR
+		SECTION QUESTION
+			example.com. IN NS
+		SECTION ANSWER
+			example.com. IN NS ns.example.com.
+		SECTION ADDITIONAL
+			ns.example.com. IN A 1.2.3.4
+	ENTRY_END
+RANGE_END
+
+STEP 1 QUERY
+ENTRY_BEGIN
+	REPLY RD DO
+	SECTION QUESTION
+		example.com. IN A
+ENTRY_END
+
+; Advance time by 1 second (>> 1 ms timeout) to fire the client-wait timer
+STEP 10 TIME_PASSES ELAPSE 1
+
+; The client should receive SERVFAIL with EDE 22 (No Reachable Authority)
+STEP 20 CHECK_ANSWER
+ENTRY_BEGIN
+	MATCH all ede=22
+	REPLY QR RD RA DO SERVFAIL
+	SECTION QUESTION
+		example.com. IN A
+ENTRY_END
+
+; Reply to the outstanding upstream A query so the scenario ends cleanly
+STEP 30 REPLY
+ENTRY_BEGIN
+	MATCH opcode qtype qname
+	ADJUST copy_id
+	REPLY QR AA NOERROR
+	SECTION QUESTION
+		example.com. IN A
+	SECTION ANSWER
+		example.com. 3600 IN A 1.2.3.4
+ENTRY_END
+
+SCENARIO_END

--- a/testdata/client_wait_timeout_no_ede.rpl
+++ b/testdata/client_wait_timeout_no_ede.rpl
@@ -1,0 +1,64 @@
+; config options
+server:
+	module-config: "iterator"
+	qname-minimisation: "no"
+	minimal-responses: no
+	client-wait-timeout: 1
+	ede: no
+
+stub-zone:
+	name: "example.com"
+	stub-addr: 1.2.3.4
+CONFIG_END
+
+SCENARIO_BEGIN Test client-wait-timeout plain SERVFAIL with ede disabled
+
+; The stub answers NS referrals but never the A query.
+; This keeps the upstream A query outstanding until the client-wait timer fires.
+RANGE_BEGIN 0 100
+	ADDRESS 1.2.3.4
+	ENTRY_BEGIN
+		MATCH opcode qtype qname
+		ADJUST copy_id
+		REPLY QR NOERROR
+		SECTION QUESTION
+			example.com. IN NS
+		SECTION ANSWER
+			example.com. IN NS ns.example.com.
+		SECTION ADDITIONAL
+			ns.example.com. IN A 1.2.3.4
+	ENTRY_END
+RANGE_END
+
+STEP 1 QUERY
+ENTRY_BEGIN
+	REPLY RD DO
+	SECTION QUESTION
+		example.com. IN A
+ENTRY_END
+
+; Advance time by 1 second (>> 1 ms timeout) to fire the client-wait timer
+STEP 10 TIME_PASSES ELAPSE 1
+
+; The client should receive a plain SERVFAIL, no EDE attached
+STEP 20 CHECK_ANSWER
+ENTRY_BEGIN
+	MATCH all
+	REPLY QR RD RA DO SERVFAIL
+	SECTION QUESTION
+		example.com. IN A
+ENTRY_END
+
+; Reply to the outstanding upstream A query so the scenario ends cleanly
+STEP 30 REPLY
+ENTRY_BEGIN
+	MATCH opcode qtype qname
+	ADJUST copy_id
+	REPLY QR AA NOERROR
+	SECTION QUESTION
+		example.com. IN A
+	SECTION ANSWER
+		example.com. 3600 IN A 1.2.3.4
+ENTRY_END
+
+SCENARIO_END

--- a/testdata/client_wait_timeout_serve_expired_cwt_wins.rpl
+++ b/testdata/client_wait_timeout_serve_expired_cwt_wins.rpl
@@ -1,0 +1,71 @@
+; config options
+server:
+	module-config: "iterator"
+	qname-minimisation: "no"
+	minimal-responses: no
+	serve-expired: yes
+	serve-expired-client-timeout: 10000
+	client-wait-timeout: 1
+	ede: yes
+
+stub-zone:
+	name: "example.com"
+	stub-addr: 1.2.3.4
+CONFIG_END
+
+SCENARIO_BEGIN Test client-wait-timeout wins over serve-expired when cache empty
+
+; serve-expired-client-timeout (10s) > client-wait-timeout (1ms), and the cache
+; is empty, so serve-expired has nothing stale to serve. The client-wait timer
+; fires first and returns SERVFAIL+EDE22.
+
+; The stub answers NS referrals but never the A query, keeping the upstream A
+; query outstanding until the client-wait timer fires.
+RANGE_BEGIN 0 100
+	ADDRESS 1.2.3.4
+	ENTRY_BEGIN
+		MATCH opcode qtype qname
+		ADJUST copy_id
+		REPLY QR NOERROR
+		SECTION QUESTION
+			example.com. IN NS
+		SECTION ANSWER
+			example.com. IN NS ns.example.com.
+		SECTION ADDITIONAL
+			ns.example.com. IN A 1.2.3.4
+	ENTRY_END
+RANGE_END
+
+STEP 1 QUERY
+ENTRY_BEGIN
+	REPLY RD DO
+	SECTION QUESTION
+		example.com. IN A
+ENTRY_END
+
+; Advance time by 1 second (>> 1 ms client-wait timeout) to fire the timer.
+; serve-expired (10s) is far away and there is nothing stale to serve anyway.
+STEP 10 TIME_PASSES ELAPSE 1
+
+; The client should receive SERVFAIL with EDE 22 (No Reachable Authority)
+STEP 20 CHECK_ANSWER
+ENTRY_BEGIN
+	MATCH all ede=22
+	REPLY QR RD RA DO SERVFAIL
+	SECTION QUESTION
+		example.com. IN A
+ENTRY_END
+
+; Reply to the outstanding upstream A query so the scenario ends cleanly
+STEP 30 REPLY
+ENTRY_BEGIN
+	MATCH opcode qtype qname
+	ADJUST copy_id
+	REPLY QR AA NOERROR
+	SECTION QUESTION
+		example.com. IN A
+	SECTION ANSWER
+		example.com. 3600 IN A 1.2.3.4
+ENTRY_END
+
+SCENARIO_END

--- a/testdata/client_wait_timeout_serve_expired_cwt_wins.rpl
+++ b/testdata/client_wait_timeout_serve_expired_cwt_wins.rpl
@@ -56,6 +56,10 @@ ENTRY_BEGIN
 		example.com. IN A
 ENTRY_END
 
+; Let the serve-expired client timer (10s) fire on the now-empty reply list;
+; it must send nothing (a spurious answer fails the scenario as unmatched).
+STEP 25 TIME_PASSES ELAPSE 10
+
 ; Reply to the outstanding upstream A query so the scenario ends cleanly
 STEP 30 REPLY
 ENTRY_BEGIN

--- a/testdata/client_wait_timeout_serve_expired_stale_wins.rpl
+++ b/testdata/client_wait_timeout_serve_expired_stale_wins.rpl
@@ -1,0 +1,134 @@
+; config options
+server:
+	module-config: "validator iterator"
+	qname-minimisation: "no"
+	minimal-responses: no
+	iter-scrub-promiscuous: no
+	serve-expired: yes
+	serve-expired-client-timeout: 1
+	serve-expired-reply-ttl: 30
+	ede: yes
+	ede-serve-expired: yes
+	client-wait-timeout: 10000
+
+stub-zone:
+	name: "example.com"
+	stub-addr: 1.2.3.4
+CONFIG_END
+
+SCENARIO_BEGIN Test serve-expired stale answer wins over client-wait-timeout
+
+; serve-expired-client-timeout (1ms) < client-wait-timeout (10s). A STALE cache
+; entry exists, so serve-expired fires first, detaches the reply, and returns the
+; stale record (NOERROR, TTL 30). The client-wait timer (10s) later finds nothing
+; to SERVFAIL. The client must NOT get SERVFAIL+EDE22.
+
+; ns.example.com.
+RANGE_BEGIN 0 100
+	ADDRESS 1.2.3.4
+	ENTRY_BEGIN
+		MATCH opcode qtype qname
+		ADJUST copy_id
+		REPLY QR NOERROR
+		SECTION QUESTION
+			example.com. IN NS
+		SECTION ANSWER
+			example.com. IN NS ns.example.com.
+		SECTION ADDITIONAL
+			ns.example.com. IN A 1.2.3.4
+	ENTRY_END
+RANGE_END
+
+; Answer the A query only during the priming window (range 0-20). After the TTL
+; expires and we re-query, the upstream never answers the A query, so the only
+; way to answer the client is the stale cache entry via serve-expired.
+RANGE_BEGIN 0 20
+	ADDRESS 1.2.3.4
+	; response to A query
+	ENTRY_BEGIN
+		MATCH opcode qtype qname
+		ADJUST copy_id
+		REPLY QR NOERROR
+		SECTION QUESTION
+			example.com. IN A
+		SECTION ANSWER
+			example.com. 200 IN A 5.6.7.8
+		SECTION AUTHORITY
+			example.com. IN NS ns.example.com.
+		SECTION ADDITIONAL
+			ns.example.com. IN A 1.2.3.4
+	ENTRY_END
+RANGE_END
+
+; Prime the cache: query with RD flag
+STEP 1 QUERY
+ENTRY_BEGIN
+	REPLY RD
+	SECTION QUESTION
+		example.com. IN A
+ENTRY_END
+
+; Check that we got the correct answer (now cached)
+STEP 10 CHECK_ANSWER
+ENTRY_BEGIN
+	MATCH all ttl
+	REPLY QR RD RA NOERROR
+	SECTION QUESTION
+		example.com. IN A
+	SECTION ANSWER
+		example.com. 200 IN A 5.6.7.8
+	SECTION AUTHORITY
+		example.com. IN NS ns.example.com.
+	SECTION ADDITIONAL
+		ns.example.com. IN A 1.2.3.4
+ENTRY_END
+
+; Wait for the TTL to expire so the cache entry becomes stale
+STEP 11 TIME_PASSES ELAPSE 3600
+
+; Query again. Upstream no longer answers the A query (range 0-20 is closed),
+; so serve-expired must serve the stale entry.
+STEP 30 QUERY
+ENTRY_BEGIN
+	REPLY RD DO
+	SECTION QUESTION
+		example.com. IN A
+ENTRY_END
+
+; Allow the serve-expired client timer (1ms) to expire. This is far below the
+; 10s client-wait-timeout, so serve-expired answers first.
+STEP 31 TIME_PASSES ELAPSE 1
+
+; Check that we got the STALE answer (NOERROR, reply-ttl 30) and NOT a SERVFAIL.
+; ede=3 (Stale Answer) is present; ede=22 must NOT be.
+STEP 40 CHECK_ANSWER
+ENTRY_BEGIN
+	MATCH all ttl ede=3
+	REPLY QR RD RA DO NOERROR
+	SECTION QUESTION
+		example.com. IN A
+	SECTION ANSWER
+		example.com.  30 IN A 5.6.7.8
+	SECTION AUTHORITY
+		example.com. 30 IN NS ns.example.com.
+	SECTION ADDITIONAL
+		ns.example.com. 30 IN A 1.2.3.4
+ENTRY_END
+
+; Reply to the outstanding query so the test doesn't fail with pending messages.
+STEP 41 REPLY
+ENTRY_BEGIN
+	MATCH opcode qtype qname
+	ADJUST copy_id
+	REPLY QR AA RD RA NOERROR
+	SECTION QUESTION
+		example.com. IN A
+	SECTION ANSWER
+		example.com.  3600 IN A 5.6.7.8
+	SECTION AUTHORITY
+		example.com. 3600 IN NS ns.example.com.
+	SECTION ADDITIONAL
+		ns.example.com. 3600 IN A 1.2.3.4
+ENTRY_END
+
+SCENARIO_END

--- a/testdata/client_wait_timeout_serve_expired_stale_wins.rpl
+++ b/testdata/client_wait_timeout_serve_expired_stale_wins.rpl
@@ -115,8 +115,12 @@ ENTRY_BEGIN
 		ns.example.com. 30 IN A 1.2.3.4
 ENTRY_END
 
+; Let the client-wait timer (10s) fire on the now-empty reply list; it must
+; be a no-op (no client waiting, nothing may be sent) and delete itself.
+STEP 41 TIME_PASSES ELAPSE 10
+
 ; Reply to the outstanding query so the test doesn't fail with pending messages.
-STEP 41 REPLY
+STEP 50 REPLY
 ENTRY_BEGIN
 	MATCH opcode qtype qname
 	ADJUST copy_id

--- a/testdata/client_wait_timeout_staggered.rpl
+++ b/testdata/client_wait_timeout_staggered.rpl
@@ -1,0 +1,90 @@
+; config options
+server:
+	module-config: "iterator"
+	qname-minimisation: "no"
+	minimal-responses: no
+	client-wait-timeout: 2000
+	ede: yes
+
+stub-zone:
+	name: "example.com"
+	stub-addr: 1.2.3.4
+CONFIG_END
+
+SCENARIO_BEGIN Test client-wait-timeout per-reply fairness on a merged state
+
+; The stub answers NS referrals but never the A query, so the upstream A query
+; stays outstanding and both clients keep waiting on one merged mesh state.
+RANGE_BEGIN 0 100
+	ADDRESS 1.2.3.4
+	ENTRY_BEGIN
+		MATCH opcode qtype qname
+		ADJUST copy_id
+		REPLY QR NOERROR
+		SECTION QUESTION
+			example.com. IN NS
+		SECTION ANSWER
+			example.com. IN NS ns.example.com.
+		SECTION ADDITIONAL
+			ns.example.com. IN A 1.2.3.4
+	ENTRY_END
+RANGE_END
+
+; t=0: client A queries. Its deadline is start_time(0) + 2000ms = 2.0s.
+STEP 1 QUERY ADDRESS 127.0.0.1
+ENTRY_BEGIN
+	REPLY RD DO
+	SECTION QUESTION
+		example.com. IN A
+ENTRY_END
+
+; t=1.0s: well within A's 2s window; nothing fires.
+STEP 10 TIME_PASSES ELAPSE 1
+
+; t=1.0s: client B queries the SAME qname/qtype, merging onto A's state.
+; B's deadline is start_time(1.0) + 2000ms = 3.0s. A's earlier 2.0s timer stands.
+STEP 11 QUERY ADDRESS 127.0.0.2
+ENTRY_BEGIN
+	REPLY RD DO
+	SECTION QUESTION
+		example.com. IN A
+ENTRY_END
+
+; t=2.5s: A's 2.0s deadline has passed (aged 2.5s >= 2000ms) so A is SERVFAILed,
+; but B (aged only 1.5s) is NOT; the timer is rescheduled to B's 3.0s deadline.
+STEP 20 TIME_PASSES ELAPSE 1.5
+
+; Only client A (127.0.0.1) gets SERVFAIL+EDE22 at this point.
+STEP 30 CHECK_ANSWER ADDRESS 127.0.0.1
+ENTRY_BEGIN
+	MATCH all ede=22
+	REPLY QR RD RA DO SERVFAIL
+	SECTION QUESTION
+		example.com. IN A
+ENTRY_END
+
+; t=3.5s: B's 3.0s deadline has now passed (aged 2.5s >= 2000ms) so B is SERVFAILed.
+STEP 40 TIME_PASSES ELAPSE 1
+
+; Client B (127.0.0.2) gets its own SERVFAIL+EDE22, at its own later deadline.
+STEP 50 CHECK_ANSWER ADDRESS 127.0.0.2
+ENTRY_BEGIN
+	MATCH all ede=22
+	REPLY QR RD RA DO SERVFAIL
+	SECTION QUESTION
+		example.com. IN A
+ENTRY_END
+
+; Reply to the outstanding upstream A query so the scenario ends cleanly.
+STEP 60 REPLY
+ENTRY_BEGIN
+	MATCH opcode qtype qname
+	ADJUST copy_id
+	REPLY QR AA NOERROR
+	SECTION QUESTION
+		example.com. IN A
+	SECTION ANSWER
+		example.com. 3600 IN A 1.2.3.4
+ENTRY_END
+
+SCENARIO_END

--- a/testdata/client_wait_timeout_staggered_fair.rpl
+++ b/testdata/client_wait_timeout_staggered_fair.rpl
@@ -1,0 +1,89 @@
+; config options
+server:
+	module-config: "iterator"
+	qname-minimisation: "no"
+	minimal-responses: no
+	client-wait-timeout: 2000
+	ede: yes
+
+stub-zone:
+	name: "example.com"
+	stub-addr: 1.2.3.4
+CONFIG_END
+
+SCENARIO_BEGIN Test client-wait-timeout does not pre-empt later client on merged state
+
+; Companion to client_wait_timeout_staggered.rpl. There the upstream stays
+; silent and B is SERVFAILed at its own later deadline. Here the upstream
+; answers between A's deadline and B's, so B must get the real NOERROR
+; answer. If a broken sweep SERVFAILed B together with A, that early
+; SERVFAIL fails the NOERROR check and is an unmatched leftover answer.
+RANGE_BEGIN 0 100
+	ADDRESS 1.2.3.4
+	ENTRY_BEGIN
+		MATCH opcode qtype qname
+		ADJUST copy_id
+		REPLY QR NOERROR
+		SECTION QUESTION
+			example.com. IN NS
+		SECTION ANSWER
+			example.com. IN NS ns.example.com.
+		SECTION ADDITIONAL
+			ns.example.com. IN A 1.2.3.4
+	ENTRY_END
+RANGE_END
+
+; t=0: client A queries. Its deadline is start_time(0) + 2000ms = 2.0s.
+STEP 1 QUERY ADDRESS 127.0.0.1
+ENTRY_BEGIN
+	REPLY RD DO
+	SECTION QUESTION
+		example.com. IN A
+ENTRY_END
+
+; t=1.0s: client B queries the SAME qname/qtype, merging onto A's state.
+; B's deadline is start_time(1.0) + 2000ms = 3.0s.
+STEP 10 TIME_PASSES ELAPSE 1
+STEP 11 QUERY ADDRESS 127.0.0.2
+ENTRY_BEGIN
+	REPLY RD DO
+	SECTION QUESTION
+		example.com. IN A
+ENTRY_END
+
+; t=2.5s: A's 2.0s deadline has passed, B's 3.0s deadline has not.
+STEP 20 TIME_PASSES ELAPSE 1.5
+
+; Only client A (127.0.0.1) gets SERVFAIL+EDE22.
+STEP 30 CHECK_ANSWER ADDRESS 127.0.0.1
+ENTRY_BEGIN
+	MATCH all ede=22
+	REPLY QR RD RA DO SERVFAIL
+	SECTION QUESTION
+		example.com. IN A
+ENTRY_END
+
+; t=2.5s: upstream answers before B's 3.0s deadline.
+STEP 40 REPLY
+ENTRY_BEGIN
+	MATCH opcode qtype qname
+	ADJUST copy_id
+	REPLY QR AA NOERROR
+	SECTION QUESTION
+		example.com. IN A
+	SECTION ANSWER
+		example.com. 3600 IN A 1.2.3.4
+ENTRY_END
+
+; Client B (127.0.0.2) must receive the real answer, not a SERVFAIL.
+STEP 50 CHECK_ANSWER ADDRESS 127.0.0.2
+ENTRY_BEGIN
+	MATCH all
+	REPLY QR RD RA DO NOERROR
+	SECTION QUESTION
+		example.com. IN A
+	SECTION ANSWER
+		example.com. 3600 IN A 1.2.3.4
+ENTRY_END
+
+SCENARIO_END

--- a/testdata/client_wait_timeout_tcp.rpl
+++ b/testdata/client_wait_timeout_tcp.rpl
@@ -1,0 +1,67 @@
+; config options
+server:
+	module-config: "iterator"
+	qname-minimisation: "no"
+	minimal-responses: no
+	client-wait-timeout: 1
+	ede: yes
+
+stub-zone:
+	name: "example.com"
+	stub-addr: 1.2.3.4
+CONFIG_END
+
+SCENARIO_BEGIN Test client-wait-timeout SERVFAIL+EDE22 for a TCP client
+
+; The stub answers NS referrals but never the A query, so the upstream A query
+; stays outstanding until the client-wait timer fires.
+RANGE_BEGIN 0 100
+	ADDRESS 1.2.3.4
+	ENTRY_BEGIN
+		MATCH opcode qtype qname
+		ADJUST copy_id
+		REPLY QR NOERROR
+		SECTION QUESTION
+			example.com. IN NS
+		SECTION ANSWER
+			example.com. IN NS ns.example.com.
+		SECTION ADDITIONAL
+			ns.example.com. IN A 1.2.3.4
+	ENTRY_END
+RANGE_END
+
+; A TCP client query (MATCH TCP forces the incoming comm_point to comm_tcp,
+; exercising the tcp_req_info re-entrant send path in the timeout callback).
+STEP 1 QUERY
+ENTRY_BEGIN
+	MATCH TCP
+	REPLY RD DO
+	SECTION QUESTION
+		example.com. IN A
+ENTRY_END
+
+; Advance time by 1 second (>> 1 ms timeout) to fire the client-wait timer.
+STEP 10 TIME_PASSES ELAPSE 1
+
+; The TCP client should receive SERVFAIL with EDE 22 (No Reachable Authority).
+STEP 20 CHECK_ANSWER
+ENTRY_BEGIN
+	MATCH all TCP ede=22
+	REPLY QR RD RA DO SERVFAIL
+	SECTION QUESTION
+		example.com. IN A
+ENTRY_END
+
+; Reply to the outstanding upstream A query so the scenario ends cleanly.
+STEP 30 REPLY
+ENTRY_BEGIN
+	MATCH opcode qtype qname
+	ADJUST copy_id
+	REPLY QR AA NOERROR
+	SECTION QUESTION
+		example.com. IN A
+	SECTION ANSWER
+		example.com. 3600 IN A 1.2.3.4
+ENTRY_END
+
+SCENARIO_END

--- a/testdata/client_wait_timeout_tcp.rpl
+++ b/testdata/client_wait_timeout_tcp.rpl
@@ -30,8 +30,9 @@ RANGE_BEGIN 0 100
 	ENTRY_END
 RANGE_END
 
-; A TCP client query (MATCH TCP forces the incoming comm_point to comm_tcp,
-; exercising the tcp_req_info re-entrant send path in the timeout callback).
+; A TCP client query. Note testbound's fake comm_point has no tcp_req_info,
+; so this only exercises the comm_tcp buffer path of the timeout callback;
+; the tcp_req_info spool-buffer path needs a real daemon (stat_values.tdir).
 STEP 1 QUERY
 ENTRY_BEGIN
 	MATCH TCP

--- a/testdata/stat_values.tdir/stat_values.pre
+++ b/testdata/stat_values.tdir/stat_values.pre
@@ -39,6 +39,7 @@ sed -e 's/@PORT\@/'$UNBOUND_PORT'/' -e 's/@TOPORT\@/'$FWD_PORT'/' -e 's/@EXPIRED
 sed -e 's/@PORT\@/'$UNBOUND_PORT'/' -e 's/@TOPORT\@/'$FWD_PORT'/' -e 's/@EXPIREDPORT\@/'$FWD_EXPIRED_PORT'/' -e 's/@CONTROL_PORT\@/'$CONTROL_PORT'/' < stat_values_cachedb.conf > ub_cachedb.conf
 sed -e 's/@PORT\@/'$UNBOUND_PORT'/'                                                                          -e 's/@CONTROL_PORT\@/'$CONTROL_PORT'/' < stat_values_downstream_cookies.conf > ub_downstream_cookies.conf
 sed -e 's/@PORT\@/'$UNBOUND_PORT'/' -e 's/@TOPORT\@/'$FWD_PORT'/'                                            -e 's/@CONTROL_PORT\@/'$CONTROL_PORT'/' < stat_values_discard_wait_limit.conf > ub_discard_wait_limit.conf
+sed -e 's/@PORT\@/'$UNBOUND_PORT'/' -e 's/@TOPORT\@/'$FWD_PORT'/'                                            -e 's/@CONTROL_PORT\@/'$CONTROL_PORT'/' < stat_values_client_wait_timeout.conf > ub_client_wait_timeout.conf
 # start unbound in the background
 $PRE/unbound -d -c ub.conf >unbound.log 2>&1 &
 UNBOUND_PID=$!

--- a/testdata/stat_values.tdir/stat_values.test
+++ b/testdata/stat_values.tdir/stat_values.test
@@ -510,23 +510,34 @@ if grep "SERVFAIL" outfile; then
 else
 	end 1
 fi
-# Wait for the outstanding upstream query to time out so the state finishes.
+# Same over TCP (different name, the first SERVFAIL is cached); this drives
+# the tcp_req_info reply path of the timeout callback, which testbound
+# replays cannot reach.
+echo "> dig www2.unresponsive +tcp"
+dig @127.0.0.1 -p $UNBOUND_PORT +tcp +retry=0 +timeout=2 www2.unresponsive. | tee outfile
+if grep "SERVFAIL" outfile; then
+	echo "OK"
+else
+	end 1
+fi
+# Wait for the outstanding upstream queries to time out so the states finish.
 sleep 4
 check_stats "\
 infra.cache.count=1
-msg.cache.count=1
-num.answer.rcode.SERVFAIL=1
-num.query.class.IN=1
-num.query.edns.present=1
-num.query.flags.AD=1
-num.query.flags.RD=1
-num.query.opcode.QUERY=1
-num.query.type.A=1
-num.query.udpout=1
-total.num.cachemiss=1
-total.num.queries=1
-total.num.queries_client_wait_timeout=1
-total.num.recursivereplies=1"
+msg.cache.count=2
+num.answer.rcode.SERVFAIL=2
+num.query.class.IN=2
+num.query.edns.present=2
+num.query.flags.AD=2
+num.query.flags.RD=2
+num.query.opcode.QUERY=2
+num.query.tcp=1
+num.query.type.A=2
+num.query.udpout=2
+total.num.cachemiss=2
+total.num.queries=2
+total.num.queries_client_wait_timeout=2
+total.num.recursivereplies=2"
 
 
 ###

--- a/testdata/stat_values.tdir/stat_values.test
+++ b/testdata/stat_values.tdir/stat_values.test
@@ -494,6 +494,43 @@ total.num.queries_wait_limit=1"
 
 ###
 #
+# Bring the client-wait-timeout configured Unbound up
+#
+bring_up_alternate_configuration ub_client_wait_timeout.conf
+#
+###
+
+
+teststep "Check client-wait-timeout"
+echo "> dig www.unresponsive"
+dig @127.0.0.1 -p $UNBOUND_PORT +retry=0 +timeout=2 www.unresponsive. | tee outfile
+# The client-wait timer (500 ms) answers SERVFAIL before dig's timeout.
+if grep "SERVFAIL" outfile; then
+	echo "OK"
+else
+	end 1
+fi
+# Wait for the outstanding upstream query to time out so the state finishes.
+sleep 4
+check_stats "\
+infra.cache.count=1
+msg.cache.count=1
+num.answer.rcode.SERVFAIL=1
+num.query.class.IN=1
+num.query.edns.present=1
+num.query.flags.AD=1
+num.query.flags.RD=1
+num.query.opcode.QUERY=1
+num.query.type.A=1
+num.query.udpout=1
+total.num.cachemiss=1
+total.num.queries=1
+total.num.queries_client_wait_timeout=1
+total.num.recursivereplies=1"
+
+
+###
+#
 # Bring the downstream DNS Cookies configured Unbound up
 #
 bring_up_alternate_configuration ub_downstream_cookies.conf

--- a/testdata/stat_values.tdir/stat_values_client_wait_timeout.conf
+++ b/testdata/stat_values.tdir/stat_values_client_wait_timeout.conf
@@ -1,0 +1,33 @@
+server:
+	verbosity: 5
+	num-threads: 1
+	interface: 127.0.0.1
+	module-config: "validator iterator"
+	port: @PORT@
+	use-syslog: no
+	directory: ""
+	pidfile: "unbound.pid"
+	chroot: ""
+	username: ""
+	do-not-query-localhost: no
+	extended-statistics: yes
+	identity: "stat_values"
+	outbound-msg-retry: 0
+	root-key-sentinel: no
+	trust-anchor-signaling: no
+
+	client-wait-timeout: 500
+	infra-cache-min-rtt: 3000  # keep the upstream query outstanding past the client-wait-timeout
+
+remote-control:
+	control-enable: yes
+	control-interface: 127.0.0.1
+	# control-interface: ::1
+	control-port: @CONTROL_PORT@
+	server-key-file: "unbound_server.key"
+	server-cert-file: "unbound_server.pem"
+	control-key-file: "unbound_control.key"
+	control-cert-file: "unbound_control.pem"
+stub-zone:
+	name: "unresponsive."
+	stub-addr: "127.0.0.1@@TOPORT@"

--- a/util/config_file.c
+++ b/util/config_file.c
@@ -319,6 +319,7 @@ config_create(void)
 	cfg->rrset_roundrobin = 1;
 	cfg->unknown_server_time_limit = 376;
 	cfg->discard_timeout = 1900; /* msec */
+	cfg->client_wait_timeout = 0;
 	cfg->wait_limit = 1000;
 	cfg->wait_limit_cookie = 10000;
 	cfg->wait_limit_netblock = NULL;
@@ -797,6 +798,7 @@ int config_set_option(struct config_file* cfg, const char* opt,
 	else S_YNO("rrset-roundrobin:", rrset_roundrobin)
 	else S_NUMBER_OR_ZERO("unknown-server-time-limit:", unknown_server_time_limit)
 	else S_NUMBER_OR_ZERO("discard-timeout:", discard_timeout)
+	else S_NUMBER_OR_ZERO("client-wait-timeout:", client_wait_timeout)
 	else S_NUMBER_OR_ZERO("wait-limit:", wait_limit)
 	else S_NUMBER_OR_ZERO("wait-limit-cookie:", wait_limit_cookie)
 	else S_STRLIST("local-data:", local_data)
@@ -1296,6 +1298,7 @@ config_get_option(struct config_file* cfg, const char* opt,
 	else O_YNO(opt, "rrset-roundrobin", rrset_roundrobin)
 	else O_DEC(opt, "unknown-server-time-limit", unknown_server_time_limit)
 	else O_DEC(opt, "discard-timeout", discard_timeout)
+	else O_DEC(opt, "client-wait-timeout", client_wait_timeout)
 	else O_DEC(opt, "wait-limit", wait_limit)
 	else O_DEC(opt, "wait-limit-cookie", wait_limit_cookie)
 	else O_LS2(opt, "wait-limit-netblock", wait_limit_netblock)

--- a/util/config_file.h
+++ b/util/config_file.h
@@ -554,6 +554,9 @@ struct config_file {
 	/** Wait time to drop recursion replies */
 	int discard_timeout;
 
+	/** client wait timeout in ms (0 = disabled) */
+	int client_wait_timeout;
+
 	/** Wait limit for number of replies per IP address */
 	int wait_limit;
 

--- a/util/configlexer.lex
+++ b/util/configlexer.lex
@@ -470,6 +470,7 @@ minimal-responses{COLON}	{ YDVAR(1, VAR_MINIMAL_RESPONSES) }
 rrset-roundrobin{COLON}		{ YDVAR(1, VAR_RRSET_ROUNDROBIN) }
 unknown-server-time-limit{COLON} { YDVAR(1, VAR_UNKNOWN_SERVER_TIME_LIMIT) }
 discard-timeout{COLON}		{ YDVAR(1, VAR_DISCARD_TIMEOUT) }
+client-wait-timeout{COLON}	{ YDVAR(1, VAR_CLIENT_WAIT_TIMEOUT) }
 wait-limit{COLON}		{ YDVAR(1, VAR_WAIT_LIMIT) }
 wait-limit-cookie{COLON}	{ YDVAR(1, VAR_WAIT_LIMIT_COOKIE) }
 wait-limit-netblock{COLON}	{ YDVAR(2, VAR_WAIT_LIMIT_NETBLOCK) }

--- a/util/configparser.y
+++ b/util/configparser.y
@@ -197,6 +197,7 @@ extern struct config_parser_state* cfg_parser;
 %token VAR_FORWARD_NO_CACHE VAR_STUB_NO_CACHE VAR_LOG_SERVFAIL VAR_DENY_ANY
 %token VAR_UNKNOWN_SERVER_TIME_LIMIT VAR_LOG_TAG_QUERYREPLY
 %token VAR_DISCARD_TIMEOUT VAR_WAIT_LIMIT VAR_WAIT_LIMIT_COOKIE
+%token VAR_CLIENT_WAIT_TIMEOUT
 %token VAR_WAIT_LIMIT_NETBLOCK VAR_WAIT_LIMIT_COOKIE_NETBLOCK
 %token VAR_STREAM_WAIT_SIZE VAR_TLS_CIPHERS VAR_TLS_CIPHERSUITES VAR_TLS_USE_SNI
 %token VAR_TLS_PROTOCOLS
@@ -360,7 +361,8 @@ content_server: server_num_threads | server_verbosity | server_port |
 	server_log_destaddr | server_cookie_secret_file |
 	server_iter_scrub_ns | server_iter_scrub_cname | server_max_global_quota |
 	server_iter_scrub_rrsig |
-	server_harden_unverified_glue | server_log_time_iso | server_iter_scrub_promiscuous
+	server_harden_unverified_glue | server_log_time_iso | server_iter_scrub_promiscuous |
+	server_client_wait_timeout
 	;
 stub_clause: stubstart contents_stub
 	{
@@ -2488,6 +2490,13 @@ server_discard_timeout: VAR_DISCARD_TIMEOUT STRING_ARG
 	{
 		OUTYY(("P(server_discard_timeout:%s)\n", $2));
 		cfg_parser->cfg->discard_timeout = atoi($2);
+		free($2);
+	}
+	;
+server_client_wait_timeout: VAR_CLIENT_WAIT_TIMEOUT STRING_ARG
+	{
+		OUTYY(("P(server_client_wait_timeout:%s)\n", $2));
+		cfg_parser->cfg->client_wait_timeout = atoi($2);
 		free($2);
 	}
 	;

--- a/util/fptr_wlist.c
+++ b/util/fptr_wlist.c
@@ -145,6 +145,7 @@ fptr_whitelist_comm_timer(void (*fptr)(void*))
 	else if(fptr == &auth_xfer_probe_timer_callback) return 1;
 	else if(fptr == &auth_xfer_transfer_timer_callback) return 1;
 	else if(fptr == &mesh_serve_expired_callback) return 1;
+	else if(fptr == &mesh_client_wait_callback) return 1;
 	else if(fptr == &serviced_timer_cb) return 1;
 #ifdef USE_DNSTAP
 	else if(fptr == &mq_wakeup_cb) return 1;

--- a/util/module.h
+++ b/util/module.h
@@ -629,6 +629,14 @@ struct serve_expired_data {
 };
 
 /**
+ * Struct to hold relevant data for client wait timeout
+ */
+struct client_wait_data {
+	/** libevent timer firing at the next client's deadline */
+	struct comm_timer* timer;
+};
+
+/**
  * Module state, per query.
  */
 struct module_qstate {
@@ -676,6 +684,8 @@ struct module_qstate {
 	time_t prefetch_leeway;
 	/** serve expired data */
 	struct serve_expired_data* serve_expired_data;
+	/** client wait timeout data */
+	struct client_wait_data* client_wait_data;
 
 	/** incoming edns options from the front end */
 	struct edns_option* edns_opts_front_in;

--- a/util/module.h
+++ b/util/module.h
@@ -629,14 +629,6 @@ struct serve_expired_data {
 };
 
 /**
- * Struct to hold relevant data for client wait timeout
- */
-struct client_wait_data {
-	/** libevent timer firing at the next client's deadline */
-	struct comm_timer* timer;
-};
-
-/**
  * Module state, per query.
  */
 struct module_qstate {
@@ -684,8 +676,8 @@ struct module_qstate {
 	time_t prefetch_leeway;
 	/** serve expired data */
 	struct serve_expired_data* serve_expired_data;
-	/** client wait timeout data */
-	struct client_wait_data* client_wait_data;
+	/** client-wait-timeout timer, fires at the next client's deadline */
+	struct comm_timer* client_wait_timer;
 
 	/** incoming edns options from the front end */
 	struct edns_option* edns_opts_front_in;


### PR DESCRIPTION
Adds optional `client-wait-timeout: <msec>` server directive. When a client waits for recursion longer than the configured time, Unbound answers it SERVFAIL + Extended DNS Error 22 (No Reachable Authority); recursion continues in the background, so the cache still fills and the next identical query is served normally. Default `0` (disabled) — opt-in, no existing behavior changes. EDE 22 is attached only when `ede:` is enabled; the libunbound callback path returns plain SERVFAIL with no EDE.

When both `client-wait-timeout` and `serve-expired-client-timeout` are set, whichever fires first answers; the other becomes a no-op (no serve-expired priority). `unbound-checkconf` warns when it sits below `serve-expired-client-timeout` and rejects negatives.

New stats counter `num.queries_client_wait_timeout`, per-thread and summed, via `unbound-control stats`.
