### PR TITLE
daemon: fix DEREF_AFTER_NULL.EX.COND on worker_init

### DIFF
--- a/daemon/worker.c
+++ b/daemon/worker.c
@@ -2383,6 +2383,8 @@ worker_init(struct worker* worker, struct config_file *cfg,
 		worker_stat_timer_cb, worker);
 	if(!worker->stat_timer) {
 		log_err("could not create statistics timer");
+		worker_delete(worker);
+		return 0;
 	}
 
 	/* we use the msg_buffer_size as a good estimate for what the


### PR DESCRIPTION
Found by the static analyzer Svace (ISP RAS).

After having been compared to a NULL value at worker.c:2216, pointer 'worker->stat_timer' is passed in call to function 'worker_restart_timer' at worker.c:2319,where it is dereferenced at worker.c:2029.

Fix that stat_timer creation failure in worker_init does not continue with a NULL timer that causes a crash later.