### PR TITLE
Attach EDE (RFC 8914) Blocked code to RPZ- and local-zone-blocked responses

### DIFF
--- a/services/localzone.c
+++ b/services/localzone.c
@@ -1702,8 +1702,11 @@ int
 local_zones_zone_answer(struct local_zone* z, struct module_env* env,
 	struct query_info* qinfo, struct edns_data* edns,
 	struct comm_reply* repinfo, sldns_buffer* buf, struct regional* temp,
-	struct local_data* ld, enum localzone_type lz_type)
+	struct local_data* ld, enum localzone_type lz_type,
+	const char* ede_txt)
 {
+	if(!ede_txt)
+		ede_txt = "blocked by local-zone policy";
 	if(lz_type == local_zone_deny ||
 		lz_type == local_zone_always_deny ||
 		lz_type == local_zone_inform_deny) {
@@ -1715,7 +1718,7 @@ local_zones_zone_answer(struct local_zone* z, struct module_env* env,
 		|| lz_type == local_zone_always_refuse) {
 		local_error_encode(qinfo, env, edns, repinfo, buf, temp,
 			LDNS_RCODE_REFUSED, (LDNS_RCODE_REFUSED|BIT_AA),
-			LDNS_EDE_NONE, NULL);
+			LDNS_EDE_BLOCKED, ede_txt);
 		return 1;
 	} else if(lz_type == local_zone_static ||
 		lz_type == local_zone_redirect ||
@@ -1741,7 +1744,7 @@ local_zones_zone_answer(struct local_zone* z, struct module_env* env,
 			return local_encode(qinfo, env, edns, repinfo, buf, temp,
 				z->soa_negative, 0, rcode);
 		local_error_encode(qinfo, env, edns, repinfo, buf, temp,
-			rcode, (rcode|BIT_AA), LDNS_EDE_NONE, NULL);
+			rcode, (rcode|BIT_AA), LDNS_EDE_BLOCKED, ede_txt);
 		return 1;
 	} else if(lz_type == local_zone_typetransparent
 		|| lz_type == local_zone_always_transparent) {
@@ -1753,7 +1756,7 @@ local_zones_zone_answer(struct local_zone* z, struct module_env* env,
 		if(qinfo->qtype == LDNS_RR_TYPE_A) {
 			local_error_encode(qinfo, env, edns, repinfo, buf, temp,
 				LDNS_RCODE_NOERROR, (LDNS_RCODE_NOERROR|BIT_AA),
-				LDNS_EDE_NONE, NULL);
+				LDNS_EDE_BLOCKED, ede_txt);
 				return 1;
 		}
 
@@ -1764,7 +1767,7 @@ local_zones_zone_answer(struct local_zone* z, struct module_env* env,
 		if(qinfo->qtype == LDNS_RR_TYPE_AAAA) {
 			local_error_encode(qinfo, env, edns, repinfo, buf, temp,
 				LDNS_RCODE_NOERROR, (LDNS_RCODE_NOERROR|BIT_AA),
-				LDNS_EDE_NONE, NULL);
+				LDNS_EDE_BLOCKED, ede_txt);
 				return 1;
 		}
 
@@ -1999,7 +2002,8 @@ local_zones_answer(struct local_zones* zones, struct module_env* env,
 		 * a local alias. */
 		return !qinfo->local_alias;
 	}
-	r = local_zones_zone_answer(z, env, qinfo, edns, repinfo, buf, temp, ld, lzt);
+	r = local_zones_zone_answer(z, env, qinfo, edns, repinfo, buf, temp, ld, lzt,
+		NULL);
 	lock_rw_unlock(&z->lock);
 	return r && !qinfo->local_alias; /* see above */
 }

--- a/services/localzone.h
+++ b/services/localzone.h
@@ -353,13 +353,18 @@ int local_zones_answer(struct local_zones* zones, struct module_env* env,
  * @param temp: temp region for encoding.
  * @param ld: local data, if NULL, no such name exists in localdata.
  * @param lz_type: type of the local zone.
+ * @param ede_txt: EDE (RFC 8914) text to attach to a blocked response, e.g.
+ * naming the specific RPZ zone that triggered. NULL for the generic
+ * "blocked by local-zone policy" text (used by plain, non-RPZ local-zone
+ * callers, which have no more specific policy name to report).
  * @return 1 if a reply is to be sent, 0 if not.
  */
 int
 local_zones_zone_answer(struct local_zone* z, struct module_env* env,
 	struct query_info* qinfo, struct edns_data* edns,
 	struct comm_reply* repinfo, sldns_buffer* buf, struct regional* temp,
-	struct local_data* ld, enum localzone_type lz_type);
+	struct local_data* ld, enum localzone_type lz_type,
+	const char* ede_txt);
 
 /**
  * Parse the string into localzone type.

--- a/services/mesh.c
+++ b/services/mesh.c
@@ -1586,10 +1586,16 @@ mesh_send_reply(struct mesh_state* m, int rcode, struct reply_info* rep,
 
 		/* Attach EDE without SERVFAIL if the validation failed.
 		 * Need to explicitly check for rep->security otherwise failed
-		 * validation paths may attach to a secure answer. */
+		 * validation paths may attach to a secure answer.
+		 * RPZ-blocked responses are excepted from that security-status
+		 * gate: their reason_bogus/security are set together atomically
+		 * on a freshly synthesized reply_info (see services/rpz.c), so
+		 * there is no risk of a stale EDE leaking onto an unrelated
+		 * secure answer the way there could be for the validator. */
 		if(m->s.env->cfg->ede && rep &&
 			(rep->security <= sec_status_bogus ||
-			rep->security == sec_status_secure_sentinel_fail)) {
+			rep->security == sec_status_secure_sentinel_fail ||
+			rep->reason_bogus == LDNS_EDE_BLOCKED)) {
 			mesh_find_and_attach_ede_and_reason(m, rep, r);
 		}
 

