### PR TITLE
Normalize domain names in the configuration

### DIFF
--- a/util/configlexer.lex
+++ b/util/configlexer.lex
@@ -627,10 +627,13 @@ iter-scrub-promiscuous{COLON}	{ YDVAR(1, VAR_ITER_SCRUB_PROMISCUOUS) }
         LEXOUT(("QE "));
 	if(--num_args == 0) { BEGIN(INITIAL); }
 	else		    { BEGIN(val); }
-        yytext[yyleng - 1] = '\0';
-	yylval.str = strdup(yytext);
+	/* deliberately allocate one extra byte so there is room to add a
+	 * trailing dot if necessary */
+	yylval.str = malloc(yyleng + 1);
 	if(!yylval.str)
 		yyerror("out of memory");
+	memcpy(yylval.str, yytext, yyleng - 1);
+	yylval.str[yyleng - 1] = yylval.str[yyleng] = '\0';
         return STRING_ARG;
 }
 
@@ -648,10 +651,13 @@ iter-scrub-promiscuous{COLON}	{ YDVAR(1, VAR_ITER_SCRUB_PROMISCUOUS) }
         LEXOUT(("SQE "));
 	if(--num_args == 0) { BEGIN(INITIAL); }
 	else		    { BEGIN(val); }
-        yytext[yyleng - 1] = '\0';
-	yylval.str = strdup(yytext);
+	/* deliberately allocate one extra byte so there is room to add a
+	 * trailing dot if necessary */
+	yylval.str = malloc(yyleng + 1);
 	if(!yylval.str)
 		yyerror("out of memory");
+	memcpy(yylval.str, yytext, yyleng - 1);
+	yylval.str[yyleng - 1] = yylval.str[yyleng] = '\0';
         return STRING_ARG;
 }
 
@@ -730,9 +736,18 @@ iter-scrub-promiscuous{COLON}	{ YDVAR(1, VAR_ITER_SCRUB_PROMISCUOUS) }
 	return (VAR_FORCE_TOPLEVEL);
 }
 
-<val>{UNQUOTEDLETTER}*	{ LEXOUT(("unquotedstr(%s) ", yytext));
-			if(--num_args == 0) { BEGIN(INITIAL); }
-			yylval.str = strdup(yytext); return STRING_ARG; }
+<val>{UNQUOTEDLETTER}*	{
+	LEXOUT(("unquotedstr(%s) ", yytext));
+	if(--num_args == 0) { BEGIN(INITIAL); }
+	/* deliberately allocate one extra byte so there is room to add a
+	 * trailing dot if necessary */
+	yylval.str = malloc(yyleng + 2);
+	if(!yylval.str)
+		yyerror("out of memory");
+	memcpy(yylval.str, yytext, yyleng);
+	yylval.str[yyleng] = yylval.str[yyleng + 1] = '\0';
+	return STRING_ARG;
+}
 
 {UNQUOTEDLETTER_NOCOLON}*	{
 	ub_c_error_msg("unknown keyword '%s'", yytext);

--- a/util/configparser.y
+++ b/util/configparser.y
@@ -39,6 +39,7 @@
 #include "config.h"
 
 #include <stdarg.h>
+#include <stdbool.h>
 #include <stdio.h>
 #include <string.h>
 #include <stdlib.h>
@@ -52,11 +53,12 @@
 int ub_c_lex(void);
 void ub_c_error(const char *message);
 
-static void validate_respip_action(const char* action);
-static void validate_acl_action(const char* action);
+static void validate_respip_action(const char *action);
+static void validate_acl_action(const char *action);
+static void normalize_domain_name(char *name, bool abs);
 
 /* these need to be global, otherwise they cannot be used inside yacc */
-extern struct config_parser_state* cfg_parser;
+extern struct config_parser_state *cfg_parser;
 
 #if 0
 #define OUTYY(s)  printf s /* used ONLY when debugging */
@@ -66,7 +68,7 @@ extern struct config_parser_state* cfg_parser;
 
 %}
 %union {
-	char*	str;
+	char	*str;
 };
 
 %token SPACE LETTER NEWLINE COMMENT COLON ANY ZONESTR
