### PR TITLE
ipsecmod: fix deref on null in ipsecmod-whitelist after OOM

### DIFF
--- a/ipsecmod/ipsecmod-whitelist.c
+++ b/ipsecmod/ipsecmod-whitelist.c
@@ -100,6 +100,8 @@ ipsecmod_whitelist_apply_cfg(struct ipsecmod_env* ie,
 	struct config_file* cfg)
 {
 	ie->whitelist = rbtree_create(name_tree_compare);
+	if (!ie->whitelist)
+		return 0;
 	if(!read_whitelist(ie->whitelist, cfg))
 		return 0;
 	name_tree_init_parents(ie->whitelist);


### PR DESCRIPTION
DEREF_OF_NULL.RET.STAT Return value of a function 'rbtree_create' is dereferenced at ipsecmod-whitelist.c:105 without checking for NULL, but it is usually checked for this function (5/6).

In ipsecmod_whitelist_apply_cfg(), the return value of rbtree_create() is not checked for NULL before being used.

Found by the static analyzer Svace (ISP	RAS).