--- a/services/rpz.c
+++ b/services/rpz.c
@@ -1990,8 +1990,26 @@ rpz_dns_msg_new(struct regional* region)
 	return msg;
 }
 
+/** Build a client-visible EDE (RFC 8914) text for an RPZ-triggered
+ * response, naming the RPZ zone (its configured rpz-log-name, if set) so
+ * the EDE text matches what rpz-log already reports server-side. Returns
+ * NULL (silently, matching regional_strdup's own OOM behaviour) on
+ * allocation failure -- the response is still emitted with the EDE code
+ * set, just without extra text. */
+static char*
+rpz_ede_text(struct rpz* r, struct regional* region)
+{
+	char buf[256];
+	if(r && r->log_name && r->log_name[0] != 0)
+		snprintf(buf, sizeof(buf), "blocked by RPZ policy \"%s\"",
+			r->log_name);
+	else
+		snprintf(buf, sizeof(buf), "blocked by RPZ policy");
+	return regional_strdup(region, buf);
+}
+
 static inline struct dns_msg*
-rpz_synthesize_nodata(struct rpz* ATTR_UNUSED(r), struct module_qstate* ms,
+rpz_synthesize_nodata(struct rpz* r, struct module_qstate* ms,
 	struct query_info* qinfo, struct auth_zone* az)
 {
 	struct dns_msg* msg = rpz_dns_msg_new(ms->region);
@@ -2009,10 +2027,11 @@ rpz_synthesize_nodata(struct rpz* ATTR_UNUSED(r), struct module_qstate* ms,
 					     0, /* ar */
 					     0, /* total */
 					     sec_status_insecure,
-					     LDNS_EDE_NONE);
+					     LDNS_EDE_BLOCKED);
 	if(!msg->rep)
 		return NULL;
 	msg->rep->authoritative = 1;
+	msg->rep->reason_bogus_str = rpz_ede_text(r, ms->region);
 	if(!rpz_add_soa(msg->rep, ms, az))
 		return NULL;
 	return msg;
@@ -2041,17 +2060,18 @@ rpz_synthesize_nxdomain(struct rpz* r, struct module_qstate* ms,
 					     0, /* ar */
 					     0, /* total */
 					     sec_status_insecure,
-					     LDNS_EDE_NONE);
+					     LDNS_EDE_BLOCKED);
 	if(!msg->rep)
 		return NULL;
 	msg->rep->authoritative = 1;
+	msg->rep->reason_bogus_str = rpz_ede_text(r, ms->region);
 	if(!rpz_add_soa(msg->rep, ms, az))
 		return NULL;
 	return msg;
 }
 
 static inline struct dns_msg*
