### PR TITLE
- Fix #1497: DS referral at the queried name was chased to the child,

### DIFF
--- a/iterator/iterator.c
+++ b/iterator/iterator.c
@@ -3344,6 +3344,38 @@ processQueryResponse(struct module_qstate* qstate, struct iter_qstate* iq,
 		iq->qchase.qname_len = orignamelen;
 	}
 
+	/* A DS referral whose NS sits exactly at the queried name is the
+	 * final answer; do not chase it down to the child. */
+	if(type == RESPONSE_TYPE_REFERRAL && iq->qchase.qtype == LDNS_RR_TYPE_DS
+		&& !iq->dsns_point && !(iq->chase_flags&BIT_RD)
+		&& reply_find_rrset_section_ns(iq->response->rep,
+			iq->qchase.qname, iq->qchase.qname_len,
+			LDNS_RR_TYPE_NS, iq->qchase.qclass)) {
+		if(!qstate->no_cache_store) {
+			iter_dns_store(qstate->env, &iq->response->qinfo,
+				iq->response->rep,
+				iq->qchase.qtype != iq->response->qinfo.qtype,
+				qstate->prefetch_leeway,
+				iq->dp&&iq->dp->has_parent_side_NS,
+				qstate->region, qstate->query_flags,
+				qstate->qstarttime, qstate->is_valrec);
+			if(qstate->env->neg_cache)
+				val_neg_addreferral(qstate->env->neg_cache,
+					iq->response->rep, iq->dp->name);
+		}
+		outbound_list_clear(&iq->outlist);
+		iq->num_current_queries = 0;
+		fptr_ok(fptr_whitelist_modenv_detach_subs(
+			qstate->env->detach_subs));
+		(*qstate->env->detach_subs)(qstate);
+		iq->num_target_queries = 0;
+		if(qstate->reply)
+			sock_list_insert(&qstate->reply_origin,
+				&qstate->reply->remote_addr,
+				qstate->reply->remote_addrlen, qstate->region);
+		return final_state(iq);
+	}
+
 	/* handle each of the type cases */
 	if(type == RESPONSE_TYPE_ANSWER) {
 		/* ANSWER type responses terminate the query algorithm, 

--- a/testdata/val_nsec3_optout_referral_ds.rpl
+++ b/testdata/val_nsec3_optout_referral_ds.rpl
@@ -1,0 +1,215 @@
+; config options
+; The island of trust is at example.com
+server:
+	trust-anchor: "example.com. DS 57024 7 1 46d134be319b2cc910b9938f1cb25dc41abb27bf"
+	val-override-date: "20070916134226"
+	target-fetch-policy: "0 0 0 0 0"
+	qname-minimisation: "no"
+	fake-sha1: yes
+	trust-anchor-signaling: no
+	harden-glue: no
+	do-ip6: no
+
+stub-zone:
+	name: "."
+	stub-addr: 193.0.14.129 	# K.ROOT-SERVERS.NET.
+CONFIG_END
+
+SCENARIO_BEGIN Test validator accepts NSEC3 optout proof from a DS referral without chasing it to the child.
+
+; K.ROOT-SERVERS.NET.
+RANGE_BEGIN 0 100
+	ADDRESS 193.0.14.129
+ENTRY_BEGIN
+MATCH opcode qtype qname
+ADJUST copy_id
+REPLY QR NOERROR
+SECTION QUESTION
+. IN NS
+SECTION ANSWER
+. IN NS	K.ROOT-SERVERS.NET.
+SECTION ADDITIONAL
+K.ROOT-SERVERS.NET.	IN	A	193.0.14.129
+ENTRY_END
+
+ENTRY_BEGIN
+MATCH opcode subdomain
+ADJUST copy_id copy_query
+REPLY QR NOERROR
+SECTION QUESTION
+com. IN A
+SECTION AUTHORITY
+com.	IN NS	a.gtld-servers.net.
+SECTION ADDITIONAL
+a.gtld-servers.net.	IN 	A	192.5.6.30
+ENTRY_END
+RANGE_END
+
+; a.gtld-servers.net.
+RANGE_BEGIN 0 100
+	ADDRESS 192.5.6.30
+ENTRY_BEGIN
+MATCH opcode qtype qname
+ADJUST copy_id
+REPLY QR NOERROR
+SECTION QUESTION
+com. IN NS
+SECTION ANSWER
+com.    IN NS   a.gtld-servers.net.
+SECTION ADDITIONAL
+a.gtld-servers.net.     IN      A       192.5.6.30
+ENTRY_END
+
+ENTRY_BEGIN
+MATCH opcode subdomain
+ADJUST copy_id copy_query
+REPLY QR NOERROR
+SECTION QUESTION
+example.com. IN A
+SECTION AUTHORITY
+example.com.	IN NS	ns.example.com.
+SECTION ADDITIONAL
+ns.example.com.		IN 	A	1.2.3.4
+ENTRY_END
+RANGE_END
+
+; ns.example.com.
+RANGE_BEGIN 0 100
+	ADDRESS 1.2.3.4
+ENTRY_BEGIN
+MATCH opcode qtype qname
+ADJUST copy_id
+REPLY QR NOERROR
+SECTION QUESTION
+example.com. IN NS
+SECTION ANSWER
+example.com.    IN NS   ns.example.com.
+example.com.	3600	IN	RRSIG	NS 7 2 3600 20070926134150 20070829134150 57024 example.com. fIE3H2v3wAm3GPajsdgJn+A8R4Cp7dMXf1PSUQ8BfklzMBMJjpc0oM/S7u/HVLYQs1jx8CMdw2TZEpIPfo6Rl0TekDqNtVk6IBw1H+zxDFwf3v7UdOjm8s6FfoEJcZ5yEFV/Lps82NzHCR9uqprhv6ddQdAeVNA5QHis1c5Y1P0= ;{id = 57024}
+SECTION ADDITIONAL
+ns.example.com.         IN      A       1.2.3.4
+ns.example.com.	3600	IN	RRSIG	A 7 3 3600 20070926134150 20070829134150 57024 example.com. b0iX5vuTqngB5F0ORFrFLx8sAeTHGJVcPpD34iNFY71ZoFnHrHfAMWC3RAWz+nQ1NmH1oDdA8NTYN/aQQNzwEz4VmVYA2PANBSiwSY3q3gp9PWZU6CfRNf2dU/210H0y35FroQpADszmwC+Hlbcvll+bQj3fSyT2W/69kRVssj4= ;{id = 57024}
+ENTRY_END
+
+; parent-side glue confirmation queries for the sub.example.com NS target.
+ENTRY_BEGIN
+MATCH opcode qtype qname
+ADJUST copy_id
+REPLY QR NOERROR
+SECTION QUESTION
+ns.sub.example.com. IN A
+SECTION ANSWER
+ns.sub.example.com. IN A 1.2.3.10
+SECTION AUTHORITY
+SECTION ADDITIONAL
+ENTRY_END
+
+ENTRY_BEGIN
+MATCH opcode qtype qname
+ADJUST copy_id
+REPLY QR NOERROR
+SECTION QUESTION
+ns.sub.example.com. IN AAAA
+SECTION ANSWER
+SECTION AUTHORITY
+SECTION ADDITIONAL
+ENTRY_END
+
+; response to DNSKEY priming query
+ENTRY_BEGIN
+MATCH opcode qtype qname
+ADJUST copy_id
+REPLY QR NOERROR
+SECTION QUESTION
+example.com. IN DNSKEY
+SECTION ANSWER
+example.com.	3600	IN	DNSKEY	257 3 7 AwEAAbvre/wK/WVeoj0SiwVkTD+NefvHPru9YIqLWY0m+0E5NYOpJZdc+PGQQYRzFNOlugVZtFirmv5Lmz7GNiASXtG/IFi//SlE30DxEKQOjt2F6qSZTZ1nZ5XOIMGTwWyp4OoI0egk5JavC5mQbyXqcj82ywt6F5Z3CmnThVl6MtOv ;{id = 57024 (ksk), size = 1024b}
+example.com.	3600	IN	RRSIG	DNSKEY 7 2 3600 20070926134150 20070829134150 57024 example.com. lqOo8W7UffLZIKBoIJg8OAPkmCWptnstiLIg1bAtzuEZDZFr2KNZGv+5k6hbRJKYnZRLReY4v8G9Eg0GCC/44gLm8BZlnh/4jLOjMH9MKusFV/jNqz/HABITYn1pBwvVak7lzqN+bmL0KMyWf1MzPWilx4fM9YWinsQFILVLPL0= ;{id = 57024}
+SECTION AUTHORITY
+example.com.	IN NS	ns.example.com.
+example.com.	3600	IN	RRSIG	NS 7 2 3600 20070926134150 20070829134150 57024 example.com. fIE3H2v3wAm3GPajsdgJn+A8R4Cp7dMXf1PSUQ8BfklzMBMJjpc0oM/S7u/HVLYQs1jx8CMdw2TZEpIPfo6Rl0TekDqNtVk6IBw1H+zxDFwf3v7UdOjm8s6FfoEJcZ5yEFV/Lps82NzHCR9uqprhv6ddQdAeVNA5QHis1c5Y1P0= ;{id = 57024}
+SECTION ADDITIONAL
+ns.example.com.		IN 	A	1.2.3.4
+ns.example.com.	3600	IN	RRSIG	A 7 3 3600 20070926134150 20070829134150 57024 example.com. b0iX5vuTqngB5F0ORFrFLx8sAeTHGJVcPpD34iNFY71ZoFnHrHfAMWC3RAWz+nQ1NmH1oDdA8NTYN/aQQNzwEz4VmVYA2PANBSiwSY3q3gp9PWZU6CfRNf2dU/210H0y35FroQpADszmwC+Hlbcvll+bQj3fSyT2W/69kRVssj4= ;{id = 57024}
+ENTRY_END
+
+; delegation to sub.example.com, answered as a bare REFERRAL (NS + optout
+; NSEC3 proof, no SOA) for ANY query at/under sub.example.com, including a
+; direct DS query -- this is the shape that must not be chased to the child.
+ENTRY_BEGIN
+MATCH opcode subdomain
+ADJUST copy_id copy_query
+REPLY QR NOERROR
+SECTION QUESTION
+sub.example.com. IN A
+SECTION AUTHORITY
+sub.example.com. IN NS ns.sub.example.com.
+
+; optout proof that there is no DS at sub.example.com.
+; example.com. -> onib9mgub9h0rml3cdf5bgrj59dkjhvk.
+; sub.example.com. covered by -> jg19n32806c832kijdnglq8p9m2r5mdj.
+onib9mgub9h0rml3cdf5bgrj59dkjhvk.example.com. NSEC3 1 1 0 - pnib9mgub9h0rml3cdf5bgrj59dkjhvk NS SOA RRSIG DNSKEY NSEC3PARAM
+jg19n32806c832kijdnglq8p9m2r5mdj.example.com. NSEC3 1 1 0 - lg19n32806c832kijdnglq8p9m2r5mdj NS DS RRSIG
+
+onib9mgub9h0rml3cdf5bgrj59dkjhvk.example.com.	3600	IN	RRSIG	NSEC3 7 3 3600 20070926134150 20070829134150 57024 example.com. jHrF+lnyRL1LE/Bwz6C+jZg3E/2qQkVSboGxya6iX71v0zA3eUsob9m9l3gHNlhwhyahbamHUKx+OMvtYuzRa+RMv4ObuLRIt8StdixeXaUU+rx7C2qCKOFsa5q4HzK4bLYPfyb5T9w67HbzHPLEllXPA7tghzyzCM9qBtbvwK4= ;{id = 57024}
+jg19n32806c832kijdnglq8p9m2r5mdj.example.com.	3600	IN	RRSIG	NSEC3 7 3 3600 20070926134150 20070829134150 57024 example.com. f7ZSCahAuKOLXquM0jpdU6I9AX31CgGicRiB3aU4jvqQp/EygbCNn5kfpyXY0FvZvzggpl8naXSStOPN9dy3bb0NwGQkJcYD94NEw307T8uEunOvx1ug5TuakBAwqjY8xKM3xab3LnWYRtx4zdln/3ZDHvBUwfzkxUZrzeKjpiI= ;{id = 57024}
+SECTION ADDITIONAL
+ns.sub.example.com. IN A 1.2.3.10
+ENTRY_END
+RANGE_END
+
+; ns.sub.example.com. -- the (unsigned) insecure child.  It must never be
+; asked a DS query for its own apex: if it is, that is the regression this
+; test guards against, and the REFUSED below turns it into a visible failure.
+RANGE_BEGIN 0 100
+	ADDRESS 1.2.3.10
+ENTRY_BEGIN
+MATCH opcode qtype qname
+ADJUST copy_id
+REPLY QR NOERROR
+SECTION QUESTION
+ns.sub.example.com. IN AAAA
+SECTION ANSWER
+SECTION AUTHORITY
+SECTION ADDITIONAL
+ENTRY_END
+
+ENTRY_BEGIN
+MATCH opcode qtype qname
+ADJUST copy_id
+REPLY QR REFUSED
+SECTION QUESTION
+sub.example.com. IN DS
+SECTION ANSWER
+SECTION AUTHORITY
+SECTION ADDITIONAL
+ENTRY_END
+
+RANGE_END
+
+STEP 1 QUERY
+ENTRY_BEGIN
+REPLY RD DO
+SECTION QUESTION
+sub.example.com. IN DS
+ENTRY_END
+
+; recursion happens here.  A live DS sub-query with a cold cache must take
+; the referral itself as the answer.  If it instead chases the referral
+; to the child (the REFUSED entry above), the answer becomes SERVFAIL and
+; this CHECK_ANSWER fails.  No AD flag: the delegation is insecure (optout).
+STEP 10 CHECK_ANSWER
+ENTRY_BEGIN
+MATCH all
+REPLY QR RD RA DO NOERROR
+SECTION QUESTION
+sub.example.com. IN DS
+SECTION ANSWER
+SECTION AUTHORITY
+onib9mgub9h0rml3cdf5bgrj59dkjhvk.example.com.	3600	IN	NSEC3	1 1 0 - pnib9mgub9h0rml3cdf5bgrj59dkjhvk NS SOA RRSIG DNSKEY NSEC3PARAM
+onib9mgub9h0rml3cdf5bgrj59dkjhvk.example.com.	3600	IN	RRSIG	NSEC3 7 3 3600 20070926134150 20070829134150 57024 example.com. jHrF+lnyRL1LE/Bwz6C+jZg3E/2qQkVSboGxya6iX71v0zA3eUsob9m9l3gHNlhwhyahbamHUKx+OMvtYuzRa+RMv4ObuLRIt8StdixeXaUU+rx7C2qCKOFsa5q4HzK4bLYPfyb5T9w67HbzHPLEllXPA7tghzyzCM9qBtbvwK4= ;{id = 57024}
+jg19n32806c832kijdnglq8p9m2r5mdj.example.com.	3600	IN	NSEC3	1 1 0 - lg19n32806c832kijdnglq8p9m2r5mdj NS DS RRSIG
+jg19n32806c832kijdnglq8p9m2r5mdj.example.com.	3600	IN	RRSIG	NSEC3 7 3 3600 20070926134150 20070829134150 57024 example.com. f7ZSCahAuKOLXquM0jpdU6I9AX31CgGicRiB3aU4jvqQp/EygbCNn5kfpyXY0FvZvzggpl8naXSStOPN9dy3bb0NwGQkJcYD94NEw307T8uEunOvx1ug5TuakBAwqjY8xKM3xab3LnWYRtx4zdln/3ZDHvBUwfzkxUZrzeKjpiI= ;{id = 57024}
+SECTION ADDITIONAL
+ENTRY_END
+
+SCENARIO_END


### PR DESCRIPTION
bogusing a valid NSEC3 opt-out insecure delegation.

When a DS query for a delegation point is answered by the parent with a REFERRAL (NS + a signed NSEC3 opt-out closest-encloser/next-closer proof, no SOA, per RFC 5155 7.2.4), processQueryResponse() had no DS-specific handling for RESPONSE_TYPE_REFERRAL, unlike its ANSWER/CNAME siblings (which use iter_ds_toolow()/iter_dp_cangodown()/processDSNSFind()). It unconditionally reset the delegation point to the child and re-issued the same DS query there. Since the child is the (expected) unsigned side of an insecure delegation, it answers with a plain NODATA (SOA, no NSEC3). That NODATA was then taken as the final DS answer, val_has_signed_nsecs() found nothing, and the whole chain went bogus -- discarding the parent's already-cached, valid opt-out proof received one step earlier.

Fix: when the referral is a DS query exactly at the queried name (iter_dp_cangodown() false, i.e. we cannot usefully descend further) and not already in the processDSNSFind() recovery path or forwarding, treat the referral as the answer instead of chasing it, reusing the existing RESPONSE_TYPE_ANSWER handling rather than adding new finalization logic.