### PR TITLE
pythonmod: add check return value after ftell()

### DIFF
--- a/pythonmod/pythonmod.c
+++ b/pythonmod/pythonmod.c
@@ -487,10 +487,17 @@ int pythonmod_init(struct module_env* env, int id)
       /* for python 3.9 and newer */
       char* fstr = NULL;
       size_t flen = 0;
+      long pos = 0;
       log_err("pythonmod: can't parse Python script %s", pe->fname);
       /* print the error to logs too, run it again */
       fseek(script_py, 0, SEEK_END);
-      flen = (size_t)ftell(script_py);
+      pos = ftell(script_py);
+      if (pos == -1L) {
+         log_err("ftell failed to print parse error: %s: %s",
+            pe->fname, strerror(errno));
+         goto fail_close_file;
+      }
+      flen = (size_t)pos;
 #ifdef SIZE_MAX
       if(flen > SIZE_MAX-2) {
 		log_err("script file too large");


### PR DESCRIPTION
Hello again!

Svace reported a missing check of negative return of ftell(). Next, `flen` is passed to fread().

Similar checks already exist elsewhere in this module, so I added one here for consistency. Nothing critical happens without it, this is a cleanup fix rather than a bug fix.

Found by the static analyzer Svace (ISP RAS):

Variable 'flen', which might receive a negative value at pythonmod.c:493 by calling function 'ftell', is used without checking at pythonmod.c:508 by calling function 'fread'.