### PR TITLE
Report the actual local source address and port for resolver and forwarder dnstap messages

### DIFF
--- a/services/outside_network.c
+++ b/services/outside_network.c
@@ -997,6 +997,23 @@ waiting_tcp_callback(struct waiting_tcp* w, struct comm_point* c, int error,
 	}
 }
 
+#ifdef USE_DNSTAP
+/** get the local source address and port of socket fd, for dnstap.
+ * On failure, out is zeroed; the resulting AF_UNSPEC family
+ * makes dt_msg_fill_net() omit the query_address and query_port instead
+ * of reporting incorrect data. */
+static void
+dt_get_local_addr(int fd, struct sockaddr_storage* out)
+{
+	socklen_t len = (socklen_t)sizeof(*out);
+	if(getsockname(fd, (struct sockaddr*)out, &len) != 0) {
+		/* TODO confirm if this failure can really ever happen */
+		log_err("dnstap: getsockname failed: %s", sock_strerror(errno));
+		memset(out, 0, sizeof(*out));
+	}
+}
+#endif /* USE_DNSTAP */
+
 /** see if buffers can be used to service TCP queries */
 static void
 use_free_buffer(struct outside_network* outnet)
@@ -1065,9 +1082,11 @@ use_free_buffer(struct outside_network* outnet)
 			(outnet->dtenv->log_resolver_query_messages ||
 			outnet->dtenv->log_forwarder_query_messages)) {
 			sldns_buffer tmp;
+			struct sockaddr_storage local_addr;
 			sldns_buffer_init_frm_data(&tmp, w->pkt, w->pkt_len);
+			dt_get_local_addr(pend_tcp->c->fd, &local_addr);
 			dt_msg_send_outside_query(outnet->dtenv, &w->sq->addr,
-				&pend_tcp->pi->addr, comm_tcp, NULL, w->sq->zone,
+				&local_addr, comm_tcp, NULL, w->sq->zone,
 				w->sq->zonelen, &tmp);
 		}
 #endif