@@ -373,7 +375,7 @@ stub_clause: stubstart contents_stub
 	;
 stubstart: VAR_STUB_ZONE
 	{
-		struct config_stub* s;
+		struct config_stub *s;
 		OUTYY(("\nP(stub_zone:)\n"));
 		cfg_parser->started_toplevel = 1;
 		s = (struct config_stub*)calloc(1, sizeof(struct config_stub));
@@ -400,7 +402,7 @@ forward_clause: forwardstart contents_forward
 	;
 forwardstart: VAR_FORWARD_ZONE
 	{
-		struct config_stub* s;
+		struct config_stub *s;
 		OUTYY(("\nP(forward_zone:)\n"));
 		cfg_parser->started_toplevel = 1;
 		s = (struct config_stub*)calloc(1, sizeof(struct config_stub));
@@ -427,7 +429,7 @@ view_clause: viewstart contents_view
 	;
 viewstart: VAR_VIEW
 	{
-		struct config_view* s;
+		struct config_view *s;
 		OUTYY(("\nP(view:)\n"));
 		cfg_parser->started_toplevel = 1;
 		s = (struct config_view*)calloc(1, sizeof(struct config_view));
@@ -446,7 +448,7 @@ content_view: view_name | view_local_zone | view_local_data | view_first |
 	;
 authstart: VAR_AUTH_ZONE
 	{
-		struct config_auth* s;
+		struct config_auth *s;
 		OUTYY(("\nP(auth_zone:)\n"));
 		cfg_parser->started_toplevel = 1;
 		s = (struct config_auth*)calloc(1, sizeof(struct config_auth));
@@ -548,7 +550,7 @@ rpz_signal_nxdomain_ra: VAR_RPZ_SIGNAL_NXDOMAIN_RA STRING_ARG
 
 rpzstart: VAR_RPZ
 	{
-		struct config_auth* s;
+		struct config_auth *s;
 		OUTYY(("\nP(rpz:)\n"));
 		cfg_parser->started_toplevel = 1;
 		s = (struct config_auth*)calloc(1, sizeof(struct config_auth));
@@ -1507,6 +1509,7 @@ server_root_key_sentinel: VAR_ROOT_KEY_SENTINEL STRING_ARG
 	;
 server_domain_insecure: VAR_DOMAIN_INSECURE STRING_ARG
 	{
+		normalize_domain_name($2, true);
 		OUTYY(("P(server_domain_insecure:%s)\n", $2));
 		if(!cfg_strlist_insert(&cfg_parser->cfg->domain_insecure, $2))
 			yyerror("out of memory");
@@ -1973,6 +1976,7 @@ server_private_address: VAR_PRIVATE_ADDRESS STRING_ARG
 	;
 server_private_domain: VAR_PRIVATE_DOMAIN STRING_ARG
 	{
+		normalize_domain_name($2, true);
 		OUTYY(("P(server_private_domain:%s)\n", $2));
 		if(!cfg_strlist_insert(&cfg_parser->cfg->private_domain, $2))
 			yyerror("out of memory");
@@ -2388,6 +2392,7 @@ server_neg_cache_size: VAR_NEG_CACHE_SIZE STRING_ARG
 	;
 server_local_zone: VAR_LOCAL_ZONE STRING_ARG STRING_ARG
 	{
+		normalize_domain_name($2, true);
 		OUTYY(("P(server_local_zone:%s %s)\n", $2, $3));
 		if(strcmp($3, "static")!=0 && strcmp($3, "deny")!=0 &&
 		   strcmp($3, "refuse")!=0 && strcmp($3, "redirect")!=0 &&
@@ -2420,19 +2425,6 @@ server_local_zone: VAR_LOCAL_ZONE STRING_ARG STRING_ARG
 			free($3);
 #ifdef USE_IPSET
 		} else if(strcmp($3, "ipset")==0) {
-			size_t len = strlen($2);
-			/* Make sure to add the trailing dot.
-			 * These are str compared to domain names. */
-			if($2[len-1] != '.') {
-				char* prev = $2;
-				if(!($2 = realloc($2, len+2))) {
-					yyerror("out of memory");
-					free(prev);
-				} else {
-					$2[len] = '.';
-					$2[len+1] = 0;
-				}
-			}
 			if(!cfg_strlist_insert(&cfg_parser->cfg->
 				local_zones_ipset, $2))
 				yyerror("out of memory");
@@ -3125,6 +3117,7 @@ server_proxy_protocol_port: VAR_PROXY_PROTOCOL_PORT STRING_ARG
 	;
 stub_name: VAR_NAME STRING_ARG
 	{
+		normalize_domain_name($2, true);
 		OUTYY(("P(name:%s)\n", $2));
 		if(cfg_parser->cfg->stubs->name)
 			yyerror("stub name override, there must be one name "
@@ -3197,6 +3190,7 @@ stub_prime: VAR_STUB_PRIME STRING_ARG
 	;
 forward_name: VAR_NAME STRING_ARG
 	{
+		normalize_domain_name($2, true);
 		OUTYY(("P(name:%s)\n", $2));
 		if(cfg_parser->cfg->forwards->name)
 			yyerror("forward name override, there must be one "
@@ -3259,6 +3253,7 @@ forward_tcp_upstream: VAR_FORWARD_TCP_UPSTREAM STRING_ARG
         ;
 auth_name: VAR_NAME STRING_ARG
 	{
+		normalize_domain_name($2, true);
 		OUTYY(("P(name:%s)\n", $2));
 		if(cfg_parser->cfg->auths->name)
 			yyerror("auth name override, there must be one name "
@@ -3375,6 +3370,7 @@ view_name: VAR_NAME STRING_ARG
 	;
 view_local_zone: VAR_LOCAL_ZONE STRING_ARG STRING_ARG
 	{
+		normalize_domain_name($2, true);
 		OUTYY(("P(view_local_zone:%s %s)\n", $2, $3));
 		if(strcmp($3, "static")!=0 && strcmp($3, "deny")!=0 &&
 		   strcmp($3, "refuse")!=0 && strcmp($3, "redirect")!=0 &&
@@ -3406,19 +3402,6 @@ view_local_zone: VAR_LOCAL_ZONE STRING_ARG STRING_ARG
 			free($3);
 #ifdef USE_IPSET
 		} else if(strcmp($3, "ipset")==0) {
-			size_t len = strlen($2);
-			/* Make sure to add the trailing dot.
-			 * These are str compared to domain names. */
-			if($2[len-1] != '.') {
-				char* prev = $2;
-				if(!($2 = realloc($2, len+2))) {
-					yyerror("out of memory");
-					free(prev);
-				} else {
-					$2[len] = '.';
-					$2[len+1] = 0;
-				}
-			}
 			if(!cfg_strlist_insert(&cfg_parser->cfg->views->
 				local_zones_ipset, $2))
 				yyerror("out of memory");
@@ -4356,7 +4339,7 @@ ipset_name_v6: VAR_IPSET_NAME_V6 STRING_ARG
 
 /* parse helper routines could be here */
 static void
-validate_respip_action(const char* action)
+validate_respip_action(const char *action)
 {
 	if(strcmp(action, "deny")!=0 &&
 		strcmp(action, "redirect")!=0 &&
@@ -4373,7 +4356,7 @@ validate_respip_action(const char* action)
 }
 
 static void
-validate_acl_action(const char* action)
+validate_acl_action(const char *action)
 {
 	if(strcmp(action, "deny")!=0 &&
 		strcmp(action, "refuse")!=0 &&
@@ -4388,4 +4371,34 @@ validate_acl_action(const char* action)
 			"refuse_non_local, allow, allow_setrd, "
 			"allow_snoop or allow_cookie as access control action");
 	}
+}
+
+static void
+normalize_domain_name(char *name, bool abs)
+{
+	char *src, *dst;
+
+	/* skip leading dot(s) */
+	for (src = dst = name; *src == '.'; src++)
+		/* nothing */;
+	/* copy to the end */
+	while (*src != '\0') {
+		if ((*dst++ = *src++) == '.') {
+			/* deduplicate dots */
+			while (*src == '.')
+				src++;
+		}
+	}
+	/* If the caller did not ask for an absolute name, strip any
+	 * trailing dot(s). */
+	while (!abs && dst > name && dst[-1] == '.')
+		dst--;
+	/* If the result is empty, or the caller asked for an absolute
+	 * name and there is no trailing dot, add a dot.  The lexer always
+	 * allocates one extra byte, so there is room to add a dot even if
+	 * we didn't skip anything while copying. */
+	if (dst == name || (abs && dst[-1] != '.'))
+		*dst++ = '.';
+	/* terminate the result */
+	*dst = '\0';
 }

--- a/util/configparser.y
+++ b/util/configparser.y
@@ -39,6 +39,7 @@
 #include "config.h"
 
 #include <stdarg.h>
+#include <stdbool.h>
 #include <stdio.h>
 #include <string.h>
 #include <stdlib.h>
@@ -52,11 +53,12 @@
 int ub_c_lex(void);
 void ub_c_error(const char *message);
 
-static void validate_respip_action(const char* action);
-static void validate_acl_action(const char* action);
+static void validate_respip_action(const char *action);
+static void validate_acl_action(const char *action);
+static void normalize_domain_name(char *name, bool abs);
 
 /* these need to be global, otherwise they cannot be used inside yacc */
-extern struct config_parser_state* cfg_parser;
+extern struct config_parser_state *cfg_parser;
 
 #if 0
 #define OUTYY(s)  printf s /* used ONLY when debugging */
@@ -66,7 +68,7 @@ extern struct config_parser_state* cfg_parser;
 
 %}
 %union {
-	char*	str;
+	char	*str;
 };
 
 %token SPACE LETTER NEWLINE COMMENT COLON ANY ZONESTR
@@ -373,7 +375,7 @@ stub_clause: stubstart contents_stub
 	;
 stubstart: VAR_STUB_ZONE
 	{
-		struct config_stub* s;
+		struct config_stub *s;
 		OUTYY(("\nP(stub_zone:)\n"));
 		cfg_parser->started_toplevel = 1;
 		s = (struct config_stub*)calloc(1, sizeof(struct config_stub));
@@ -400,7 +402,7 @@ forward_clause: forwardstart contents_forward
 	;
 forwardstart: VAR_FORWARD_ZONE
 	{
-		struct config_stub* s;
+		struct config_stub *s;
 		OUTYY(("\nP(forward_zone:)\n"));
 		cfg_parser->started_toplevel = 1;
 		s = (struct config_stub*)calloc(1, sizeof(struct config_stub));
@@ -427,7 +429,7 @@ view_clause: viewstart contents_view
 	;
 viewstart: VAR_VIEW
 	{
-		struct config_view* s;
+		struct config_view *s;
 		OUTYY(("\nP(view:)\n"));
 		cfg_parser->started_toplevel = 1;
 		s = (struct config_view*)calloc(1, sizeof(struct config_view));
@@ -446,7 +448,7 @@ content_view: view_name | view_local_zone | view_local_data | view_first |
 	;
 authstart: VAR_AUTH_ZONE
 	{
-		struct config_auth* s;
+		struct config_auth *s;
 		OUTYY(("\nP(auth_zone:)\n"));
 		cfg_parser->started_toplevel = 1;
 		s = (struct config_auth*)calloc(1, sizeof(struct config_auth));
@@ -548,7 +550,7 @@ rpz_signal_nxdomain_ra: VAR_RPZ_SIGNAL_NXDOMAIN_RA STRING_ARG
 
 rpzstart: VAR_RPZ
 	{
-		struct config_auth* s;
+		struct config_auth *s;
 		OUTYY(("\nP(rpz:)\n"));
 		cfg_parser->started_toplevel = 1;
 		s = (struct config_auth*)calloc(1, sizeof(struct config_auth));
@@ -1507,6 +1509,7 @@ server_root_key_sentinel: VAR_ROOT_KEY_SENTINEL STRING_ARG
 	;
 server_domain_insecure: VAR_DOMAIN_INSECURE STRING_ARG
 	{
+		normalize_domain_name($2, true);
 		OUTYY(("P(server_domain_insecure:%s)\n", $2));
 		if(!cfg_strlist_insert(&cfg_parser->cfg->domain_insecure, $2))
 			yyerror("out of memory");
@@ -1973,6 +1976,7 @@ server_private_address: VAR_PRIVATE_ADDRESS STRING_ARG
 	;
 server_private_domain: VAR_PRIVATE_DOMAIN STRING_ARG
 	{
+		normalize_domain_name($2, true);
 		OUTYY(("P(server_private_domain:%s)\n", $2));
 		if(!cfg_strlist_insert(&cfg_parser->cfg->private_domain, $2))
 			yyerror("out of memory");
@@ -2388,6 +2392,7 @@ server_neg_cache_size: VAR_NEG_CACHE_SIZE STRING_ARG
 	;
 server_local_zone: VAR_LOCAL_ZONE STRING_ARG STRING_ARG
 	{
+		normalize_domain_name($2, true);
 		OUTYY(("P(server_local_zone:%s %s)\n", $2, $3));
 		if(strcmp($3, "static")!=0 && strcmp($3, "deny")!=0 &&
 		   strcmp($3, "refuse")!=0 && strcmp($3, "redirect")!=0 &&
@@ -2425,19 +2430,6 @@ server_local_zone: VAR_LOCAL_ZONE STRING_ARG STRING_ARG
 			free($3);
 #ifdef USE_IPSET
 		} else if(strcmp($3, "ipset")==0) {
-			size_t len = strlen($2);
-			/* Make sure to add the trailing dot.
-			 * These are str compared to domain names. */
-			if($2[len-1] != '.') {
-				char* prev = $2;
-				if(!($2 = realloc($2, len+2))) {
-					yyerror("out of memory");
-					free(prev);
-				} else {
-					$2[len] = '.';
-					$2[len+1] = 0;
-				}
-			}
 			if(!cfg_strlist_insert(&cfg_parser->cfg->
 				local_zones_ipset, $2))
 				yyerror("out of memory");
@@ -3130,6 +3122,7 @@ server_proxy_protocol_port: VAR_PROXY_PROTOCOL_PORT STRING_ARG
 	;
 stub_name: VAR_NAME STRING_ARG
 	{
+		normalize_domain_name($2, true);
 		OUTYY(("P(name:%s)\n", $2));
 		if(cfg_parser->cfg->stubs->name)
 			yyerror("stub name override, there must be one name "
@@ -3202,6 +3195,7 @@ stub_prime: VAR_STUB_PRIME STRING_ARG
 	;
 forward_name: VAR_NAME STRING_ARG
 	{
+		normalize_domain_name($2, true);
 		OUTYY(("P(name:%s)\n", $2));
 		if(cfg_parser->cfg->forwards->name)
 			yyerror("forward name override, there must be one "
@@ -3264,6 +3258,7 @@ forward_tcp_upstream: VAR_FORWARD_TCP_UPSTREAM STRING_ARG
         ;
 auth_name: VAR_NAME STRING_ARG
 	{
+		normalize_domain_name($2, true);
 		OUTYY(("P(name:%s)\n", $2));
 		if(cfg_parser->cfg->auths->name)
 			yyerror("auth name override, there must be one name "
@@ -3380,6 +3375,7 @@ view_name: VAR_NAME STRING_ARG
 	;
 view_local_zone: VAR_LOCAL_ZONE STRING_ARG STRING_ARG
 	{
+		normalize_domain_name($2, true);
 		OUTYY(("P(view_local_zone:%s %s)\n", $2, $3));
 		if(strcmp($3, "static")!=0 && strcmp($3, "deny")!=0 &&
 		   strcmp($3, "refuse")!=0 && strcmp($3, "redirect")!=0 &&
@@ -3411,19 +3407,6 @@ view_local_zone: VAR_LOCAL_ZONE STRING_ARG STRING_ARG
 			free($3);
 #ifdef USE_IPSET
 		} else if(strcmp($3, "ipset")==0) {
-			size_t len = strlen($2);
-			/* Make sure to add the trailing dot.
-			 * These are str compared to domain names. */
-			if($2[len-1] != '.') {
-				char* prev = $2;
-				if(!($2 = realloc($2, len+2))) {
-					yyerror("out of memory");
-					free(prev);
-				} else {
-					$2[len] = '.';
-					$2[len+1] = 0;
-				}
-			}
 			if(!cfg_strlist_insert(&cfg_parser->cfg->views->
 				local_zones_ipset, $2))
 				yyerror("out of memory");
@@ -4361,7 +4344,7 @@ ipset_name_v6: VAR_IPSET_NAME_V6 STRING_ARG
 
 /* parse helper routines could be here */
 static void
-validate_respip_action(const char* action)
+validate_respip_action(const char *action)
 {
 	if(strcmp(action, "deny")!=0 &&
 		strcmp(action, "redirect")!=0 &&
@@ -4378,7 +4361,7 @@ validate_respip_action(const char* action)
 }
 
 static void
-validate_acl_action(const char* action)
+validate_acl_action(const char *action)
 {
 	if(strcmp(action, "deny")!=0 &&
 		strcmp(action, "refuse")!=0 &&
@@ -4393,4 +4376,34 @@ validate_acl_action(const char* action)
 			"refuse_non_local, allow, allow_setrd, "
 			"allow_snoop or allow_cookie as access control action");
 	}
+}
+
+static void
+normalize_domain_name(char *name, bool abs)
+{
+	char *src, *dst;
+
+	/* skip leading dot(s) */
+	for (src = dst = name; *src == '.'; src++)
+		/* nothing */;
+	/* copy to the end */
+	while (*src != '\0') {
+		if ((*dst++ = *src++) == '.') {
+			/* deduplicate dots */
+			while (*src == '.')
+				src++;
+		}
+	}
+	/* If the caller did not ask for an absolute name, strip any
+	 * trailing dot(s). */
+	while (!abs && dst > name && dst[-1] == '.')
+		dst--;
+	/* If the result is empty, or the caller asked for an absolute
+	 * name and there is no trailing dot, add a dot.  The lexer always
+	 * allocates one extra byte, so there is room to add a dot even if
+	 * we didn't skip anything while copying. */
+	if (dst == name || (abs && dst[-1] != '.'))
+		*dst++ = '.';
+	/* terminate the result */
+	*dst = '\0';
 }


### PR DESCRIPTION
* In the lexer, when returning a string argument, always allocate one more byte than we need.

* In the parser, whenever we expect a host name, pass it to a function that copies the string in place, removing leading dots, deduplicating intermediate dots, and optionally appending a dot at the end if the caller requested an absolute name.  If the original string was empty or consisted entirely of dots, the result is always a single dot.

This means that common mistakes such as forgetting the final dot in the name of a local zone or including a leading dot in the name of a stub or forwarding zone no longer result in Unbound refusing to start or misbehaving.

This was motivated by seeing Unbound fail to start due to an invalid forwarding zone generated by openresolv from data provided by a misconfigured DHCP server.