-rpz_synthesize_localdata_from_rrset(struct rpz* ATTR_UNUSED(r), struct module_qstate* ms,
+rpz_synthesize_localdata_from_rrset(struct rpz* r, struct module_qstate* ms,
 	struct query_info* qi, struct local_rrset* rrset, struct auth_zone* az)
 {
 	struct dns_msg* msg = NULL;
@@ -2075,12 +2095,13 @@ rpz_synthesize_localdata_from_rrset(struct rpz* ATTR_UNUSED(r), struct module_qs
                                                    0, /* ar */
                                                    1, /* total */
                                                    sec_status_insecure,
-                                                   LDNS_EDE_NONE);
+                                                   LDNS_EDE_BLOCKED);
 	if(new_reply_info == NULL) {
 		log_err("out of memory");
 		return NULL;
 	}
 	new_reply_info->authoritative = 1;
+	new_reply_info->reason_bogus_str = rpz_ede_text(r, ms->region);
 	rp = respip_copy_rrset(rrset->rrset, ms->region);
 	if(rp == NULL) {
 		log_err("out of memory");
@@ -2239,12 +2260,13 @@ rpz_synthesize_cname_override_msg(struct rpz* r, struct module_qstate* ms,
                                                    0, /* ar */
                                                    1, /* total */
                                                    sec_status_insecure,
-                                                   LDNS_EDE_NONE);
+                                                   LDNS_EDE_BLOCKED);
 	if(new_reply_info == NULL) {
 		log_err("out of memory");
 		return NULL;
 	}
 	new_reply_info->authoritative = 1;
+	new_reply_info->reason_bogus_str = rpz_ede_text(r, ms->region);
 
 	rp = respip_copy_rrset(r->cname_override, ms->region);
 	if(rp == NULL) {
@@ -2300,7 +2322,7 @@ rpz_synthesize_qname_localdata(struct module_env* env, struct rpz* r,
 	}
 
 	ret = local_zones_zone_answer(z, env, qinfo, edns, repinfo, buf, temp,
-		0 /* no local data used */, lzt);
+		0 /* no local data used */, lzt, rpz_ede_text(r, temp));
 	if(r->signal_nxdomain_ra && LDNS_RCODE_WIRE(sldns_buffer_begin(buf))
 		== LDNS_RCODE_NXDOMAIN)
 		LDNS_RA_CLR(sldns_buffer_begin(buf));
@@ -2746,7 +2768,8 @@ rpz_apply_maybe_clientip_trigger(struct auth_zones* az, struct module_env* env,
 		} else {
 			local_zones_zone_answer(*z_out /*likely NULL, no zone*/, env, qinfo, edns,
 				repinfo, buf, temp, 0 /* no local data used */,
-				rpz_action_to_localzone_type(client_action));
+				rpz_action_to_localzone_type(client_action),
+				rpz_ede_text(*r_out, temp));
 			if(*r_out && (*r_out)->signal_nxdomain_ra &&
 				LDNS_RCODE_WIRE(sldns_buffer_begin(buf))
 				== LDNS_RCODE_NXDOMAIN)

--- a/testdata/ede_rpz_blocked.rpl
+++ b/testdata/ede_rpz_blocked.rpl
@@ -1,0 +1,57 @@
+; Regression test: RPZ-triggered responses (NXDOMAIN, NODATA, local-data/
+; sinkhole override, CNAME override) should attach an EDE (RFC 8914) code
+; 15 (Blocked) when ede: yes is configured, so clients can distinguish a
+; genuine NXDOMAIN/NODATA from one caused by RPZ policy -- previously RPZ
+; never attached any EDE code at all, even with ede: yes set.
+
+; config options
+server:
+	module-config: "respip iterator"
+	target-fetch-policy: "0 0 0 0 0"
+	qname-minimisation: no
+	rrset-roundrobin: no
+	access-control: 192.0.0.0/8 allow
+	ede: yes
+
+rpz:
+	name: "rpz.example.com"
+	rpz-log: yes
+	rpz-log-name: "test-policy"
+	zonefile:
+TEMPFILE_NAME rpz.example.com
+TEMPFILE_CONTENTS rpz.example.com
+rpz.example.com. 3600 IN SOA ns.rpz.example.com. hostmaster.rpz.example.com. 1 3600 900 86400 3600
+rpz.example.com.	3600	IN	NS	ns.rpz.example.net.
+badname.rpz.example.com. CNAME .
+TEMPFILE_END
+
+CONFIG_END
+
+SCENARIO_BEGIN Test RPZ NXDOMAIN action attaches EDE 15 (Blocked)
+
+STEP 10 QUERY
+ENTRY_BEGIN
+REPLY RD
+SECTION QUESTION
+badname.	IN	A
+SECTION ADDITIONAL
+	HEX_EDNSDATA_BEGIN
+    HEX_EDNSDATA_END
+ENTRY_END
+
+; The RPZ zonefile above blocks "badname." with the rpz-nxdomain action.
+; The response should be NXDOMAIN, and now also carry EDE code 15
+; (Blocked) since ede: yes is configured -- this is the actual fix under
+; test; without it, no EDE option is attached at all.
+STEP 20 CHECK_ANSWER
+ENTRY_BEGIN
+MATCH all ede=15
+REPLY QR RD RA AA NXDOMAIN
+SECTION QUESTION
+badname.	IN	A
+SECTION ADDITIONAL
+	HEX_EDNSDATA_BEGIN
+    HEX_EDNSDATA_END
+ENTRY_END
+
+SCENARIO_END


### PR DESCRIPTION
Closes #1505.

## Problem

Previously, a response synthesized by RPZ (NXDOMAIN, NODATA, local-data/sinkhole override, or CNAME override) or by a plain local-zone block never carried an EDE (RFC 8914) code, even with `ede: yes` configured -- clients had no standards-based way to distinguish a genuine NXDOMAIN/NODATA from one caused by policy.

This covers two independent response paths:

### 1. Early/instant path

`daemon/worker.c` (`rpz_callback_from_worker_request`) -> `services/localzone.c`'s `local_zones_zone_answer()`. Used whenever a qname trigger can be decided from the query name alone, before any real resolution starts -- the common case for straightforward blocklist entries.

`local_zones_zone_answer()` previously called `local_error_encode()` with a hardcoded `LDNS_EDE_NONE` for every block type (refuse, nxdomain/nodata/static/redirect, block_a, block_aaaa). Since this function is shared between RPZ and plain `local-zone:` blocking, it now takes an optional `ede_txt` parameter: RPZ callers pass a zone-specific message (see `rpz_ede_text()` below), the plain local-zone caller passes `NULL` and keeps the existing generic `"blocked by local-zone policy"` text.

### 2. Mid-resolution path

`services/rpz.c`'s `rpz_synthesize_nxdomain`/`_nodata`/`_localdata_from_rrset`/`_cname_override_msg`, invoked from `iterator/iterator.c` via `rpz_callback_from_iterator_module`/`_cname`. Used for triggers that can only be evaluated once resolution has started -- NSIP, NSDNAME, or a qname discovered via a CNAME chain.

These four functions also previously passed `LDNS_EDE_NONE` unconditionally; they now pass `LDNS_EDE_BLOCKED` plus a zone-specific message from the new `rpz_ede_text()` helper (uses the RPZ zone's `rpz-log-name`, if set).

Getting this path to actually reach the client required a second fix: `services/mesh.c`'s `mesh_send_reply()` only attaches a `reply_info`'s `reason_bogus`/EDE for validator-bogus responses (`rep->security <= sec_status_bogus`). RPZ-synthesized replies are `sec_status_insecure`, so this gate silently dropped their EDE code. RPZ is explicitly excepted from that gate: its `reason_bogus`/`security` are set together, atomically, on a freshly synthesized `reply_info` per query, so there is no risk of a stale EDE leaking onto an unrelated secure answer the way there could be for the validator's incrementally-updated state.

## Testing

- `testdata/ede_rpz_blocked.rpl`: new regression test, qname-trigger NXDOMAIN via the early path, asserts EDE code 15.
- Live traffic against a production RPZ deployment: a qname-trigger NXDOMAIN (early path, threat-intel-fed zone) and an NSDNAME trigger discovered via CNAME/delegation (mid-resolution path, static zone) both correctly show `EDE: 15 (Blocked)` with the specific RPZ zone's `rpz-log-name` in the message, e.g.:
  ```
  ; EDE: 15 (Blocked): (blocked by RPZ policy "phishing")
  ; EDE: 15 (Blocked): (blocked by RPZ policy "local")
  ```
- Full `make test` suite passes.
