### PR TITLE
Fix pthread detection on Solaris 11.4

### DIFF
--- a/ax_pthread.m4
+++ b/ax_pthread.m4
@@ -87,7 +87,7 @@
 #   modified version of the Autoconf Macro, you may extend this special
 #   exception to the GPL to apply to your modified version as well.
 
-#serial 31
+#serial 32
 
 AU_ALIAS([ACX_PTHREAD], [AX_PTHREAD])
 AC_DEFUN([AX_PTHREAD], [
@@ -249,7 +249,22 @@ AS_IF([test "x$ax_pthread_clang" = "xyes"],
 # correctly enabled
 
 case $host_os in
-        darwin* | hpux* | linux* | osf* | solaris*)
+        solaris*)
+        # Solaris 11.4 introduced XPG7 support and did away with the need for
+        # _REENTRANT.
+
+        AC_EGREP_CPP([AX_PTHREAD_SOLARIS__REENTRANT],
+            [
+#            undef _XOPEN_SOURCE
+#            include <sys/feature_tests.h>
+#            if _XOPEN_VERSION < 700
+             AX_PTHREAD_SOLARIS__REENTRANT
+#            endif
+            ],
+            [ax_pthread_check_macro="_REENTRANT"],
+            [ax_pthread_check_macro="--"])
+        ;;
+        darwin* | hpux* | linux* | osf*)
         ax_pthread_check_macro="_REENTRANT"
         ;;
 

--- a/configure
+++ b/configure
@@ -18415,7 +18415,31 @@ fi
 # correctly enabled
 
 case $host_os in
-        darwin* | hpux* | linux* | osf* | solaris*)
+        solaris*)
+        # Solaris 11.4 introduced XPG7 support and did away with the need for
+        # _REENTRANT.
+
+        cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+/* end confdefs.h.  */
+
+#            undef _XOPEN_SOURCE
+#            include <sys/feature_tests.h>
+#            if _XOPEN_VERSION < 700
+             AX_PTHREAD_SOLARIS__REENTRANT
+#            endif
+
+_ACEOF
+if (eval "$ac_cpp conftest.$ac_ext") 2>&5 |
+  $EGREP "AX_PTHREAD_SOLARIS__REENTRANT" >/dev/null 2>&1
+then :
+  ax_pthread_check_macro="_REENTRANT"
+else $as_nop
+  ax_pthread_check_macro="--"
+fi
+rm -rf conftest*
+
+        ;;
+        darwin* | hpux* | linux* | osf*)
         ax_pthread_check_macro="_REENTRANT"
         ;;
 


### PR DESCRIPTION
GCC 16 no longer defines _REENTRANT for -pthread on Solaris because pthreads have been provided by libc since Solaris 10 and Solaris 11.4 headers no longer use the macro.

Do not require _REENTRANT on Solaris. The existing link test checks the pthread API directly and continues to select the same flags with older GCC versions.

Regenerate configure with Autoconf 2.71.

Tested on Solaris 11.4 with GCC 15.2 and GCC 16.1.