### PR TITLE
Fix bounds check in packed_rr_to_string

### DIFF
--- a/doc/Changelog
+++ b/doc/Changelog
@@ -1,3 +1,11 @@
+6 August 2026: Alex Khanin
+	- Fix bounds check in packed_rr_to_string, it checked the
+	  assembled rr length against the output string length
+	  dest_len, instead of against the size of the rr buffer it
+	  writes into. Callers in cachedump.c and remote.c pass a
+	  dest_len larger than that buffer.
+	- Unit test for packed_rr_to_string.
+
 6 August 2026: Wouter
 	- Fix #1485: the list_forwards command omits port numbers.
 	  The list_forwards and list_stubs commands for

--- a/testcode/unitmain.c
+++ b/testcode/unitmain.c
@@ -1337,6 +1337,89 @@ static void mesh_test(void)
 	free(c1);
 }
 
+#include "util/data/packed_rrset.h"
+#include "sldns/sbuffer.h"
+/** packed_rrset unit tests */
+static void packed_rrset_test(void)
+{
+	/* packed_rr_to_string assembles the dname, type, class, ttl and
+	 * rdata of one rr into a buffer of 65535 bytes.  Check that it
+	 * refuses an rr that does not fit in there, also when the caller
+	 * passes a dest_len that is larger than that, like the callers in
+	 * daemon/cachedump.c and daemon/remote.c do.  Without the check it
+	 * writes past the end of the assembly buffer. */
+	uint8_t smalldname[] = "\003www\007example\003com";
+	uint8_t smallrdata[] = {0, 4, 1, 2, 3, 4};
+	uint8_t maxdname[LDNS_MAX_DOMAINLEN];
+	struct ub_packed_rrset_key rrk;
+	struct packed_rrset_data d;
+	uint8_t* rr_data[1];
+	size_t rr_len[1];
+	time_t rr_ttl[1];
+	size_t dest_len = 65535*4+2048; /* the size daemon/cachedump.c uses */
+	char* dest = (char*)malloc(dest_len);
+	int i;
+
+	unit_show_func("util/data/packed_rrset.c", "packed_rr_to_string");
+	if(!dest) fatal_exit("out of memory");
+	memset(&rrk, 0, sizeof(rrk));
+	memset(&d, 0, sizeof(d));
+	rrk.entry.data = &d;
+	rrk.rk.rrset_class = htons(LDNS_RR_CLASS_IN);
+	d.count = 1;
+	d.rr_len = rr_len;
+	d.rr_ttl = rr_ttl;
+	d.rr_data = rr_data;
+	rr_ttl[0] = 3600;
+
+	/* an ordinary rr is printed, also with the large dest_len */
+	rrk.rk.dname = smalldname;
+	rrk.rk.dname_len = sizeof(smalldname);
+	rrk.rk.type = htons(LDNS_RR_TYPE_A);
+	rr_data[0] = smallrdata;
+	rr_len[0] = sizeof(smallrdata);
+	unit_assert(packed_rr_to_string(&rrk, 0, 0, dest, dest_len) == 1);
+	unit_assert(strstr(dest, "1.2.3.4") != NULL);
+
+	/* a dname of the maximum length, 127 labels of one character */
+	for(i=0; i<127; i++) {
+		maxdname[i*2] = 1;
+		maxdname[i*2+1] = (uint8_t)'a';
+	}
+	maxdname[254] = 0;
+	rrk.rk.dname = maxdname;
+	rrk.rk.dname_len = sizeof(maxdname);
+	rrk.rk.type = htons(LDNS_RR_TYPE_TXT);
+
+	/* 255+2+2+4+65272 is exactly 65535, that still fits */
+	rr_len[0] = 65535 - 255 - 8;
+	rr_data[0] = (uint8_t*)calloc(1, rr_len[0]);
+	if(!rr_data[0]) fatal_exit("out of memory");
+	sldns_write_uint16(rr_data[0], (uint16_t)(rr_len[0]-2));
+	unit_assert(packed_rr_to_string(&rrk, 0, 0, dest, dest_len) == 1);
+	free(rr_data[0]);
+
+	/* one more byte of rdata does not fit and must be refused */
+	rr_len[0] = 65535 - 255 - 8 + 1;
+	rr_data[0] = (uint8_t*)calloc(1, rr_len[0]);
+	if(!rr_data[0]) fatal_exit("out of memory");
+	sldns_write_uint16(rr_data[0], (uint16_t)(rr_len[0]-2));
+	unit_assert(packed_rr_to_string(&rrk, 0, 0, dest, dest_len) == 0);
+	unit_assert(dest[0] == 0);
+	free(rr_data[0]);
+
+	/* the largest rdata an rr can hold, well over the buffer */
+	rr_len[0] = 2 + 65535;
+	rr_data[0] = (uint8_t*)calloc(1, rr_len[0]);
+	if(!rr_data[0]) fatal_exit("out of memory");
+	sldns_write_uint16(rr_data[0], 65535);
+	unit_assert(packed_rr_to_string(&rrk, 0, 0, dest, dest_len) == 0);
+	unit_assert(dest[0] == 0);
+	free(rr_data[0]);
+
+	free(dest);
+}
+
 void unit_show_func(const char* file, const char* func)
 {
 	printf("test %s:%s\n", file, func);
@@ -1409,6 +1492,7 @@ main(int argc, char* argv[])
 	zonemd_test();
 	tcpreuse_test();
 	msgparse_test();
+	packed_rrset_test();
 	edns_ede_answer_encode_test();
 	localzone_test();
 	mesh_test();

--- a/util/data/packed_rrset.c
+++ b/util/data/packed_rrset.c
@@ -280,7 +280,9 @@ int packed_rr_to_string(struct ub_packed_rrset_key* rrset, size_t i,
 	size_t rlen = rrset->rk.dname_len + 2 + 2 + 4 + d->rr_len[i];
 	time_t adjust = 0;
 	log_assert(dest_len > 0 && dest);
-	if(rlen > dest_len) {
+	/* rlen is the length written into rr, dest_len bounds the output
+	 * string; check both, callers can pass a dest_len over sizeof(rr). */
+	if(rlen > dest_len || rlen > sizeof(rr)) {
 		dest[0] = 0;
 		return 0;
 	}


### PR DESCRIPTION
`packed_rr_to_string()` assembles one RR (dname, type, class, ttl, rdata) into a
fixed 65535 byte stack buffer, but the guard checks the assembled length against
`dest_len` — the size of the caller's *output string* buffer, a different object:

```c
uint8_t rr[65535];
size_t rlen = rrset->rk.dname_len + 2 + 2 + 4 + d->rr_len[i];
if(rlen > dest_len) { ... }          /* guards the wrong buffer */
memmove(rr, rrset->rk.dname, rrset->rk.dname_len);
...
memmove(rr+rrset->rk.dname_len+8, d->rr_data[i], d->rr_len[i]);
```

Nothing checks `rlen` against `sizeof(rr)`. Two of the six callers pass a
`dest_len` larger than that buffer, so for them the guard cannot protect `rr`:

| Caller | `dest_len` |
| --- | --- |
| `daemon/cachedump.c:102` | `char s[65535*4+2048]` = 264188 |
| `daemon/remote.c:3582` | `sldns_buffer_capacity(scratch_buffer)` = `msg-buffer-size`, default 65552 |

The other four use `char s[65535]`, where the existing check happens to be correct.

### Reachability

I could not construct a way to trigger this, and I would rather present it as
hardening than as a security issue. `rlen = dname_len + 10 + rdatalen`, and every
data source independently caps that at 65535:

- **Wire-parsed RRsets** (the cache): the RR and its owner name must fit in one
  DNS message. Reconstructing a decompressed owner name costs at least
  `dname_len + 4` in the question section even when the answer compresses it to a
  2 byte pointer, so `rlen <= msgsize - 18`, and DNS/TCP framing caps `msgsize` at
  65535.
- **Zone file, `local-data` and auth-zone RRs**, where rdata is not bounded by
  message framing: these are parsed into `uint8_t rr[LDNS_RR_BUF_SIZE]` (65535)
  buffers that hold dname+type+class+ttl+rdlen+rdata, so `rlen <= 65535` again.

Both affected callers are also behind unbound-control authentication
(`dump_cache`, `list_local_data`).

So this is latent rather than live. The margin is 12-18 bytes and it comes from
invariants in other files rather than from the check itself, which seemed worth
closing. Note `msg-buffer-size` is operator configurable, which widens the window
at `remote.c:3592`.

### The change

```c
if(rlen > dest_len || rlen > sizeof(rr)) {
```

Behaviour is unchanged for the four callers passing `dest_len == 65535`; for the
two oversized ones an over-large RR now returns 0 / `"BADRR"` instead of writing
past `rr`.

### Test

Added `packed_rrset_test()` to `testcode/unitmain.c`. It hand-builds the
`packed_rrset_data` (no wire or zone file input path can produce these sizes) and
calls with `dest_len = 65535*4+2048`, matching `cachedump.c`:

| Case | `rlen` | Expected |
| --- | --- | --- |
| ordinary A record | 31 | returns 1, prints `1.2.3.4` |
| 255 byte dname + 65272 rdata, exactly fills `rr` | 65535 | returns 1 |
| one byte more | 65536 | returns 0 |
| max rdata (65535) | 65798 | returns 0 |

The first two guard against breaking normal operation and against a future `>=`
slip rejecting legitimate maximum size RRs; the last two are the regression.

Verified the test is not vacuous: with the guard reverted, `./unittest` aborts
(SIGABRT, stack protector) immediately after printing
`test util/data/packed_rrset.c:packed_rr_to_string`. With the fix, `make test`
passes — 1132997 unit test checks and all 484 `.rpl` scenarios.
