### PR TITLE
DNS64 client/interface tag support

### DIFF
--- a/daemon/remote.c
+++ b/daemon/remote.c
@@ -5488,6 +5488,7 @@ config_file_getmem(struct config_file* cfg)
 	m += getmem_config_strlist(cfg->dynlib_file);
 	m += getmem_str(cfg->dns64_prefix);
 	m += getmem_config_strlist(cfg->dns64_ignore_aaaa);
+	m += (cfg->dns64_taglist ? cfg->dns64_taglistlen : 0);
 	m += getmem_str(cfg->nat64_prefix);
 	m += getmem_str(cfg->dnstap_socket_path);
 	m += getmem_str(cfg->dnstap_ip);
@@ -6510,6 +6511,9 @@ fr_atomic_copy_cfg(struct config_file* oldcfg, struct config_file* cfg,
 	COPY_VAR_ptr(dns64_prefix);
 	COPY_VAR_int(dns64_synthall);
 	COPY_VAR_ptr(dns64_ignore_aaaa);
+	/* Not copied because it references tagname.
+	 dns64_taglist, dns64_taglistlen
+	*/
 	COPY_VAR_ptr(nat64_prefix);
 	COPY_VAR_int(dnstap);
 	COPY_VAR_int(dnstap_bidirectional);

--- a/daemon/worker.c
+++ b/daemon/worker.c
@@ -1956,7 +1956,8 @@ worker_handle_request(struct comm_point* c, void* arg, int error,
 	/* If we may apply IP-based actions to the answer, build the client
 	 * information.  As this can be expensive, skip it if there is
 	 * absolutely no possibility of it. */
-	if((worker->daemon->use_response_ip || worker->daemon->use_rpz) &&
+	if((worker->daemon->use_response_ip || worker->daemon->use_rpz ||
+		worker->env.cfg->dns64_taglist) &&
 		(qinfo.qtype == LDNS_RR_TYPE_A ||
 		qinfo.qtype == LDNS_RR_TYPE_AAAA ||
 		qinfo.qtype == LDNS_RR_TYPE_ANY)) {
@@ -1981,7 +1982,9 @@ lookup_cache:
 	 * this is a two-pass operation, and lookup_qinfo is different for
 	 * each pass.  We should still pass the original qinfo to
 	 * answer_from_cache(), however, since it's used to build the reply. */
-	if(!edns_bypass_cache_stage(edns.opt_list_in, &worker->env)) {
+	if(!edns_bypass_cache_stage(edns.opt_list_in, &worker->env) &&
+		!(worker->env.cfg->dns64_taglist &&
+		qinfo.qtype == LDNS_RR_TYPE_AAAA)) {
 		is_expired_answer = 0;
 		is_secure_answer = 0;
 		h = query_info_hash(lookup_qinfo, sldns_buffer_read_u16_at(c->buffer, 2));

--- a/dns64/dns64.c
+++ b/dns64/dns64.c
@@ -129,6 +129,12 @@ struct dns64_env {
      * Tree of names for which AAAA is ignored. always synthesize from A.
      */
     rbtree_type ignore_aaaa;
+
+	/** Tags for clients for which DNS64 is enabled. */
+	uint8_t* taglist;
+
+	/** Length of the DNS64 client tag bitlist. */
+	size_t taglen;
 };
 
 
@@ -389,6 +395,15 @@ dns64_apply_cfg(struct dns64_env* dns64_env, struct config_file* cfg)
 	    if(!dns64_insert_ignore_aaaa(dns64_env, s->str))
 		    return 0;
     }
+	if(cfg->dns64_taglist) {
+		dns64_env->taglist = memdup(cfg->dns64_taglist,
+			cfg->dns64_taglistlen);
+		if(!dns64_env->taglist) {
+			log_err("malloc failure");
+			return 0;
+		}
+		dns64_env->taglen = cfg->dns64_taglistlen;
+	}
     name_tree_init_parents(&dns64_env->ignore_aaaa);
     return 1;
 }
@@ -443,6 +458,8 @@ dns64_deinit(struct module_env* env, int id)
     if(dns64_env) {
 	    traverse_postorder(&dns64_env->ignore_aaaa, free_ignore_aaaa_node,
 	    	NULL);
+	    free(dns64_env->taglist);
+	    dns64_env->taglist = NULL;
     }
     free(env->modinfo[id]);
     env->modinfo[id] = NULL;
@@ -605,6 +622,31 @@ handle_event_pass(struct module_qstate* qstate, int id)
 }
 
 /**
+ * Check whether DNS64 processing is enabled for this query.
+ *
+ * DNS64 is enabled for every query when dns64-tags is not configured.
+ * Otherwise, the query's effective client tags must intersect the configured
+ * DNS64 tags. Queries without client information do not match a configured
+ * DNS64 tag list.
+ *
+ * \param dns64_env DNS64 module configuration.
+ *
+ * \param qstate Query state containing the effective client tags.
+ *
+ * \return True when DNS64 processing is enabled for the query.
+ */
+static int
+dns64_client_is_enabled(struct dns64_env* dns64_env,
+	struct module_qstate* qstate)
+{
+	if(!dns64_env->taglist)
+		return 1;
+	return qstate->client_info && taglist_intersect(dns64_env->taglist,
+		dns64_env->taglen, qstate->client_info->taglist,
+		qstate->client_info->taglen);
+}
+
+/**
  * Handles the "done" event for a query. We need to analyze the response and
  * maybe issue a new sub-query for the A record.
  *
@@ -693,11 +735,23 @@ dns64_operate(struct module_qstate* qstate, enum module_ev event, int id,
 		struct outbound_entry* outbound)
 {
 	struct dns64_qstate* iq;
+	struct dns64_env* dns64_env =
+		(struct dns64_env*)qstate->env->modinfo[id];
 	(void)outbound;
 	verbose(VERB_QUERY, "dns64[module %d] operate: extstate:%s event:%s",
 			id, strextstate(qstate->ext_state[id]),
 			strmodulevent(event));
 	log_query_info(VERB_QUERY, "dns64 operate: query", &qstate->qinfo);
+	/* The DNS64 result depends on the client's tags, so a shared cached
+	 * AAAA response cannot be used when DNS64 is limited by dns64-tags. */
+	if(dns64_env->taglist && qstate->qinfo.qtype == LDNS_RR_TYPE_AAAA)
+		qstate->no_cache_lookup = 1;
+	if(!dns64_client_is_enabled(dns64_env, qstate)) {
+		qstate->ext_state[id] =
+			(event == module_event_new || event == module_event_pass) ?
+			module_wait_module : module_finished;
+		return;
+	}
 
 	switch(event) {
 		case module_event_new:
@@ -1092,7 +1146,7 @@ dns64_get_mem(struct module_env* env, int id)
     struct dns64_env* dns64_env = (struct dns64_env*)env->modinfo[id];
     if (!dns64_env)
         return 0;
-    return sizeof(*dns64_env);
+    return sizeof(*dns64_env) + dns64_env->taglen;
 }
 
 /**

--- a/doc/unbound.conf.5.in
+++ b/doc/unbound.conf.5.in
@@ -4863,6 +4863,22 @@ Can be entered multiple times, list a new domain for which it applies, one
 per line.
 Applies also to names underneath the name given.
 .UNINDENT
+.INDENT 0.0
+.TP
+.B dns64\-tags: \fI\(dq<list of tags>\(dq\fP
+Limit DNS64 processing to clients with a matching tag.
+.sp
+Tags need to be defined in \fI\%define\-tag\fP and can be assigned to
+client addresses with \fI\%access\-control\-tag\fP or to listening
+interfaces with \fI\%interface\-tag\fP.
+Enclose list of tags in quotes (\fB\(dq\(dq\fP) and put spaces between tags.
+.sp
+For clients that match an \fI\%access\-control*\fP setting, the
+access-control settings override the interface settings. Assign the DNS64
+tag with \fI\%access\-control\-tag\fP for those clients as well.
+.sp
+If no tags are specified, DNS64 processing will be applied to all clients.
+.UNINDENT
 .SH NAT64 OPTIONS
 .sp
 These options are part of the \fBserver:\fP section.

--- a/doc/unbound.conf.rst
+++ b/doc/unbound.conf.rst
@@ -4270,6 +4270,23 @@ and be compiled into the daemon to be enabled.
     per line.
     Applies also to names underneath the name given.
 
+@@UAHL@unbound.conf.dns64@dns64-tags@@: *"<list of tags>"*
+    Limit DNS64 processing to clients with a matching tag.
+
+    Tags need to be defined in :ref:`define-tag<unbound.conf.define-tag>` and
+    can be assigned to client addresses using
+    :ref:`access-control-tag<unbound.conf.access-control-tag>` or
+    :ref:`interface-tag<unbound.conf.interface-tag>`.
+    Enclose list of tags in quotes (``""``) and put spaces between tags.
+
+    For clients that match an ``access-control-*`` setting, the access-control
+    settings override the interface settings.
+    Assign the DNS64 tag with
+    :ref:`access-control-tag<unbound.conf.access-control-tag>` for those
+    clients as well.
+
+    If no tags are specified, DNS64 processing will be applied to all clients.
+
 NAT64 Options
 -------------
 

--- a/testdata/dns64_interface_tag.tdir/dns64_interface_tag.conf
+++ b/testdata/dns64_interface_tag.tdir/dns64_interface_tag.conf
@@ -1,0 +1,22 @@
+server:
+	verbosity: 5
+	use-syslog: no
+	directory: ""
+	pidfile: "unbound.pid"
+	chroot: ""
+	username: ""
+	module-config: "dns64 iterator"
+	do-not-query-localhost: no
+	use-caps-for-id: no
+	define-tag: "dns64"
+	dns64-prefix: 64:ff9b::/96
+	dns64-tags: "dns64"
+	interface: 10.0.0.1@@TAGGED_PORT@
+	interface: 10.0.0.1@@UNTAGGED_PORT@
+	interface-action: 10.0.0.1@@TAGGED_PORT@ allow
+	interface-action: 10.0.0.1@@UNTAGGED_PORT@ allow
+	interface-tag: 10.0.0.1@@TAGGED_PORT@ "dns64"
+
+forward-zone:
+	name: "."
+	forward-addr: 10.0.0.1@@FORWARD_PORT@

--- a/testdata/dns64_interface_tag.tdir/dns64_interface_tag.dsc
+++ b/testdata/dns64_interface_tag.tdir/dns64_interface_tag.dsc
@@ -1,0 +1,16 @@
+BaseName: dns64_interface_tag
+Version: 1.0
+Description: Check DNS64 is enabled only for tagged interfaces.
+CreationDate: Thu Aug 27 2026
+Maintainer:
+Category:
+Component:
+CmdDepends:
+Depends:
+Help:
+Pre: dns64_interface_tag.pre
+Post: dns64_interface_tag.post
+Test: dns64_interface_tag.test
+AuxFiles:
+Passed:
+Failure:

--- a/testdata/dns64_interface_tag.tdir/dns64_interface_tag.post
+++ b/testdata/dns64_interface_tag.tdir/dns64_interface_tag.post
@@ -1,0 +1,2 @@
+# #-- dns64_interface_tag.post --#
+# All processes run in the test's network namespace and exit with it.

--- a/testdata/dns64_interface_tag.tdir/dns64_interface_tag.pre
+++ b/testdata/dns64_interface_tag.tdir/dns64_interface_tag.pre
@@ -1,0 +1,32 @@
+# #-- dns64_interface_tag.pre --#
+[ -f ../.tpkg.var.master ] && source ../.tpkg.var.master
+[ -f .tpkg.var.test ] && source .tpkg.var.test
+
+PRE="../.."
+. ../common.sh
+
+if test ! -x "`which unshare 2>&1`"; then
+	skip_test "no unshare (from util-linux package) available, skip test"
+fi
+
+if test -x "`which bash`"; then
+	shell="bash"
+else
+	shell="sh"
+fi
+
+get_random_port 3
+TAGGED_PORT=$RND_PORT
+UNTAGGED_PORT=$(($RND_PORT + 1))
+FORWARD_PORT=$(($RND_PORT + 2))
+
+echo "TAGGED_PORT=$TAGGED_PORT" >> .tpkg.var.test
+echo "UNTAGGED_PORT=$UNTAGGED_PORT" >> .tpkg.var.test
+echo "FORWARD_PORT=$FORWARD_PORT" >> .tpkg.var.test
+echo "shell=$shell" >> .tpkg.var.test
+
+sed \
+	-e 's/@TAGGED_PORT\@/'$TAGGED_PORT'/' \
+	-e 's/@UNTAGGED_PORT\@/'$UNTAGGED_PORT'/' \
+	-e 's/@FORWARD_PORT\@/'$FORWARD_PORT'/' \
+	< dns64_interface_tag.conf > ub.conf

--- a/testdata/dns64_interface_tag.tdir/dns64_interface_tag.test
+++ b/testdata/dns64_interface_tag.tdir/dns64_interface_tag.test
@@ -1,0 +1,6 @@
+# #-- dns64_interface_tag.test --#
+[ -f ../.tpkg.var.master ] && source ../.tpkg.var.master
+[ -f .tpkg.var.test ] && source .tpkg.var.test
+
+unshare -rUn $shell dns64_interface_tag.test.scenario
+exit $?

--- a/testdata/dns64_interface_tag.tdir/dns64_interface_tag.test.scenario
+++ b/testdata/dns64_interface_tag.tdir/dns64_interface_tag.test.scenario
@@ -1,0 +1,58 @@
+# #-- dns64_interface_tag.test.scenario --#
+[ -f ../.tpkg.var.master ] && source ../.tpkg.var.master
+[ -f .tpkg.var.test ] && source .tpkg.var.test
+
+PRE="../.."
+. ../common.sh
+get_ldns_testns
+
+ip addr add 10.0.0.1/32 dev lo
+ip link set lo up
+
+$LDNS_TESTNS -p $FORWARD_PORT dns64_interface_tag.testns >fwd.log 2>&1 &
+FWD_PID=$!
+echo "FWD_PID=$FWD_PID" >> .tpkg.var.test
+
+$PRE/unbound -d -c ub.conf >unbound.log 2>&1 &
+UNBOUND_PID=$!
+echo "UNBOUND_PID=$UNBOUND_PID" >> .tpkg.var.test
+
+wait_ldns_testns_up fwd.log
+wait_unbound_up unbound.log
+
+fail () {
+	echo "> cat logfiles"
+	cat fwd.log
+	cat unbound.log
+	exit 1
+}
+
+echo "> dig tagged.example. AAAA through tagged interface"
+dig @10.0.0.1 -p $TAGGED_PORT tagged.example. AAAA | tee tagged.out
+if ! grep "64:ff9b::c000:201" tagged.out; then
+	echo "DNS64 synthesis was not applied to tagged interface"
+	fail
+fi
+
+echo "> dig tagged.example. AAAA through untagged interface"
+dig @10.0.0.1 -p $UNTAGGED_PORT tagged.example. AAAA | tee tagged-untagged.out
+if grep "64:ff9b::c000:201" tagged-untagged.out; then
+	echo "DNS64 synthesis was incorrectly applied to untagged interface"
+	fail
+fi
+
+echo "> dig untagged.example. AAAA through untagged interface"
+dig @10.0.0.1 -p $UNTAGGED_PORT untagged.example. AAAA | tee untagged.out
+if grep "64:ff9b::c000:202" untagged.out; then
+	echo "DNS64 synthesis was incorrectly applied to untagged interface"
+	fail
+fi
+
+echo "> dig untagged.example. AAAA through tagged interface"
+dig @10.0.0.1 -p $TAGGED_PORT untagged.example. AAAA | tee untagged-tagged.out
+if ! grep "64:ff9b::c000:202" untagged-tagged.out; then
+	echo "DNS64 synthesis was not applied to tagged interface"
+	fail
+fi
+
+echo "OK"

--- a/testdata/dns64_interface_tag.tdir/dns64_interface_tag.testns
+++ b/testdata/dns64_interface_tag.tdir/dns64_interface_tag.testns
@@ -1,0 +1,47 @@
+; nameserver test file
+$ORIGIN example.
+$TTL 3600
+
+ENTRY_BEGIN
+MATCH opcode qtype qname
+REPLY QR AA NOERROR
+ADJUST copy_id
+SECTION QUESTION
+tagged	IN	AAAA
+SECTION ANSWER
+; NO AAAA present
+SECTION AUTHORITY
+example.	IN	SOA	ns.example. hostmaster.example. 1 2 3 4 5
+ENTRY_END
+
+ENTRY_BEGIN
+MATCH opcode qtype qname
+REPLY QR AA NOERROR
+ADJUST copy_id
+SECTION QUESTION
+tagged	IN	A
+SECTION ANSWER
+tagged	IN	A	192.0.2.1
+ENTRY_END
+
+ENTRY_BEGIN
+MATCH opcode qtype qname
+REPLY QR AA NOERROR
+ADJUST copy_id
+SECTION QUESTION
+untagged	IN	AAAA
+SECTION ANSWER
+; NO AAAA present
+SECTION AUTHORITY
+example.	IN	SOA	ns.example. hostmaster.example. 1 2 3 4 5
+ENTRY_END
+
+ENTRY_BEGIN
+MATCH opcode qtype qname
+REPLY QR AA NOERROR
+ADJUST copy_id
+SECTION QUESTION
+untagged	IN	A
+SECTION ANSWER
+untagged	IN	A	192.0.2.2
+ENTRY_END

--- a/util/config_file.c
+++ b/util/config_file.c
@@ -1099,6 +1099,14 @@ config_collate_cat(struct config_strlist* list)
 		} \
 	} \
 	}
+/** compare and print a taglist option */
+#define O_TAG(opt, name, tags, taglen) if(strcmp(opt, name)==0) { \
+	char* tmpstr = config_taglist2str(cfg, cfg->tags, cfg->taglen); \
+	if(tmpstr) { \
+		func(tmpstr, arg); \
+		free(tmpstr); \
+	} \
+	}
 
 int
 config_get_option(struct config_file* cfg, const char* opt,
@@ -1398,6 +1406,7 @@ config_get_option(struct config_file* cfg, const char* opt,
 	else O_LTG(opt, "local-zone-tag", local_zone_tags)
 	else O_LTG(opt, "access-control-tag", acl_tags)
 	else O_LTG(opt, "response-ip-tag", respip_tags)
+	else O_TAG(opt, "dns64-tags", dns64_taglist, dns64_taglistlen)
 	else O_LS3(opt, "local-zone-override", local_zone_overrides)
 	else O_LS3(opt, "access-control-tag-action", acl_tag_actions)
 	else O_LS3(opt, "access-control-tag-data", acl_tag_datas)
@@ -1843,6 +1852,7 @@ config_delete(struct config_file* cfg)
 	free(cfg->nat64_prefix);
 	free(cfg->dns64_prefix);
 	config_delstrlist(cfg->dns64_ignore_aaaa);
+	free(cfg->dns64_taglist);
 	free(cfg->dnstap_socket_path);
 	free(cfg->dnstap_ip);
 	free(cfg->dnstap_tls_server_name);

--- a/util/config_file.h
+++ b/util/config_file.h
@@ -578,6 +578,10 @@ struct config_file {
 	int dns64_synthall;
 	/** ignore AAAAs for these domain names and use A record anyway */
 	struct config_strlist* dns64_ignore_aaaa;
+	/** tags that enable DNS64 processing for a client */
+	uint8_t* dns64_taglist;
+	/** length of the DNS64 tag bitlist */
+	size_t dns64_taglistlen;
 
 	/* NAT64 prefix; if unset defaults to dns64_prefix */
 	char* nat64_prefix;

--- a/util/configlexer.lex
+++ b/util/configlexer.lex
@@ -479,6 +479,7 @@ max-udp-size{COLON}		{ YDVAR(1, VAR_MAX_UDP_SIZE) }
 dns64-prefix{COLON}		{ YDVAR(1, VAR_DNS64_PREFIX) }
 dns64-synthall{COLON}		{ YDVAR(1, VAR_DNS64_SYNTHALL) }
 dns64-ignore-aaaa{COLON}	{ YDVAR(1, VAR_DNS64_IGNORE_AAAA) }
+dns64-tags{COLON}		{ YDVAR(1, VAR_DNS64_TAGS) }
 nat64-prefix{COLON}		{ YDVAR(1, VAR_NAT64_PREFIX) }
 define-tag{COLON}		{ YDVAR(1, VAR_DEFINE_TAG) }
 local-zone-tag{COLON}		{ YDVAR(2, VAR_LOCAL_ZONE_TAG) }

--- a/util/configparser.y
+++ b/util/configparser.y
@@ -124,7 +124,7 @@ extern struct config_parser_state* cfg_parser;
 %token VAR_MAX_UDP_SIZE VAR_DELAY_CLOSE VAR_UDP_CONNECT
 %token VAR_UNBLOCK_LAN_ZONES VAR_INSECURE_LAN_ZONES
 %token VAR_INFRA_CACHE_MIN_RTT VAR_INFRA_CACHE_MAX_RTT VAR_INFRA_KEEP_PROBING
-%token VAR_DNS64_PREFIX VAR_DNS64_SYNTHALL VAR_DNS64_IGNORE_AAAA
+%token VAR_DNS64_PREFIX VAR_DNS64_SYNTHALL VAR_DNS64_IGNORE_AAAA VAR_DNS64_TAGS
 %token VAR_NAT64_PREFIX
 %token VAR_DNSTAP VAR_DNSTAP_ENABLE VAR_DNSTAP_SOCKET_PATH VAR_DNSTAP_IP
 %token VAR_DNSTAP_TLS VAR_DNSTAP_TLS_SERVER_NAME VAR_DNSTAP_TLS_CERT_BUNDLE
@@ -300,6 +300,7 @@ content_server: server_num_threads | server_verbosity | server_port |
 	server_so_reuseport | server_delay_close | server_udp_connect |
 	server_unblock_lan_zones | server_insecure_lan_zones |
 	server_dns64_prefix | server_dns64_synthall | server_dns64_ignore_aaaa |
+	server_dns64_tags |
 	server_nat64_prefix |
 	server_infra_cache_min_rtt | server_infra_cache_max_rtt | server_harden_algo_downgrade |
 	server_ip_transparent | server_ip_ratelimit | server_ratelimit |
@@ -2589,6 +2590,22 @@ server_dns64_ignore_aaaa: VAR_DNS64_IGNORE_AAAA STRING_ARG
 		if(!cfg_strlist_insert(&cfg_parser->cfg->dns64_ignore_aaaa,
 			$2))
 			yyerror("out of memory");
+	}
+	;
+server_dns64_tags: VAR_DNS64_TAGS STRING_ARG
+	{
+		size_t len = 0;
+		uint8_t* taglist;
+		OUTYY(("P(server_dns64_tags:%s)\n", $2));
+		taglist = config_parse_taglist(cfg_parser->cfg, $2, &len);
+		free($2);
+		if(!taglist) {
+			yyerror("could not parse tags, (define-tag them first)");
+		} else {
+			free(cfg_parser->cfg->dns64_taglist);
+			cfg_parser->cfg->dns64_taglist = taglist;
+			cfg_parser->cfg->dns64_taglistlen = len;
+		}
 	}
 	;
 server_nat64_prefix: VAR_NAT64_PREFIX STRING_ARG


### PR DESCRIPTION
### Summary

Allow DNS64 to be tagged by client or interface in order to limit it running globally. 

Configuration now takes a list of tags that limit DNS64 operation, with no tags defined it will operate globally as it does currently.
One change I did have to make was to deny the AAAA cache resolution when tagged DNS64 is in use, and the record must be re-synthesized from the A record; this is just about as cheap as if the A record is cached, it is fetched and transformed immediately, and normally the TTL of a synthetic cached AAAA record is the same as the A record.

### Testing

    make distclean
    ./configure
    make
    make test


All the existing tests pass, (but i had some issues in longtest is hanging in my environment with an ldns-testns error periodically). I have added  tests cases where DNS64 resolution is expected (tag matches) and where it is not expected (tag doesn't match). The existing DNS64 tests all ran successfully show that non-tagged behavior is unchanged.