### PR TITLE
Fix qname-minimisation to use real qtype on terminal label

### DIFF
--- a/iterator/iterator.c
+++ b/iterator/iterator.c
@@ -2639,6 +2639,7 @@ processQueryTargets(struct module_qstate* qstate, struct iter_qstate* iq,
 		iq->qinfo_out.qname_len = iq->qchase.qname_len;
 		iq->minimise_count++;
 		iq->timeout_count = 0;
+		iq->minimise_terminal_probe = 0;
 
 		iter_dec_attempts(iq->dp, 1, ie->outbound_msg_retry);
 
@@ -2677,21 +2678,36 @@ processQueryTargets(struct module_qstate* qstate, struct iter_qstate* iq,
 				&iq->qinfo_out.qname_len, 
 				labdiff-1);
 		}
-		if(labdiff < 1 || (labdiff < 2 
+		if(labdiff < 1 || (labdiff < 2
 			&& (iq->qchase.qtype == LDNS_RR_TYPE_DS
 			|| iq->qchase.qtype == LDNS_RR_TYPE_A)))
 			/* Stop minimising this query, resolve "as usual" */
 			iq->minimisation_state = DONOT_MINIMISE_STATE;
 		else if(!qstate->no_cache_lookup) {
-			struct dns_msg* msg = dns_cache_lookup(qstate->env, 
-				iq->qinfo_out.qname, iq->qinfo_out.qname_len, 
-				iq->qinfo_out.qtype, iq->qinfo_out.qclass, 
-				qstate->query_flags, qstate->region, 
+			struct dns_msg* msg;
+			if(labdiff < 2)
+				/* labdiff==1: qinfo_out.qname already equals
+				 * the full target qname, but qtype is still
+				 * the type-hiding "A" probe (qtype not A/DS)
+				 * -- this IS the terminal label. Mark it so
+				 * that, if this probe fails, the best-effort
+				 * minimisation fallback below can restore
+				 * this query target's attempt budget before
+				 * retrying with the real qtype. Otherwise a
+				 * single-nameserver zone can be left with no
+				 * usable target at all for the real query,
+				 * causing an avoidable SERVFAIL
+				 * (GitHub issue #1500). */
+				iq->minimise_terminal_probe = 1;
+			msg = dns_cache_lookup(qstate->env,
+				iq->qinfo_out.qname, iq->qinfo_out.qname_len,
+				iq->qinfo_out.qtype, iq->qinfo_out.qclass,
+				qstate->query_flags, qstate->region,
 				qstate->env->scratch, 0, iq->dp->name,
 				iq->dp->namelen);
 			if(msg && FLAGS_GET_RCODE(msg->rep->flags) ==
 				LDNS_RCODE_NOERROR)
-				/* no need to send query if it is already 
+				/* no need to send query if it is already
 				 * cached as NOERROR */
 				return 1;
 			if(msg && FLAGS_GET_RCODE(msg->rep->flags) ==
@@ -3412,9 +3428,25 @@ processQueryResponse(struct module_qstate* qstate, struct iter_qstate* iq,
 					return error_response_cache(qstate, id,
 						LDNS_RCODE_SERVFAIL);
 				}
-				/* Best effort qname-minimisation. 
+				/* Best effort qname-minimisation.
 				 * Stop minimising and send full query when
 				 * RCODE is not NOERROR. */
+				if(iq->minimise_terminal_probe) {
+					/* The query that just failed was the
+					 * terminal-label type-hiding "A"
+					 * probe, not a real answer attempt.
+					 * Restore this query target's attempt
+					 * budget so the real qtype (about to
+					 * be sent via DONOT_MINIMISE_STATE
+					 * below) still has a target to go to,
+					 * instead of an avoidable SERVFAIL
+					 * when the zone has few or no other
+					 * usable addresses
+					 * (GitHub issue #1500). */
+					iter_dec_attempts(iq->dp, 1,
+						ie->outbound_msg_retry);
+					iq->minimise_terminal_probe = 0;
+				}
 				iq->minimisation_state = DONOT_MINIMISE_STATE;
 			}
 			if(FLAGS_GET_RCODE(iq->response->rep->flags) ==

--- a/iterator/iterator.h
+++ b/iterator/iterator.h
@@ -474,6 +474,18 @@ struct iter_qstate {
 	int minimise_count;
 
 	/**
+	 * True if the outbound query just sent from MINIMISE_STATE is the
+	 * terminal-label type-hiding "A" probe (qinfo_out.qname already
+	 * equals the full target qname, but qtype is not the real requested
+	 * qtype). If that probe fails (non-NOERROR response), the
+	 * best-effort minimisation fallback restores this query target's
+	 * attempt budget before retrying with the real qtype -- otherwise a
+	 * single-nameserver zone can be left with no usable target at all
+	 * for the real query, causing an avoidable SERVFAIL.
+	 * See GitHub issue #1500. */
+	int minimise_terminal_probe;
+
+	/**
 	 * Count number of time-outs. Used to prevent resolving failures when
 	 * the QNAME minimisation QTYPE is blocked. Used to determine if
 	 * capsforid fallback should be started.*/

--- a/testdata/iter_minimise_terminal_qtype.rpl
+++ b/testdata/iter_minimise_terminal_qtype.rpl
@@ -1,0 +1,200 @@
+; Regression test for GitHub issue #1500.
+;
+; When qname-minimisation is enabled, the terminal (final) query is sent
+; as a type-hiding "A" probe rather than the real requested qtype (unless
+; qtype is already A or DS). If that probe gets a non-NOERROR response
+; (e.g. NXDOMAIN, because the target name genuinely has no A record) and
+; the zone has only a single nameserver, the probe alone can exhaust that
+; nameserver's outbound-msg-retry budget, leaving no usable query target
+; at all for the real qtype -- causing an erroneous SERVFAIL for a record
+; that genuinely exists.
+;
+; The fix restores the query target's attempt budget specifically when a
+; terminal-label probe fails, so the real qtype is still sent to the same
+; server afterwards. This test asserts the full sequence: the terminal A
+; probe IS still sent (NXDOMAINs, as the target name has no A record),
+; and the real TXT query is THEN also sent to the very same nameserver
+; and succeeds -- matching the real-world case from the bug report
+; (a wildcard TXT-only zone with a single NS).
+;
+; Setup mirrors the real-world case from the bug report:
+;   - Query: www.example.com. TXT
+;   - The zone example.com is served by a single NS (ns.example.com.)
+;   - www.example.com. has a TXT record but NO A record
+;   - outbound-msg-retry is forced to 1 so a single failed probe would,
+;     without the fix, fully exhaust the sole nameserver's address.
+
+; config options
+server:
+	target-fetch-policy: "0 0 0 0 0"
+	qname-minimisation: yes
+	minimal-responses: no
+	iter-scrub-promiscuous: no
+	outbound-msg-retry: 1
+	do-not-query-localhost: no
+
+stub-zone:
+	name: "."
+	stub-addr: 193.0.14.129 	# K.ROOT-SERVERS.NET.
+CONFIG_END
+
+SCENARIO_BEGIN Test that a failed qname-minimisation terminal-label A probe does not exhaust a single-NS zone's only query target before the real qtype is tried (issue #1500).
+
+; K.ROOT-SERVERS.NET.
+RANGE_BEGIN 0 100
+	ADDRESS 193.0.14.129
+ENTRY_BEGIN
+MATCH opcode qtype qname
+ADJUST copy_id
+REPLY QR NOERROR
+SECTION QUESTION
+. IN NS
+SECTION ANSWER
+. IN NS	K.ROOT-SERVERS.NET.
+SECTION ADDITIONAL
+K.ROOT-SERVERS.NET.	IN	A	193.0.14.129
+ENTRY_END
+
+ENTRY_BEGIN
+MATCH opcode qtype qname
+ADJUST copy_id
+REPLY QR NOERROR
+SECTION QUESTION
+com. IN A
+SECTION AUTHORITY
+com.	IN NS	a.gtld-servers.net.
+SECTION ADDITIONAL
+a.gtld-servers.net.	IN 	A	192.5.6.30
+ENTRY_END
+RANGE_END
+
+; a.gtld-servers.net.
+RANGE_BEGIN 0 100
+	ADDRESS 192.5.6.30
+ENTRY_BEGIN
+MATCH opcode qtype qname
+ADJUST copy_id
+REPLY QR NOERROR
+SECTION QUESTION
+com. IN A
+SECTION AUTHORITY
+com.	IN NS	a.gtld-servers.net.
+SECTION ADDITIONAL
+a.gtld-servers.net.	IN 	A	192.5.6.30
+ENTRY_END
+
+ENTRY_BEGIN
+MATCH opcode qtype qname
+ADJUST copy_id
+REPLY QR NOERROR
+SECTION QUESTION
+example.com. IN A
+SECTION AUTHORITY
+example.com.	IN NS	ns.example.com.
+SECTION ADDITIONAL
+ns.example.com.		IN 	A	1.2.3.4
+ENTRY_END
+RANGE_END
+
+; ns.example.com. -- the single authoritative nameserver for example.com.
+; www.example.com. has only a TXT record; there is no A record, so the
+; terminal-label probe genuinely NXDOMAINs here, exactly like a real
+; misconfigured/unusual zone would.
+RANGE_BEGIN 0 100
+	ADDRESS 1.2.3.4
+ENTRY_BEGIN
+MATCH opcode qtype qname
+ADJUST copy_id
+REPLY QR AA NOERROR
+SECTION QUESTION
+example.com. IN A
+SECTION AUTHORITY
+example.com.	IN NS	ns.example.com.
+SECTION ADDITIONAL
+ns.example.com.		IN 	A	1.2.3.4
+ENTRY_END
+
+; The terminal-label type-hiding probe: no A record exists at this name.
+ENTRY_BEGIN
+MATCH opcode qtype qname
+ADJUST copy_id
+REPLY QR AA NXDOMAIN
+SECTION QUESTION
+www.example.com. IN A
+SECTION AUTHORITY
+example.com. 300 IN SOA a.example.com. b.example.com. 1 2 3 4 300
+ENTRY_END
+
+; The real query, retried against the same (only) nameserver after the
+; probe failed -- this is what the fix makes possible.
+ENTRY_BEGIN
+MATCH opcode qtype qname
+ADJUST copy_id
+REPLY QR AA NOERROR
+SECTION QUESTION
+www.example.com. IN TXT
+SECTION ANSWER
+www.example.com.	IN TXT	"v=spf1 -all"
+SECTION AUTHORITY
+example.com.	IN NS	ns.example.com.
+SECTION ADDITIONAL
+ns.example.com.		IN 	A	1.2.3.4
+ENTRY_END
+RANGE_END
+
+STEP 10 QUERY
+ENTRY_BEGIN
+REPLY RD
+SECTION QUESTION
+www.example.com. IN TXT
+ENTRY_END
+
+; Intermediate minimisation step: hide target within com.
+STEP 20 CHECK_OUT_QUERY
+ENTRY_BEGIN
+MATCH qname qtype opcode
+SECTION QUESTION
+com. IN A
+ENTRY_END
+
+; Intermediate minimisation step: hide target within example.com.
+STEP 30 CHECK_OUT_QUERY
+ENTRY_BEGIN
+MATCH qname qtype opcode
+SECTION QUESTION
+example.com. IN A
+ENTRY_END
+
+; Terminal-label probe: still sent as "A" (qtype-hiding), same as before
+; the fix -- this is expected and correct, not the bug.
+STEP 40 CHECK_OUT_QUERY
+ENTRY_BEGIN
+MATCH qname qtype opcode
+SECTION QUESTION
+www.example.com. IN A
+ENTRY_END
+
+; The fix: despite the probe's NXDOMAIN and outbound-msg-retry: 1, the
+; real qtype is still sent to the same (only) nameserver, not SERVFAIL.
+STEP 50 CHECK_OUT_QUERY
+ENTRY_BEGIN
+MATCH qname qtype opcode
+SECTION QUESTION
+www.example.com. IN TXT
+ENTRY_END
+
+STEP 60 CHECK_ANSWER
+ENTRY_BEGIN
+MATCH all
+REPLY QR RD RA NOERROR
+SECTION QUESTION
+www.example.com. IN TXT
+SECTION ANSWER
+www.example.com.	IN TXT	"v=spf1 -all"
+SECTION AUTHORITY
+example.com.	IN NS	ns.example.com.
+SECTION ADDITIONAL
+ns.example.com.		IN 	A	1.2.3.4
+ENTRY_END
+
+SCENARIO_END


### PR DESCRIPTION
## Problem

When qname-minimisation is enabled, the terminal (final) query uses a generic `A` probe instead of the actual requested qtype. If the authoritative zone has a **single nameserver** and no `A` record exists at the target name, the NXDOMAIN response exhausts the only available server address, and unbound returns SERVFAIL — even though the record genuinely exists.

**Reproduction:** `dig zurhbjwo-4.t.nessus.org TXT` with qname-minimisation enabled. The zone `t.nessus.org` has exactly one NS (`ns.t.nessus.org` → `206.205.255.205`) and only a wildcard TXT record — no A record.

Vanilla unbound log (broken):
```
sending query: zurhbjwo-4.t.nessus.org. A IN          ← terminal A probe
incoming scrubbed packet: rcode: NXDOMAIN             ← no A record
DelegationPoint<t.nessus.org.>: 1 addrs (0 result, 0 avail)  ← sole NS exhausted
No more query targets, attempting last resort          ← → SERVFAIL
```

Closes #1500. Related to #870.

## Root cause

In `iterator/iterator.c` (`processQueryTargets`, `MINIMISE_STATE`), the condition that stops minimisation at the terminal label was:

```c
if(labdiff < 1 || (labdiff < 2
    && (iq->qchase.qtype == LDNS_RR_TYPE_DS
    || iq->qchase.qtype == LDNS_RR_TYPE_A)))
```

When `labdiff == 1` (the outgoing qname IS already the full target name), the code only switched to the real qtype for `DS` and `A` queries. For all other qtypes (TXT, AAAA, MX, …) it sent the full qname with `qtype=A` as a type-hiding probe. If that probe fails and the zone has few/no other usable addresses, the real query can be left with nowhere to go.

## Fix (revised)

An earlier version of this PR removed the terminal-label `A` probe entirely for all qtypes. Testing surfaced a real downside to that approach: some authoritative/GSLB-managed zones (e.g. CDN-backed CNAMEs on managed DNS providers) only answer certain record types correctly and return NODATA on others -- a pre-existing upstream misconfiguration, independently confirmed against multiple such zones. The terminal `A` probe, when it succeeds, incidentally warms the resolver's cache with a `CNAME` that the real qtype then chases directly to the target's own correctly-configured nameservers, avoiding an otherwise-reproducible NODATA. Removing the probe outright would have turned that pre-existing upstream gap into a user-facing NODATA/outage risk for anyone relying on it, instead of just fixing the actual correctness bug.

This revised version **keeps the terminal-label probe**, but fixes the real problem: when that probe gets a non-NOERROR response, the existing best-effort qname-minimisation fallback (which already exists in `processQueryResponse` for exactly this purpose) now also restores the query target's attempt budget via `iter_dec_attempts()` -- the same idiom already used elsewhere in this file for other fallback scenarios -- before retrying with the real qtype. A new `iq->minimise_terminal_probe` flag marks which outbound query is the terminal-label probe, so this restoration is scoped precisely to that case and doesn't touch intermediate-label minimisation behavior.

```c
/* iterator.h */
int minimise_terminal_probe;   /* set when the terminal-label A probe is sent */

/* iterator.c, processQueryResponse(), best-effort minimisation fallback */
if(iq->minimise_terminal_probe) {
    iter_dec_attempts(iq->dp, 1, ie->outbound_msg_retry);
    iq->minimise_terminal_probe = 0;
}
iq->minimisation_state = DONOT_MINIMISE_STATE;
```

## Testing

- `testdata/iter_resolve_minimised.rpl` and `testdata/iter_resolve_minimised_timeout.rpl` are unchanged from `master` -- this fix doesn't alter their code paths (successful-probe and probe-timeout scenarios respectively), confirming the change is additive.
- `testdata/iter_minimise_terminal_qtype.rpl` rewritten: single-NS zone, `outbound-msg-retry: 1`, terminal `A` probe genuinely NXDOMAINs (no A record exists), asserts the real `TXT` query is still sent to the same nameserver afterward and succeeds.
- Full `make test` regression suite passes.
- Verified against two independent real-world cases: `dig zurhbjwo-4.t.nessus.org TXT` (the original single-NS/NXDOMAIN-probe case from the bug report) and `dig www.scholastic.ca AAAA` (a GSLB-zone case where the probe's cache-warming side effect avoids an unrelated upstream NODATA) both now succeed, including repeated back-to-back queries against the live zone.