@@ -2098,7 +2117,7 @@ udp_sockport(struct sockaddr_storage* addr, socklen_t addrlen, int pfxlen,
 		 * not mutate the shared interface template. */
 		struct sockaddr_in sa = *(struct sockaddr_in*)addr;
 		sa.sin_port = (in_port_t)htons((uint16_t)port);
-		fd = create_udp_sock(AF_INET, SOCK_DGRAM, 
+		fd = create_udp_sock(AF_INET, SOCK_DGRAM,
 			(struct sockaddr*)&sa, addrlen, 1, inuse, &noproto,
 			0, 0, 0, NULL, 0, 0, 0, dscp);
 	}
@@ -2317,19 +2336,17 @@ randomize_and_send_udp(struct pending* pend, sldns_buffer* packet, int timeout)
 	comm_timer_set(pend->timer, &tv);
 
 #ifdef USE_DNSTAP
-	/*
-	 * sending src (local service)/dst (upstream) addresses over DNSTAP
-	 * There are no chances to get the src (local service) addr if unbound
-	 * is not configured with specific outgoing IP-addresses. So we will
-	 * pass 0.0.0.0 (::) to argument for
-	 * dt_msg_send_outside_query()/dt_msg_send_outside_response() calls.
-	 */
+	/* sending src (local service)/dst (upstream) addresses over DNSTAP;
+	 * read the real source from the socket, as the interface template
+	 * lacks the kernel-chosen source port */
 	if(outnet->dtenv &&
 	   (outnet->dtenv->log_resolver_query_messages ||
 		outnet->dtenv->log_forwarder_query_messages)) {
-			log_addr(VERB_ALGO, "from local addr", &pend->pc->pif->addr, pend->pc->pif->addrlen);
+			struct sockaddr_storage local_addr;
+			dt_get_local_addr(pend->pc->cp->fd, &local_addr);
+			log_addr(VERB_ALGO, "from local addr", &local_addr, (socklen_t)sizeof(local_addr));
 			log_addr(VERB_ALGO, "request to upstream", &pend->addr, pend->addrlen);
-			dt_msg_send_outside_query(outnet->dtenv, &pend->addr, &pend->pc->pif->addr, comm_udp, NULL,
+			dt_msg_send_outside_query(outnet->dtenv, &pend->addr, &local_addr, comm_udp, NULL,
 				pend->sq->zone, pend->sq->zonelen, packet);
 	}
 #endif
@@ -2607,9 +2624,11 @@ pending_tcp_query(struct serviced_query* sq, sldns_buffer* packet,
 		    sq->outnet->dtenv->log_forwarder_query_messages)) {
 			/* use w->pkt, because it has the ID value */
 			sldns_buffer tmp;
+			struct sockaddr_storage local_addr;
 			sldns_buffer_init_frm_data(&tmp, w->pkt, w->pkt_len);
+			dt_get_local_addr(pend->c->fd, &local_addr);
 			dt_msg_send_outside_query(sq->outnet->dtenv, &sq->addr,
-				&pend->pi->addr, comm_tcp, NULL, sq->zone,
+				&local_addr, comm_tcp, NULL, sq->zone,
 				sq->zonelen, &tmp);
 		}
 #endif
@@ -3179,10 +3198,13 @@ serviced_tcp_callback(struct comm_point* c, void* arg, int error,
 	if(error==NETEVENT_NOERROR && pi && sq->outnet->dtenv &&
 	   (sq->outnet->dtenv->log_resolver_response_messages ||
 	    sq->outnet->dtenv->log_forwarder_response_messages)) {
+		struct sockaddr_storage local_addr;
+		dt_get_local_addr(c->fd, &local_addr);
 		log_addr(VERB_ALGO, "response from upstream", &sq->addr, sq->addrlen);
-		log_addr(VERB_ALGO, "to local addr", &pi->addr, pi->addrlen);
+		log_addr(VERB_ALGO, "to local addr", &local_addr,
+			(socklen_t)sizeof(local_addr));
 		dt_msg_send_outside_response(sq->outnet->dtenv, &sq->addr,
-			&pi->addr, c->type, c->ssl, sq->zone, sq->zonelen, sq->qbuf,
+			&local_addr, c->type, c->ssl, sq->zone, sq->zonelen, sq->qbuf,
 			sq->qbuflen, &sq->last_sent_time, sq->outnet->now_tv,
 			c->buffer);
 	}
@@ -3392,11 +3414,13 @@ serviced_udp_callback(struct comm_point* c, void* arg, int error,
 	if(error == NETEVENT_NOERROR && outnet->dtenv && p->pc &&
 		(outnet->dtenv->log_resolver_response_messages ||
 		outnet->dtenv->log_forwarder_response_messages)) {
+		struct sockaddr_storage local_addr;
+		dt_get_local_addr(c->fd, &local_addr);
 		log_addr(VERB_ALGO, "response from upstream", &sq->addr, sq->addrlen);
-		log_addr(VERB_ALGO, "to local addr", &p->pc->pif->addr,
-			p->pc->pif->addrlen);
+		log_addr(VERB_ALGO, "to local addr", &local_addr,
+			(socklen_t)sizeof(local_addr));
 		dt_msg_send_outside_response(outnet->dtenv, &sq->addr,
-			&p->pc->pif->addr, c->type, c->ssl, sq->zone, sq->zonelen,
+			&local_addr, c->type, c->ssl, sq->zone, sq->zonelen,
 			sq->qbuf, sq->qbuflen, &sq->last_sent_time,
 			sq->outnet->now_tv, c->buffer);
 	}

--- a/services/outside_network.c
+++ b/services/outside_network.c
@@ -1703,8 +1703,8 @@ static int setup_if(struct port_if* pif, const char* addrstr,
 	if(!pif->avail_ports)
 		return 0;
 #endif
-	if(!ipstrtoaddr(addrstr, UNBOUND_DNS_PORT, &pif->addr, &pif->addrlen) &&
-	   !netblockstrtoaddr(addrstr, UNBOUND_DNS_PORT,
+	if(!ipstrtoaddr(addrstr, 0, &pif->addr, &pif->addrlen) &&
+	   !netblockstrtoaddr(addrstr, 0,
 			      &pif->addr, &pif->addrlen, &pif->pfxlen))
 		return 0;
 #ifdef INT_MAX
@@ -2094,10 +2094,12 @@ udp_sockport(struct sockaddr_storage* addr, socklen_t addrlen, int pfxlen,
 			(struct sockaddr*)&sa, addrlen, 1, inuse, &noproto,
 			0, 0, 0, NULL, 0, freebind, 0, dscp);
 	} else {
-		struct sockaddr_in* sa = (struct sockaddr_in*)addr;
-		sa->sin_port = (in_port_t)htons((uint16_t)port);
+		/* Bind from a copy so setting the per-query source port does
+		 * not mutate the shared interface template. */
+		struct sockaddr_in sa = *(struct sockaddr_in*)addr;
+		sa.sin_port = (in_port_t)htons((uint16_t)port);
 		fd = create_udp_sock(AF_INET, SOCK_DGRAM, 
-			(struct sockaddr*)addr, addrlen, 1, inuse, &noproto,
+			(struct sockaddr*)&sa, addrlen, 1, inuse, &noproto,
 			0, 0, 0, NULL, 0, 0, 0, dscp);
 	}
 	return fd;
@@ -3698,10 +3700,11 @@ fd_for_dest(struct outside_network* outnet, struct sockaddr_storage* to_addr,
 				(struct sockaddr*)&sa, addrlen, 1, &inuse, &noproto,
 				0, 0, 0, NULL, 0, freebind, 0, dscp);
 		} else {
-			struct sockaddr_in* sa = (struct sockaddr_in*)addr;
-			sa->sin_port = (in_port_t)htons((uint16_t)port);
+			/* Use the same local-copy pattern as udp_sockport(). */
+			struct sockaddr_in sa = *(struct sockaddr_in*)addr;
+			sa.sin_port = (in_port_t)htons((uint16_t)port);
 			fd = create_udp_sock(AF_INET, SOCK_DGRAM, 
-				(struct sockaddr*)addr, addrlen, 1, &inuse, &noproto,
+				(struct sockaddr*)&sa, addrlen, 1, &inuse, &noproto,
 				0, 0, 0, NULL, 0, freebind, 0, dscp);
 		}
 		if(fd != -1) {


### PR DESCRIPTION
This change makes `query_address` and `query_port` of the dnstap `RESOLVER_*` and `FORWARDER_*` messages reflect the actual local socket used to reach the upstream, instead of the outgoing interface template.

The local (source) endpoint for these "outside" messages currently comes from the per-interface bind template (`pif->addr` / `pi->addr`). When no `outgoing-interface` is configured, that template is the wildcard, so `query_address` is reported as `0.0.0.0` (or `::`) and `query_port` as `53`. I think this was a known limitation from the moment the feature was added.

From https://github.com/NLnetLabs/unbound/issues/365, the contributor who added this logging wrote:

> right now i can log only the front side, i.e. client requests and responses. Upstream side is currently logged as 0.0.0.0 local address. Its a question of some rework of outside_network code.

Captures below are trimmed to the relevant fields. 

Before the patch (RESOLVER, UDP, default config with no `outgoing-interface`):

```
  type: RESOLVER_QUERY
  socket_family: INET6
  query_address: ::
  response_address: 2001:dc3::35
  query_port: 53
---
  type: RESOLVER_QUERY
  socket_family: INET
  query_address: 0.0.0.0
  response_address: 193.0.14.129
  query_port: 55102
```

After the patch:

```
  type: RESOLVER_QUERY
  socket_family: INET6
  query_address: 2800:200:f5a0:cd6:542b:6c87:bfd:e6fb
  response_address: 2001:500:2d::d
  query_port: 26293
---
  type: RESOLVER_QUERY
  socket_family: INET
  query_address: 192.168.100.235
  response_address: 192.33.4.12
  query_port: 18909
```

The same applies to TCP and to the `FORWARDER_*` messages. Before the patch (FORWARDER, TCP), the query and the response both show the template values:

```
  type: FORWARDER_QUERY
  socket_family: INET
  socket_protocol: TCP
  query_address: 0.0.0.0
  response_address: 8.8.8.8
  query_port: 53
```

After the patch, `query_port` is now the real source port:

```
  type: FORWARDER_QUERY
  socket_family: INET
  socket_protocol: TCP
  query_address: 192.168.100.235
  response_address: 8.8.8.8
  query_port: 49477
```

What the change does:

- Reads the real local endpoint with `getsockname()` when the dnstap message is built (a small `dt_get_local_addr()` helper), and passes it to the `dt_msg_send_outside_query()` / `dt_msg_send_outside_response()` calls and the matching `log_addr()` debug lines. On a `getsockname()` failure the address is zeroed, so `dt_msg_fill_net()` omits `query_address` and `query_port` rather than reporting incorrect data.
- To make intent more explicit, stops storing an unnecessary default port in the per-interface template (`setup_if()` uses port `0` now), and binds IPv4 UDP sockets from a local copy, as the IPv6 path already does, so the shared template is no longer mutated per query.

Caveat about `udp-connect` and the source address:

`getsockname()` only reports what the socket has pinned locally. With `udp-connect: yes` (the default) Unbound connects the outgoing UDP socket, so the kernel pins a concrete source address, and `getsockname()` returns the real address and port, as the captures above show. With `udp-connect: no` the socket stays unconnected, so no source address is ever pinned onto it, and `getsockname()` returns the wildcard address with the correct port. So the only combination where `query_address` stays `0.0.0.0` / `::` is UDP with `udp-connect: no` and no `outgoing-interface` configured. TCP always connects and reports the real address and port. I think this is acceptable since it is not a regression: without `outgoing-interface` the address was already the wildcard before this change, and the port now becomes correct in that case as well.

Other notes, and where I would appreciate review:

- I'm not really familiar with the Unbound source code, configuration, or build flags, so something might be wrong in the proposed code.
- Testing is on macOS only.

Related issues and PRs:

- #365 is the origin of this logging and documents the `0.0.0.0` limitation quoted above.
- #367 ("DNSTAP log local address") imported and merged that contribution. From its description: "The code adds logging of the destination, or local, address to the dnstap logging."
