### PR TITLE
authzone: fix memory leak in xfer_set_masters() error path

### DIFF
--- a/services/authzone.c
+++ b/services/authzone.c
@@ -7575,35 +7575,48 @@ xfer_set_masters(struct auth_master** list, struct config_auth* c,
 {
 	struct auth_master* m;
 	struct config_strlist* p;
+	struct auth_master** tail;
 	/* list points to the first, or next pointer for the new element */
 	while(*list) {
 		list = &( (*list)->next );
 	}
 	if(with_http)
 	  for(p = c->urls; p; p = p->next) {
+		tail = list;
 		m = auth_master_new(&list);
 		if(!m) return 0;
 		m->http = 1;
-		if(!parse_url(p->str, &m->host, &m->file, &m->port, &m->ssl))
+		if(!parse_url(p->str, &m->host, &m->file, &m->port, &m->ssl)) {
+			free(m->host);
+			free(m->file);
+			free(m);
+			*tail = NULL;
 			return 0;
+		}
 	}
 	for(p = c->masters; p; p = p->next) {
+		tail = list;
 		m = auth_master_new(&list);
 		if(!m) return 0;
 		m->ixfr = 1; /* this flag is not configurable */
 		m->host = strdup(p->str);
 		if(!m->host) {
 			log_err("malloc failure");
+			free(m);
+			*tail = NULL;
 			return 0;
 		}
 	}
 	for(p = c->allow_notify; p; p = p->next) {
+		tail = list;
 		m = auth_master_new(&list);
 		if(!m) return 0;
 		m->allow_notify = 1;
 		m->host = strdup(p->str);
 		if(!m->host) {
 			log_err("malloc failure");
+			free(m);
+			*tail = NULL;
 			return 0;
 		}
 	}


### PR DESCRIPTION
Hello!

I fixed possible memory leak on `xfer_set_masters()`.

Added memory deallocation for the `file` and `host` fields of the `auth_master` node in the event of a URL/allocation error, and unlinked the partially created node from the masters list by resetting the link that pointed to it.

I didn't remove `free(m->file);` from the code, even though it is redundant - since it would be null anyway in the event of a URL parsing error - because I decided to keep the line in case the `parse_url()` function changes. `free(NULL)` is safe, and the compiler will likely strip out the unnecessary code during the build process.

Found by the static analyzer Svace (ISP RAS):

MEMORY_LEAK.EX Dynamic memory, referenced by 'm', is allocated at authzone.c:7282 by calling function 'auth_master_new' and lost at authzone.c:7288.