### PR TITLE
iterator: stop retrying an unreachable address family within one query

### DIFF
--- a/iterator/iter_utils.c
+++ b/iterator/iter_utils.c
@@ -302,7 +302,7 @@ iter_apply_cfg(struct iter_env* iter_env, struct config_file* cfg)
 static int
 iter_filter_unsuitable(struct iter_env* iter_env, struct module_env* env,
 	uint8_t* name, size_t namelen, uint16_t qtype, time_t now,
-	struct delegpt_addr* a)
+	struct delegpt_addr* a, int no_route_family)
 {
 	int rtt, lame, reclame, dnsseclame;
 	if(a->bogus)
@@ -333,8 +333,12 @@ iter_filter_unsuitable(struct iter_env* iter_env, struct module_env* env,
 			return -1; /* server is on the donotquery list */
 		}
 	}
-	if(!iter_env->supports_ipv6 && addr_is_ip6(&a->addr, a->addrlen)) {
+	if((!iter_env->supports_ipv6 || no_route_family == AF_INET6) &&
+		addr_is_ip6(&a->addr, a->addrlen)) {
 		return -1; /* there is no ip6 available */
+	}
+	if(no_route_family == AF_INET && !addr_is_ip6(&a->addr, a->addrlen)) {
+		return -1; /* this query already saw ip4 has no route */
 	}
 	if(!iter_env->supports_ipv4 && !iter_env->nat64.use_nat64 &&
 	   !addr_is_ip6(&a->addr, a->addrlen)) {
@@ -397,7 +401,7 @@ static int
 iter_fill_rtt(struct iter_env* iter_env, struct module_env* env,
 	uint8_t* name, size_t namelen, uint16_t qtype, time_t now,
 	struct delegpt* dp, int* best_rtt, struct sock_list* blacklist,
-	size_t* num_suitable_results)
+	size_t* num_suitable_results, int no_route_family)
 {
 	int got_it = 0;
 	struct delegpt_addr* a;
@@ -407,7 +411,7 @@ iter_fill_rtt(struct iter_env* iter_env, struct module_env* env,
 		return 0; /* NS bogus, all bogus, nothing found */
 	for(a=dp->result_list; a; a = a->next_result) {
 		a->sel_rtt = iter_filter_unsuitable(iter_env, env,
-			name, namelen, qtype, now, a);
+			name, namelen, qtype, now, a, no_route_family);
 		if(a->sel_rtt != -1) {
 			if(sock_list_find(blacklist, &a->addr, a->addrlen))
 				a->sel_rtt += BLACKLIST_PENALTY;
@@ -476,7 +480,7 @@ static int
 iter_filter_order(struct iter_env* iter_env, struct module_env* env,
 	uint8_t* name, size_t namelen, uint16_t qtype, time_t now,
 	struct delegpt* dp, int* selected_rtt, int open_target,
-	struct sock_list* blacklist, time_t prefetch)
+	struct sock_list* blacklist, time_t prefetch, int no_route_family)
 {
 	int got_num = 0, low_rtt = 0, swap_to_front, rtt_band = RTT_BAND, nth;
 	int alllame = 0;
@@ -485,7 +489,7 @@ iter_filter_order(struct iter_env* iter_env, struct module_env* env,
 
 	/* fillup sel_rtt and find best rtt in the bunch */
 	got_num = iter_fill_rtt(iter_env, env, name, namelen, qtype, now, dp,
-		&low_rtt, blacklist, &num_results);
+		&low_rtt, blacklist, &num_results, no_route_family);
 	if(got_num == 0)
 		return 0;
 	if(low_rtt >= USEFUL_SERVER_TOP_TIMEOUT &&
@@ -670,13 +674,14 @@ iter_server_selection(struct iter_env* iter_env,
 	struct module_env* env, struct delegpt* dp,
 	uint8_t* name, size_t namelen, uint16_t qtype, int* dnssec_lame,
 	int* chase_to_rd, int open_target, struct sock_list* blacklist,
-	time_t prefetch)
+	time_t prefetch, int no_route_family)
 {
 	int sel;
 	int selrtt;
 	struct delegpt_addr* a, *prev;
 	int num = iter_filter_order(iter_env, env, name, namelen, qtype,
-		*env->now, dp, &selrtt, open_target, blacklist, prefetch);
+		*env->now, dp, &selrtt, open_target, blacklist, prefetch,
+		no_route_family);
 
 	if(num == 0)
 		return NULL;

--- a/iterator/iter_utils.h
+++ b/iterator/iter_utils.h
@@ -104,14 +104,16 @@ int iter_apply_cfg(struct iter_env* iter_env, struct config_file* cfg);
  * 	This means the query can have different timing, because prefetch is
  * 	not waited upon by the downstream client, and thus a good time to
  * 	perform exploration of other targets.
+ * @param no_route_family: AF_INET/AF_INET6 to skip that family's
+ * 	addresses for this query, or 0 to skip neither.
  * @return best target or NULL if no target.
  *	if not null, that target is removed from the result list in the dp.
  */
-struct delegpt_addr* iter_server_selection(struct iter_env* iter_env, 
-	struct module_env* env, struct delegpt* dp, uint8_t* name, 
+struct delegpt_addr* iter_server_selection(struct iter_env* iter_env,
+	struct module_env* env, struct delegpt* dp, uint8_t* name,
 	size_t namelen, uint16_t qtype, int* dnssec_lame,
 	int* chase_to_rd, int open_target, struct sock_list* blacklist,
-	time_t prefetch);
+	time_t prefetch, int no_route_family);
 
 /**
  * Allocate dns_msg from parsed msg, in regional.

--- a/iterator/iterator.c
+++ b/iterator/iterator.c
@@ -55,6 +55,7 @@
 #include "services/cache/rrset.h"
 #include "services/cache/infra.h"
 #include "services/authzone.h"
+#include "services/outside_network.h"
 #include "util/module.h"
 #include "util/netevent.h"
 #include "util/net_help.h"
@@ -150,6 +151,7 @@ iter_new(struct module_qstate* qstate, int id)
 	iq->ratelimit_ok = 0;
 	iq->target_count = NULL;
 	iq->dp_target_count = 0;
+	iq->no_route_family = 0;
 	iq->wait_priming_stub = 0;
 	iq->refetch_glue = 0;
 	iq->dnssec_expected = 0;
@@ -2942,7 +2944,7 @@ processQueryTargets(struct module_qstate* qstate, struct iter_qstate* iq,
 		iq->dp->name, iq->dp->namelen, iq->qchase.qtype,
 		&iq->dnssec_lame_query, &iq->chase_to_rd,
 		iq->num_target_queries, qstate->blacklist,
-		qstate->prefetch_leeway);
+		qstate->prefetch_leeway, iq->no_route_family);
 
 	/* If no usable target was selected... */
 	if(!target) {
@@ -4406,6 +4408,12 @@ process_response(struct module_qstate* qstate, struct iter_qstate* iq,
 	iq->response = NULL;
 	iq->state = QUERY_RESP_STATE;
 	if(event == module_event_noreply || event == module_event_error) {
+		if(event == module_event_noreply && outbound && outbound->qsent &&
+			outbound->qsent->last_send_no_route) {
+			/* skip this address family for the rest of this query */
+			iq->no_route_family = addr_is_ip6(&outbound->qsent->addr,
+				outbound->qsent->addrlen) ? AF_INET6 : AF_INET;
+		}
 		if(event == module_event_noreply && iq->timeout_count >= 3 &&
 			qstate->env->cfg->use_caps_bits_for_id &&
 			!iq->caps_fallback && !is_caps_whitelisted(ie, iq)) {

--- a/iterator/iterator.h
+++ b/iterator/iterator.h
@@ -424,9 +424,14 @@ struct iter_qstate {
 	 */
 	int dnssec_lame_query;
 
+	/** address family (AF_INET/AF_INET6) with no route from this host
+	 * for this query, or 0 if none; addresses of that family are
+	 * skipped for the rest of this query. */
+	int no_route_family;
+
 	/**
-	 * This is flag that, if true, means that this event is 
-	 * waiting for a stub priming query. 
+	 * This is flag that, if true, means that this event is
+	 * waiting for a stub priming query.
 	 */
 	int wait_priming_stub;
 

--- a/services/outside_network.c
+++ b/services/outside_network.c
@@ -2227,11 +2227,34 @@ select_ifport(struct outside_network* outnet, struct pending* pend,
 				/* connect() to the destination */
 				if(connect(fd, (struct sockaddr*)&pend->addr,
 					pend->addrlen) < 0) {
-					if(udp_connect_needs_log(errno,
+					int err = errno;
+					if(udp_connect_needs_log(err,
 						&pend->addr, pend->addrlen)) {
 						log_err_addr("udp connect failed",
-							strerror(errno), &pend->addr,
+							strerror(err), &pend->addr,
 							pend->addrlen);
+					}
+					switch(err) {
+#ifdef ENETUNREACH
+					case ENETUNREACH:
+#endif
+#ifdef ENETDOWN
+					case ENETDOWN:
+#endif
+#ifdef EHOSTUNREACH
+					case EHOSTUNREACH:
+#endif
+#ifdef EHOSTDOWN
+					case EHOSTDOWN:
+#endif
+#ifdef EADDRNOTAVAIL
+					case EADDRNOTAVAIL:
+#endif
+						/* no route for this address family */
+						pend->sq->last_send_no_route = 1;
+						break;
+					default:
+						break;
 					}
 					sock_close(fd);
 #ifndef DISABLE_EXPLICIT_PORT_RANDOMISATION
@@ -2767,6 +2790,7 @@ serviced_create(struct outside_network* outnet, sldns_buffer* buff, int dnssec,
 	sq->status = serviced_initial;
 	sq->retry = 0;
 	sq->to_be_deleted = 0;
+	sq->last_send_no_route = 0;
 	sq->padding_block_size = pad_queries_block_size;
 #ifdef UNBOUND_DEBUG
 	ins =

--- a/services/outside_network.h
+++ b/services/outside_network.h
@@ -551,6 +551,9 @@ struct serviced_query {
 	struct timeval last_sent_time;
 	/** rtt of last message */
 	int last_rtt;
+	/** true if the last send failed with no route for the
+	 * destination's address family */
+	int last_send_no_route;
 	/** do we know edns probe status already, for UDP_EDNS queries */
 	int edns_lame_known;
 	/** edns options to use for sending upstream packet */

--- a/testcode/unitmain.c
+++ b/testcode/unitmain.c
@@ -457,6 +457,83 @@ rtt_test(void)
 	unit_assert(UB_STATS_BUCKET_NUM == NUM_BUCKETS_HIST);
 }
 
+#include "iterator/iter_utils.h"
+#include "iterator/iter_delegpt.h"
+#include "services/cache/infra.h"
+#include "util/regional.h"
+/** build a delegation point with one ip4 and one ip6 address, both
+ * on the result list, ready for iter_server_selection */
+static struct delegpt*
+no_route_family_test_dp(struct regional* region)
+{
+	struct delegpt* dp = delegpt_create(region);
+	struct sockaddr_storage addr4, addr6;
+	socklen_t addr4len, addr6len;
+	struct delegpt_addr* a;
+	int additions;
+	unit_assert(dp);
+	unit_assert(ipstrtoaddr("192.0.2.1", 53, &addr4, &addr4len));
+	unit_assert(ipstrtoaddr("2001:db8::1", 53, &addr6, &addr6len));
+	unit_assert(delegpt_add_addr(dp, region, &addr4, addr4len, 0, 0,
+		NULL, -1, &additions));
+	unit_assert(delegpt_add_addr(dp, region, &addr6, addr6len, 0, 0,
+		NULL, -1, &additions));
+	unit_assert((a=delegpt_find_addr(dp, &addr4, addr4len)));
+	delegpt_add_to_result_list(dp, a);
+	unit_assert((a=delegpt_find_addr(dp, &addr6, addr6len)));
+	delegpt_add_to_result_list(dp, a);
+	return dp;
+}
+
+/** test that iter_server_selection skips a family already proven to
+ * have no route for the current query */
+static void
+no_route_family_test(void)
+{
+	struct iter_env ie;
+	struct module_env env;
+	struct config_file* cfg = config_create();
+	struct regional* region = regional_create();
+	int dnssec_lame = 0, chase_to_rd = 0;
+	time_t now = 0;
+	struct delegpt_addr* target;
+
+	unit_show_func("iterator/iter_utils.c", "iter_server_selection");
+	config_auto_slab_values(cfg);
+	memset(&ie, 0, sizeof(ie));
+	unit_assert(iter_apply_cfg(&ie, cfg));
+	memset(&env, 0, sizeof(env));
+	env.cfg = cfg;
+	env.now = &now;
+	env.infra_cache = infra_create(cfg);
+
+	/* neither family excluded: some target is picked */
+	target = iter_server_selection(&ie, &env,
+		no_route_family_test_dp(region), (uint8_t*)"", 1,
+		LDNS_RR_TYPE_A, &dnssec_lame, &chase_to_rd, 0, NULL, 0, 0);
+	unit_assert(target != NULL);
+
+	/* ip6 has no route: the ip4 address is picked */
+	target = iter_server_selection(&ie, &env,
+		no_route_family_test_dp(region), (uint8_t*)"", 1,
+		LDNS_RR_TYPE_A, &dnssec_lame, &chase_to_rd, 0, NULL, 0,
+		AF_INET6);
+	unit_assert(target != NULL);
+	unit_assert(!addr_is_ip6(&target->addr, target->addrlen));
+
+	/* ip4 has no route: the ip6 address is picked */
+	target = iter_server_selection(&ie, &env,
+		no_route_family_test_dp(region), (uint8_t*)"", 1,
+		LDNS_RR_TYPE_A, &dnssec_lame, &chase_to_rd, 0, NULL, 0,
+		AF_INET);
+	unit_assert(target != NULL);
+	unit_assert(addr_is_ip6(&target->addr, target->addrlen));
+
+	regional_destroy(region);
+	infra_delete(env.infra_cache);
+	config_delete(cfg);
+}
+
 #include "util/edns.h"
 /* Complete version-invalid client cookie; needs a new one.
  * Based on edns_cookie_rfc9018_a2 */
@@ -1481,6 +1558,7 @@ main(int argc, char* argv[])
 	config_tag_test();
 	dname_test();
 	rtt_test();
+	no_route_family_test();
 	anchors_test();
 	alloc_test();
 	regional_test();


### PR DESCRIPTION
A UDP connect() failing with ENETUNREACH/EHOSTUNREACH/etc. is a local, instant routing-table fact, not a remote timeout, but nothing recorded it: every remaining delegation-point address of that family got tried again from scratch, which could exhaust MAX_TARGET_NX or the global send quota before an address of the working family was ever reached, producing SERVFAIL for a name that was otherwise resolvable.

Track the failure on the query instead of persisting it: the first such failure marks that family unusable for the rest of this query's target selection (iter_qstate->no_route_family), and the state is discarded when the query completes, so the next query tries the family again on its own and recovers automatically once routing is restored.